### PR TITLE
undo merge conflict

### DIFF
--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -209,26 +209,9 @@ export function buildCodes(container) {
   const codes = [...container.querySelectorAll('main > div > pre > code')];
   codes.forEach((code) => {
     const block = buildBlock('code', code.outerHTML);
-
-    if (code) {
-      const wrapperDiv = document.createElement('div');
-      const blockDiv = document.createElement('div');
-
-      wrapperDiv.style.margin = "1em 0";
-      wrapperDiv.style.maxWidth = "1155px"
-      code.style.whiteSpace = "pre-wrap";
-
-      code.parentNode.insertBefore(wrapperDiv, code);
-
-      wrapperDiv.classList.add('code-wrapper')
-      blockDiv.classList.add('code', 'block');
-
-      blockDiv.appendChild(code);
-      wrapperDiv.appendChild(blockDiv);
-
-      decorateBlock(blockDiv);
-      block.replaceWith(wrapperDiv);
-    }
+    const parentContainer = code.parentElement.parentElement;
+    const pre = parentContainer.querySelector('pre');
+    pre.replaceWith(block);
   });
 }
 


### PR DESCRIPTION
#### Issue:

Old code got reintroduced in a PR intended to fix breadcrumbs:
- from third commit where `one-repo` was merged to the PR's branch: https://github.com/AdobeDocs/adp-devsite/pull/33/commits
- the unintended merge: https://github.com/AdobeDocs/adp-devsite/pull/33/files#diff-e09b42e560eecc65cd532c29d6e08f7914959673b6070af5633e95cc70adaff0R200-R219

This causes regression on code block issue fix:
- from this PR where it was relying on `buildCodes` to be: https://github.com/AdobeDocs/adp-devsite/pull/29/files#diff-e09b42e560eecc65cd532c29d6e08f7914959673b6070af5633e95cc70adaff0R208-R216

#### Fix:
Undo unintended merge

