### PR TITLE
fix : fixed the issue of taking content from footer

### DIFF
--- a/hlx_statics/blocks/onthispage/onthispage.js
+++ b/hlx_statics/blocks/onthispage/onthispage.js
@@ -13,7 +13,7 @@ export default async function decorate(block) {
     block.append(aside);
 
     const mainContainer = document.querySelector('main');
-    const headings = mainContainer.querySelectorAll('h2:not(.sid-nav h2):not(footer h2), h3:not(.sid-nav h3):not(footer h3)');
+    const headings = mainContainer.querySelectorAll('h2:not(.side-nav h2):not(footer h2), h3:not(.side-nav h3):not(footer h3)');
 
     Object.assign(aside.style, {
         display: 'flex',

--- a/hlx_statics/blocks/onthispage/onthispage.js
+++ b/hlx_statics/blocks/onthispage/onthispage.js
@@ -1,7 +1,6 @@
 import {
-    applyAnalyticHeaderOverride,
     createTag
-  } from '../../scripts/lib-adobeio.js';
+} from '../../scripts/lib-adobeio.js';
 
 /**
  * Decorates the onthispage block.
@@ -14,7 +13,7 @@ export default async function decorate(block) {
     block.append(aside);
 
     const mainContainer = document.querySelector('main');
-    const headings = mainContainer.querySelectorAll('h2, h3');
+    const headings = mainContainer.querySelectorAll('h2:not(.sid-nav h2):not(footer h2), h3:not(.sid-nav h3):not(footer h3)');
 
     Object.assign(aside.style, {
         display: 'flex',


### PR DESCRIPTION
I found an issue in the "OnThisPage" section. In the existing implementation, we were taking h2 and h3 tags from the main container, which in some cases included tags from the footer as well, which we don’t need. I have fixed that and created a PR. Kindly review it.

![Screenshot 2024-10-30 155309](https://github.com/user-attachments/assets/7e1f5995-65d1-4bbd-bf1a-9904019f30af)

