### PR TITLE
feat: redoclyapiblock

### DIFF
--- a/hlx_statics/blocks/redoclyapiblock/redoclyapiblock.js
+++ b/hlx_statics/blocks/redoclyapiblock/redoclyapiblock.js
@@ -35,7 +35,7 @@ function parseOptions(block) {
       value = value.trim();
 
       // JSX shorthand for passing true
-      if(value === 'undefined') {
+      if(value === '') {
         value = true;
       }
       

--- a/hlx_statics/blocks/redoclyapiblock/redoclyapiblock.js
+++ b/hlx_statics/blocks/redoclyapiblock/redoclyapiblock.js
@@ -1,0 +1,133 @@
+import { createTag, getResourceUrl } from '../../scripts/lib-adobeio.js';
+
+const REDOCLY_LICENSE_KEY = "eyJ0IjpmYWxzZSwiaSI6MTczMjEzNzQzNSwiZSI6MTc1OTI2NTQxNywiaCI6WyJyZWRvYy5seSIsImRldmVsb3Blci5hZG9iZS5jb20iLCJkZXZlbG9wZXItc3RhZ2UuYWRvYmUuY29tIiwiZGV2ZWxvcGVyLmZyYW1lLmlvIiwiZGV2ZWxvcGVyLmRldi5mcmFtZS5pbyIsImxvY2FsaG9zdC5jb3JwLmFkb2JlLmNvbSIsInJlZG9jbHktYXBpLWJsb2NrLS1hZHAtZGV2c2l0ZS0tYWRvYmVkb2NzLmFlbS5wYWdlIiwiZGV2ZWxvcGVyLWRldi5hZG9iZS5jb20iXSwicyI6InBvcnRhbCJ9.gf0tCrK+ApckZEqbuOlYJFlt19NU6UEWpiruC4VIMg9ZYUojkyDGde2aEKpBK2cm57r6yNNFNWHyIRljWAQnsg==";
+
+const DEFAULT_OPTIONS = {
+  src: 'https://raw.githubusercontent.com/AdobeDocs/adp-devsite-github-actions-test/refs/heads/main/static/openapi.yaml',
+  width: '500px',
+  typography: 'fontFamily: `adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif`',
+  codeBlock: 'tokens: { punctuation: { color: "white" }}',
+  disableSidebar: false,
+  disableSearch: false,
+  hideTryItPanel: false,
+  scrollYOffset: 0,
+  sortOperationsAlphabetically: false,
+  sortTagsAlphabetically: false,
+  jsonSampleExpandLevel: 2,
+  generateCodeSamples: 'languages: [], skipOptionalParameters: false,',
+  requestInterceptor: '',
+};
+
+const ATTRIBUTE_PREFIX = 'data-';
+
+function parseOptions(block) {
+  // start with default options
+  const options = Object.assign({}, DEFAULT_OPTIONS);
+
+  const blockChildrenToRemove = [];
+
+  // overwrite with options from user
+  block.querySelectorAll('div > div > pre > code').forEach(code => {
+    if(code.textContent.startsWith(ATTRIBUTE_PREFIX)){
+      let [name, value] = code.textContent.split("=");
+      name = name.replace(ATTRIBUTE_PREFIX, '');
+      value = value.trim();
+
+      // JSX shorthand for passing true
+      if(value === 'undefined') {
+        value = true;
+      }
+      
+      options[name] = value;
+
+      // remove attribute row since already been parsed
+      blockChildrenToRemove.push(code.parentElement.parentElement.parentElement);
+    }
+  });
+
+  block.querySelectorAll('div > div > strong').forEach(strong => {
+    if(strong.textContent.startsWith(ATTRIBUTE_PREFIX)) {
+       // remove comma-separated attributes row as this is redundant with the ones already parsed above
+      blockChildrenToRemove.push(strong.parentElement.parentElement);
+    } 
+  })
+
+  // clear attribute rows
+  blockChildrenToRemove.forEach(child => block.removeChild(child));
+
+  return options;
+}
+
+export default function decorate(block) {
+  const { 
+      src,
+      width,
+      typography,
+      codeBlock,
+      disableSidebar,
+      disableSearch,
+      hideTryItPanel,
+      scrollYOffset,
+      sortOperationsAlphabetically,
+      sortTagsAlphabetically,
+      jsonSampleExpandLevel,
+      generateCodeSamples,
+      requestInterceptor,
+    } = parseOptions(block);
+  
+  const absoluteSrc = getResourceUrl(src);
+
+  // https://redocly.com/docs/api-reference-docs/guides/on-premise-html-element#steps
+  const redocly_container = createTag('div', {id: 'redocly_container'});
+  block.appendChild(redocly_container);
+
+  const redocly = createTag('script', {
+      src: 'https://cdn.redoc.ly/reference-docs/latest/redocly-reference-docs.min.js', 
+      async: true
+    });  
+
+  const console = createTag('script', {
+      src: 'https://cdn.redoc.ly/reference-docs/latest/redocly-reference-docs.min.js',
+      async: true
+    });
+
+  document.head.appendChild(redocly);
+  document.head.appendChild(console);
+
+  redocly.addEventListener("load", () => {
+    const init = createTag('script');
+    init.innerHTML = `
+      RedoclyReferenceDocs.init(
+        '${absoluteSrc}',
+        {
+          licenseKey: '${REDOCLY_LICENSE_KEY}',
+          disableSidebar: ${disableSidebar}, 
+          disableSearch: ${disableSearch},
+          hideTryItPanel: ${hideTryItPanel},
+          scrollYOffset: ${scrollYOffset},
+          sortOperationsAlphabetically: ${sortOperationsAlphabetically},
+          sortTagsAlphabetically: ${sortTagsAlphabetically},
+          jsonSampleExpandLevel: ${jsonSampleExpandLevel === 'all' ? `'${jsonSampleExpandLevel}'` : jsonSampleExpandLevel},
+          ${generateCodeSamples ? "generateCodeSamples: { " + generateCodeSamples + "}," : ''}
+          ${requestInterceptor ? "requestInterceptor: " + requestInterceptor + "," : ''}
+          hideLoading: true,
+          theme: {
+          ${typography ? "typography: { " + typography + "}," : ''}
+          rightPanel: {
+            width: '${width}',
+            },
+            ${codeBlock ? "codeBlock: { " + codeBlock + "}," : ''}
+          },
+        },
+        document.querySelector('#redocly_container')
+      );
+    `;
+    block.appendChild(init);
+  });
+
+  redocly.addEventListener("error", (err) => {
+    // eslint-disable-next-line no-console
+    console.error(err);
+  });
+}
+  

--- a/hlx_statics/blocks/redoclyapiblock/redoclyapiblock.js
+++ b/hlx_statics/blocks/redoclyapiblock/redoclyapiblock.js
@@ -87,7 +87,7 @@ export default function decorate(block) {
     });  
 
   const console = createTag('script', {
-      src: 'https://cdn.redoc.ly/reference-docs/latest/redocly-reference-docs.min.js',
+      src: 'https://cdn.redoc.ly/reference-docs/latest/console.redocly-reference-docs.min.js',
       async: true
     });
 

--- a/hlx_statics/blocks/redoclyapiblock/redoclyapiblock.js
+++ b/hlx_statics/blocks/redoclyapiblock/redoclyapiblock.js
@@ -1,5 +1,6 @@
 import { createTag, getResourceUrl } from '../../scripts/lib-adobeio.js';
 
+// TODO - retrieve from secret or config file
 const REDOCLY_LICENSE_KEY = "eyJ0IjpmYWxzZSwiaSI6MTczMjEzNzQzNSwiZSI6MTc1OTI2NTQxNywiaCI6WyJyZWRvYy5seSIsImRldmVsb3Blci5hZG9iZS5jb20iLCJkZXZlbG9wZXItc3RhZ2UuYWRvYmUuY29tIiwiZGV2ZWxvcGVyLmZyYW1lLmlvIiwiZGV2ZWxvcGVyLmRldi5mcmFtZS5pbyIsImxvY2FsaG9zdC5jb3JwLmFkb2JlLmNvbSIsInJlZG9jbHktYXBpLWJsb2NrLS1hZHAtZGV2c2l0ZS0tYWRvYmVkb2NzLmFlbS5wYWdlIiwiZGV2ZWxvcGVyLWRldi5hZG9iZS5jb20iXSwicyI6InBvcnRhbCJ9.gf0tCrK+ApckZEqbuOlYJFlt19NU6UEWpiruC4VIMg9ZYUojkyDGde2aEKpBK2cm57r6yNNFNWHyIRljWAQnsg==";
 
 const DEFAULT_OPTIONS = {

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -194,32 +194,13 @@ export function decorateInlineCodes(element) {
  * @param {*} container The container to inspect
  */
 export function buildCodes(container) {
-  const codes = [...container.querySelectorAll('main > div pre')];
-
+  const codes = [...container.querySelectorAll('main > div > pre > code')];
   codes.forEach((code) => {
-
-    const parentDiv = code.closest('div');
-    parentDiv.classList.add('code-container');
     const block = buildBlock('code', code.outerHTML);
-
-    if (code) {
-      const wrapperDiv = document.createElement('div');
-      const blockDiv = document.createElement('div');
-
-      wrapperDiv.style.margin = "1em 0";
-      code.style.whiteSpace = "pre-wrap";
-
-      code.parentNode.insertBefore(wrapperDiv, code);
-
-      wrapperDiv.classList.add('code-wrapper')
-      blockDiv.classList.add('code', 'block');
-
-      blockDiv.appendChild(code);
-      wrapperDiv.appendChild(blockDiv);
-
-      decorateBlock(blockDiv);
-      block.replaceWith(wrapperDiv);
-    }
+    block.classList.add('block');
+    const parentContainer = code.parentElement.parentElement;
+    const pre = parentContainer.querySelector('pre');
+    pre.replaceWith(block);
   });
 }
 

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -344,7 +344,6 @@ export function toggleScale() {
  * @param {*} block The block containing the picture to rearrange
  */
 export function rearrangeHeroPicture(block, overlayStyle) {
-  console.log('block', block)
   const picture = block.querySelector('picture');
   const emptyDiv = picture.parentElement.parentElement;
   block.prepend(picture);

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -197,7 +197,6 @@ export function buildCodes(container) {
   const codes = [...container.querySelectorAll('main > div > pre > code')];
   codes.forEach((code) => {
     const block = buildBlock('code', code.outerHTML);
-    block.classList.add('block');
     const parentContainer = code.parentElement.parentElement;
     const pre = parentContainer.querySelector('pre');
     pre.replaceWith(block);


### PR DESCRIPTION
#### Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1241

#### Description
The EDS counterpart of Gatsby's [RedoclyAPIBlock](https://github.com/adobe/aio-theme/blob/main/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js)

#### Implementation notes
Differences from Gatsby:
- In Gatsby, secrets were accessed during the [deploy process](https://github.com/AdobeDocs/redocly-test/blob/main/.github/workflows/deploy.yml#L129) and [env](https://github.com/adobe/aio-theme/blob/main/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js#L18). For EDS, this is something we still need to figure out.
- Attributes from markdown were passed as rows by the `devsite-runtime-connector` ([#18](https://github.com/aemsites/devsite-runtime-connector/pull/18), [#19](https://github.com/aemsites/devsite-runtime-connector/pull/19), [#20](https://github.com/aemsites/devsite-runtime-connector/pull/20)), and so we parse then remove them from the markup in `adp-devsite`.
- In Gatsby, open api specs were stored in static folders and can be referenced by relative path. However, for EDS, we need to convert the relative path to their equivalent raw git URL.

#### URL for testing

- page: https://redocly-api-block--adp-devsite--adobedocs.aem.page/github-actions-test/test/redocly-api-block
- markdown: https://raw.githubusercontent.com/AdobeDocs/adp-devsite-github-actions-test/refs/heads/main/src/pages/test/redocly-api-block.md
- markup: https://redocly-api-block--adp-devsite--adobedocs.aem.page/github-actions-test/test/redocly-api-block.md
- how the props get passed to redocly:
<img width="1509" alt="Screenshot 2024-11-26 at 3 09 04 PM" src="https://github.com/user-attachments/assets/265ff33c-8a24-415b-80b3-47d59a428456">
