### PR TITLE
Breadcrumbs layout

### DIFF
--- a/hlx_statics/blocks/side-nav/side-nav.js
+++ b/hlx_statics/blocks/side-nav/side-nav.js
@@ -17,12 +17,7 @@ export default async function decorate(block) {
   navigationLinksUl.setAttribute('aria-label', 'Table of contents');
   navigationLinksContainer.append(navigationLinksUl);
 
-  let sideNavContainer = document.querySelector('.side-nav-container');
-  if(sideNavContainer) {
-    sideNavContainer.style.gridArea = 'sidenav';
-  }
-
-  // TODO: have fall back when side nav not available in sessios
+  // TODO: have fall back when side nav not available in session
   navigationLinksUl.innerHTML = sessionStorage.getItem('sideNav');
 
   block.append(navigationLinks);

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -254,6 +254,44 @@ export function buildHeadings(container) {
 }
 
 /**
+ * Builds the layout grid
+ * @param {*} main The grid container
+ */
+export function buildGrid(main) {
+  main.style.display = 'grid';
+  main.style.gridTemplateAreas = '"sidenav main aside" "sidenav footer aside"';
+
+  const gridAreaMain = main.querySelector(".section");
+  gridAreaMain.style.gridArea = 'main';
+}
+
+/**
+ * Builds the side nav
+ * @param {*} main The grid container
+ */
+export function buildSideNav(main) {
+  let sideNavDiv = createTag ('div', {class: 'section side-nav-container', style: 'grid-area: sidenav'});
+  let sideNavWrapper = createTag('div', {class: 'side-nav-wrapper'});
+  let sideNavBlock = createTag('div', {class: 'side-nav block', 'data-block-name': 'side-nav'});
+
+  sideNavWrapper.append(sideNavBlock);
+  sideNavDiv.append(sideNavWrapper);
+  main.prepend(sideNavDiv);
+}
+
+/**
+ * Builds the on this page wrapper
+ * @param {*} main The grid container
+ */
+export function buildOnThisPage(main) {
+  let asideWrapper = createTag('div', {class: 'onthispage-wrapper block', 'data-block-name': 'onthispage'});
+  let aside = createTag('aside');
+
+  asideWrapper.append(aside);
+  main.append(asideWrapper);
+}
+
+/**
  * Toggles the scale according to the client width
  */
 export function toggleScale() {

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -295,6 +295,22 @@ export function buildOnThisPage(main) {
 }
 
 /**
+ * Builds the breadcrumbs
+ * @param {*} main The grid container
+ */
+export function buildBreadcrumbs(main) {
+  let breadcrumbsDiv = createTag ('div', {class: 'section breadcrumbs-container'});
+  let breadcrumbsWrapper = createTag('div', {class: 'breadcrumbs-wrapper'});
+  let breadcrumbsBlock = createTag('div', {class: 'breadcrumbs block', 'data-block-name': 'breadcrumbs'});
+  
+  breadcrumbsWrapper.append(breadcrumbsBlock);
+  breadcrumbsDiv.append(breadcrumbsWrapper);
+  
+  const contentHeader = main.querySelector('.content-header');
+  contentHeader?.append(breadcrumbsDiv);
+}
+
+/**
  * Toggles the scale according to the client width
  */
 export function toggleScale() {

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -263,6 +263,9 @@ export function buildGrid(main) {
 
   const gridAreaMain = main.querySelector(".section");
   gridAreaMain.style.gridArea = 'main';
+
+  let contentHeader = createTag('div', {class: 'content-header'});
+  gridAreaMain.prepend(contentHeader)
 }
 
 /**

--- a/hlx_statics/scripts/lib-helix.js
+++ b/hlx_statics/scripts/lib-helix.js
@@ -628,10 +628,8 @@ export function githubActionsBlock(doc) {
                       </a>
               </div>
       `;
-    const sectionContainers = doc.querySelectorAll('.section');
-    if (sectionContainers.length > 1) {
-      sectionContainers[1].prepend(newContent);
-    }
+    const contentHeader = doc.querySelector('.content-header');
+    contentHeader?.append(newContent);
   }
 };
 

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -19,6 +19,7 @@ import {
 } from './lib-helix.js';
 
 import {
+  buildBreadcrumbs,
   buildCodes,
   buildEmbeds,
   buildGrid,
@@ -189,6 +190,7 @@ async function loadEager(doc) {
     buildGrid(main);
     buildSideNav(main);
     buildOnThisPage(main);
+    buildBreadcrumbs(main);
   }
 
   await loadConfig();

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -21,7 +21,10 @@ import {
 import {
   buildCodes,
   buildEmbeds,
+  buildGrid,
   buildHeadings,
+  buildSideNav,
+  buildOnThisPage,
   createTag,
   toggleScale,
   decorateAnchorLink,
@@ -183,19 +186,9 @@ async function loadEager(doc) {
   }
 
   if (getMetadata('template') === 'documentation') {
-    main.style.display = 'grid';
-    main.style.gridTemplateAreas = '"sidenav main aside" "sidenav footer aside"';
-    let sideNavDiv = createTag ('div', {class: 'section side-nav-container', style: 'grid-area: sidenav'});
-    let sideNavWrapper = createTag('div', {class: 'side-nav-wrapper'});
-    let sideNavBlock = createTag('div', {class: 'side-nav block', 'data-block-name': 'side-nav'});
-    let asideWrapper = createTag('div', {class: 'onthispage-wrapper block', 'data-block-name': 'onthispage'});
-    let aside = createTag('aside');
-    asideWrapper.append(aside);
-
-    sideNavWrapper.append(sideNavBlock);
-    sideNavDiv.append(sideNavWrapper);
-    main.prepend(sideNavDiv);
-    main.append(asideWrapper);
+    buildGrid(main);
+    buildSideNav(main);
+    buildOnThisPage(main);
   }
 
   await loadConfig();
@@ -393,12 +386,6 @@ async function loadLazy(doc) {
   loadFooter(doc.querySelector('footer'));
 
   if (getMetadata('template') === 'documentation') {
-    const sidenav = main.querySelector('.side-nav-container');
-    if (sidenav) {
-      // set whatever is the next section next to sidenav to be the documentation main content area
-      sidenav.nextElementSibling.style.gridArea = 'main';
-    }
-
     // rearrange footer and append to main when in doc mode
     const footer = doc.querySelector('footer');
     footer.style.gridArea = 'footer';

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -892,10 +892,6 @@ main .heading6 h6>span {
   background-color: rgb(213, 213, 213);
 }
 
-main .content-header {
-  display:flex;
-}
-
 main .default-content-wrapper {
   width: 100%;
   max-width: 1280px;
@@ -914,6 +910,14 @@ main .default-content-wrapper a:hover{
 
 main .default-content-wrapper strong{
   color: rgb(34,34,34);
+}
+
+main .content-header {
+  display:flex;
+}
+
+main .content-header .breadcrumbs-container {
+  flex: 1;
 }
 
 main .github-actions-wrapper{

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -892,6 +892,10 @@ main .heading6 h6>span {
   background-color: rgb(213, 213, 213);
 }
 
+main .content-header {
+  display:flex;
+}
+
 main .default-content-wrapper {
   width: 100%;
   max-width: 1280px;


### PR DESCRIPTION
- Refactor to prep for adding breadcrumbs
- Set up breadcrumbs layout so that it is on top of `gridAreaMain` and next to `gitHubActions`:
<img width="1541" alt="Screenshot 2024-10-22 at 3 22 30 PM" src="https://github.com/user-attachments/assets/3c1b9cfd-e749-4508-9746-9c0cb02f65cc">


Test link: https://breadcrumbs-layout--adp-devsite--adobedocs.hlx.page/developer-console/docs/guides/getting-started
