### PR TITLE
Fix code block issue

### DIFF
--- a/hlx_statics/blocks/code/code.css
+++ b/hlx_statics/blocks/code/code.css
@@ -1,5 +1,3 @@
-@import url('../../styles/prism.css');
-
 pre[class*=language-] {
     border-radius: 4px;
 }

--- a/hlx_statics/blocks/code/code.js
+++ b/hlx_statics/blocks/code/code.js
@@ -5,5 +5,5 @@ export default function decorate(block) {
   const code = block.querySelector('code');
   code.parentElement.replaceChild(pre, code);
   pre.appendChild(code);
-  decoratePreformattedCode({ block, language: 'none' });
+  decoratePreformattedCode(block);
 }

--- a/hlx_statics/blocks/codeblock/codeblock.css
+++ b/hlx_statics/blocks/codeblock/codeblock.css
@@ -1,5 +1,3 @@
-@import url("../../styles/prism.css");
-
 pre[class*="language-"] {
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;

--- a/hlx_statics/blocks/codeblock/codeblock.js
+++ b/hlx_statics/blocks/codeblock/codeblock.js
@@ -1,5 +1,5 @@
 import { toClassName } from '../../scripts/lib-helix.js';
-import decoratePreformattedCode, { getLanguageDecorateCode } from '../../components/code.js';
+import decoratePreformattedCode from '../../components/code.js';
 
 // Function to create a button element for tabs
 function createTabButton(tab, id, isSelected, onClick) {
@@ -60,8 +60,6 @@ export default function decorate(block) {
   decorateTabs(block);
 
   block.querySelectorAll('[role=tabpanel]').forEach(panel => {
-    const code = panel.querySelector('code');
-    const language = getLanguageDecorateCode({ code });
-    decoratePreformattedCode({ block: panel, language });
+    decoratePreformattedCode(panel);
   });
 }

--- a/hlx_statics/blocks/tab/tab.css
+++ b/hlx_statics/blocks/tab/tab.css
@@ -1,5 +1,3 @@
-@import url('../../styles/prism.css');
-
 main div.tab-container:has(.tab.background-color-navy) {
     background-color: rgb(15, 55, 95);
 }

--- a/hlx_statics/blocks/tab/tab.js
+++ b/hlx_statics/blocks/tab/tab.js
@@ -1,4 +1,4 @@
-import decoratePreformattedCode, { getLanguageDecorateCode } from "../../components/code.js";
+import decoratePreformattedCode from "../../components/code.js";
 
 /**
  * decorates the text
@@ -69,11 +69,8 @@ export default async function decorate(block) {
           codeContentContainer.appendChild(code);
           tabContent.appendChild(codeContentContainer);
 
-          //get language and align the code
-          const language = getLanguageDecorateCode({ code });
-
           //formatted the code with number
-          decoratePreformattedCode({ block: tabContent, language });
+          decoratePreformattedCode(tabContent);
 
           if (index !== 0) {
             tabContent.style.display = 'none';

--- a/hlx_statics/components/code.js
+++ b/hlx_statics/components/code.js
@@ -6,7 +6,6 @@ export default function decoratePreformattedCode({ block, language }) {
   pre.classList.add('line-numbers');
 
   const code = block.querySelector('code');
-  code.textContent = code.textContent.trim();
   // see https://prismjs.com/#basic-usage
   code.classList.add(`language-${toClassName(language)}`);
   // see https://prismjs.com/plugins/copy-to-clipboard/#settings

--- a/hlx_statics/components/code.js
+++ b/hlx_statics/components/code.js
@@ -1,22 +1,25 @@
 import { toClassName } from '../scripts/lib-helix.js';
 
-export default function decoratePreformattedCode({ block, language }) {
+function getLanguageDecorateCode(code) {
+  return 'none';
+  // TODO - connector is stripping out the language, so nothing to parse here
+  // const index = code.innerHTML.indexOf('\n');
+  // const language = code.innerHTML.substring(0, index);
+  // code.innerHTML = code.innerHTML.substring(index + 1, code.innerHTML.length);
+  // return language;
+}
+
+export default function decoratePreformattedCode(block) {
   const pre = block.querySelector('pre');
   // see https://prismjs.com/plugins/line-numbers/#how-to-use
   pre.classList.add('line-numbers');
 
   const code = block.querySelector('code');
+  const language = getLanguageDecorateCode(code);
   // see https://prismjs.com/#basic-usage
   code.classList.add(`language-${toClassName(language)}`);
   // see https://prismjs.com/plugins/copy-to-clipboard/#settings
   code.setAttribute('data-prismjs-copy', 'Copy');
   code.setAttribute('data-prismjs-copy-success', 'Copied to your clipboard');
   code.setAttribute('data-prismjs-copy-timeout', '3000');
-}
-
-export function getLanguageDecorateCode({ code }) {
-  const index = code.innerHTML.indexOf('\n');
-  const language = code.innerHTML.substring(0, index);
-  code.innerHTML = code.innerHTML.substring(index + 1, code.innerHTML.length);
-  return language;
 }

--- a/hlx_statics/components/code.js
+++ b/hlx_statics/components/code.js
@@ -6,6 +6,7 @@ export default function decoratePreformattedCode({ block, language }) {
   pre.classList.add('line-numbers');
 
   const code = block.querySelector('code');
+  code.textContent = code.textContent.trim();
   // see https://prismjs.com/#basic-usage
   code.classList.add(`language-${toClassName(language)}`);
   // see https://prismjs.com/plugins/copy-to-clipboard/#settings

--- a/hlx_statics/scripts/delayed.js
+++ b/hlx_statics/scripts/delayed.js
@@ -1,5 +1,8 @@
 // eslint-disable-next-line import/no-cycle
-import { sampleRUM } from './lib-helix.js';
+import { 
+  sampleRUM, 
+  loadCSS 
+} from './lib-helix.js';
 import {
   focusRing,
   isHlxPath,
@@ -23,6 +26,7 @@ function loadPrism(document) {
   // see: https://prismjs.com/docs/Prism.html#.manual
   window.Prism = window.Prism || {};
   window.Prism.manual = true;
+  loadCSS(`${window.hlx.codeBasePath}/styles/prism.css`);
   import('./prism.js')
     .then(() => {
       // see: https://prismjs.com/plugins/autoloader/

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -1,5 +1,5 @@
 import {
-  buildBlock, decorateBlock, getMetadata,
+  buildBlock, getMetadata,
 } from './lib-helix.js';
 
 /**

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -1,6 +1,5 @@
-import {
-  buildBlock, getMetadata,
-} from './lib-helix.js';
+import { buildBlock, getMetadata, loadCSS } from './lib-helix.js';
+import decoratePreformattedCode from '../components/code.js';
 
 /**
  * Breakpoints
@@ -187,6 +186,19 @@ export function decorateInlineCodes(element) {
       code.classList.add('inline-code');
     }
   });
+}
+
+/**
+ * Decorates all nested codes in a container element.
+ * @param {Element} element container element
+ */
+export function decorateNestedCodes(element) {
+  element.querySelectorAll('div.default-content-wrapper pre > code').forEach((code) => {
+    loadCSS(`${window.hlx.codeBasePath}/blocks/code/code.css`);
+    const container = code.parentElement.parentElement;
+    decoratePreformattedCode(container);
+  });
+  
 }
 
 /**

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -30,6 +30,7 @@ import {
   toggleScale,
   decorateAnchorLink,
   decorateInlineCodes,
+  decorateNestedCodes,
   isHlxPath,
   decorateProfile,
   isStageEnvironment,
@@ -119,6 +120,7 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
+  decorateNestedCodes(main);
   decorateHR(main);
 }
 

--- a/hlx_statics/styles/prism.css
+++ b/hlx_statics/styles/prism.css
@@ -136,7 +136,8 @@ pre[class*=language-].line-numbers>code {
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
-    user-select: none
+    user-select: none;
+    border-right: none;
 }
 
 .line-numbers-rows>span {

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -973,3 +973,7 @@ main .default-content-wrapper img{
   width: 100%;
   height: 100%;
 }
+
+main li h3{
+  color: black;
+}


### PR DESCRIPTION
Ticket: 
https://jira.corp.adobe.com/browse/DEVSITE-1454

Test URLs : 
- code nested in list: https://fix-code-block-issue--adp-devsite--adobedocs.aem.page/app-builder/docs/guides/application-logging/azure-log-analytics
- code: https://fix-code-block-issue--adp-devsite--adobedocs.aem.page/github-actions-test/test/code
- code block (known issue with connector stripping out code language): https://fix-code-block-issue--adp-devsite--adobedocs.aem.page/tools/sidekick/blocks/codeblock
- tab: https://fix-code-block-issue--adp-devsite--adobedocs.aem.page/tools/sidekick/blocks/tab
- redocly api block (known issue with license not allowed on PR branches):  https://fix-code-block-issue--adp-devsite--adobedocs.aem.page/github-actions-test/test/redocly-api-block

Issue: 
EDS doesn't allow for blocks within blocks - in this case, `code` block within a list (i.e. `default content`)

Fix : 
Decorate code nested in list without creating a block