### PR TITLE
fix: prevent main from overlapping with onthispage

### DIFF
--- a/hlx_statics/blocks/table/table.css
+++ b/hlx_statics/blocks/table/table.css
@@ -3,7 +3,6 @@ main div.table-wrapper {
 } 
 
 main div.table-container {
-  width: 100%;
   background: rgb(245, 245, 245);
   overflow-x: auto;
 }


### PR DESCRIPTION
#### Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1292

#### Test URL
https://main-overlaps-with-onthispage--adp-devsite--adobedocs.hlx.page/developer-console/docs/guides/authentication/UserAuthentication/

#### Before

<img width="1728" alt="before" src="https://github.com/user-attachments/assets/53d68b38-6c5f-475c-a832-b3756585cffb">


#### After

<img width="1728" alt="after" src="https://github.com/user-attachments/assets/9e4ab115-60ec-4ac8-b0fd-35a5706e155d">
