### PR TITLE
Hide breadcrumbs based on hero and config

### DIFF
--- a/hlx_statics/blocks/breadcrumbs/breadcrumbs.js
+++ b/hlx_statics/blocks/breadcrumbs/breadcrumbs.js
@@ -49,7 +49,9 @@ async function buildBreadcrumbs() {
 }
 
 export default async function decorate(block) {
-  const showBreadcrumbs = getMetadata('hideBreadcrumbNav') !== 'true'; // TODO
+  const hasHero = Boolean(document.querySelector('.herosimple-container') || document.querySelector('.hero-container'));
+  const showBreadcrumbsConfig = getMetadata('hidebreadcrumbnav') !== 'true';
+  const showBreadcrumbs = !hasHero && showBreadcrumbsConfig;
   if(showBreadcrumbs) {
     const nav = document.createElement('nav');
     nav.ariaLabel = "Breadcrumb";
@@ -76,6 +78,8 @@ export default async function decorate(block) {
     })
     
     ol.append(...lis);
+  } else{
+    block.parentElement?.parentElement?.remove();
   }
 }
   

--- a/hlx_statics/scripts/lib-helix.js
+++ b/hlx_statics/scripts/lib-helix.js
@@ -688,7 +688,7 @@ export function githubActionsBlock(doc) {
   const githubIssueUrl = baseUrl.replace('blob', 'issues/new?title=Issue%20in%20');
   if (!doc.querySelector('.herosimple-container') && !doc.querySelector('.hero-container')) {
     const newContent = doc.createElement('div');
-    newContent.classList.add('github-actions-wrapper');
+    newContent.classList.add('section', 'github-actions-wrapper');
     newContent.innerHTML = `
               <div class="github-actions-block">
                       <a class="action-buttons" target="_blank" rel="noopener noreferrer nofollow" href=${githubEditUrl} role="button">

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -923,11 +923,13 @@ main .content-header .breadcrumbs-container {
 
 main .github-actions-wrapper{
   padding: 40px 20px 20px 0px;
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
 }
 
 main .github-actions-block{
   display: flex;
-  justify-content: flex-end;
   gap: 20px;
 }
 


### PR DESCRIPTION
**Ticket:** https://jira.corp.adobe.com/browse/DEVSITE-1233

**Description:** Hide breadcrumbs if there's a hero block on the page or if hideBreadcrumbsNav config is set to true

**Test:**
 - without hero, without config -> show breadcrumbs
   - md: https://github.com/AdobeDocs/adobe-dev-console/blob/main/src/pages/guides/authentication/UserAuthentication/implementation.md?plain=1#L1
   - page: https://hide-breadcrumbs--adp-devsite--adobedocs.hlx.page/developer-console/docs/guides/authentication/UserAuthentication/implementation
 - without hero, with config -> hide breadcrumbs
   - md: https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/index.md?plain=1#L2
   - page: https://hide-breadcrumbs--adp-devsite--adobedocs.hlx.page/github-actions-test/test/
 - with hero, without config -> hide breadcrumbs
   - md: https://github.com/AdobeDocs/adobe-dev-console/blob/main/src/pages/guides/authentication/index.md?plain=1#L1
   - page: https://hide-breadcrumbs--adp-devsite--adobedocs.hlx.page/developer-console/docs/guides/authentication/