### PR TITLE
Fix inline alert

### DIFF
--- a/hlx_statics/blocks/breadcrumbs/breadcrumbs.css
+++ b/hlx_statics/blocks/breadcrumbs/breadcrumbs.css
@@ -98,7 +98,7 @@
 }
 
 main div.breadcrumbs-wrapper{
-   width: 770px;
+  min-width: 250px;
 }
 
 @media screen and (min-width : 320px ) and (max-width : 1024px ) {

--- a/hlx_statics/blocks/inline-nested-alert/inline-nested-alert.css
+++ b/hlx_statics/blocks/inline-nested-alert/inline-nested-alert.css
@@ -10,12 +10,13 @@
 }
 
 .inline-nested-alert-wrapper .InLineNestedAlert-error {
-  border: 2px solid rgb(203, 93, 0);
+  border: 2px solid rgb(209 10 10);
 }
 
-.inline-nested-alert-wrapper .InLineNestedAlert-warning,
-.inline-nested-alert-wrapper .InLineNestedAlert-neutral,
-.inline-nested-alert-wrapper .InLineNestedAlert-default {
+.inline-nested-alert-wrapper .InLineNestedAlert-warning{
+  border: 2px solid rgb(246,133,17);
+}
+.inline-nested-alert-wrapper .InLineNestedAlert-neutral{
   border: 2px solid rgb(110, 110, 110);
 }
 
@@ -23,8 +24,7 @@
   border: 2px solid rgb(0, 143, 93);
 }
 
-.inline-nested-alert-wrapper .InLineNestedAlert-info,
-.inline-nested-alert-wrapper .InLineNestedAlert-help {
+.inline-nested-alert-wrapper .InLineNestedAlert-info, .inline-nested-alert-wrapper .InLineNestedAlert-help{
   border: 2px solid rgb(20, 122, 243);
 }
 

--- a/hlx_statics/blocks/inline-nested-alert/inline-nested-alert.js
+++ b/hlx_statics/blocks/inline-nested-alert/inline-nested-alert.js
@@ -18,11 +18,11 @@ function getVariant(variant) {
 export default async function decorate(block) {
     const parent = block?.parentElement?.parentElement;
 
-    const variant = parent?.getAttribute('data-variant');
+    const header = parent?.getAttribute('data-header');
+    const variant = header === 'true' ? parent?.getAttribute('data-variant') : (parent?.getAttribute('data-variant') || 'info');
     const iconPosition = parent?.getAttribute('data-iconposition');
     const isNested = parent?.getAttribute('data-isnested');
     const isLinkDecorate = parent?.getAttribute('data-islinkdecorate');
-    const header = parent?.getAttribute('data-header');
 
     parent.style.padding = header === 'true' ? '0px' : '10px 0px';
     const anchorTags = block.querySelectorAll('.inline-nested-alert a');

--- a/hlx_statics/blocks/inlinealert/inlinealert.css
+++ b/hlx_statics/blocks/inlinealert/inlinealert.css
@@ -149,6 +149,6 @@ main .inlinealert img {
 }
 
 main .spectrum-InLineAlert--warning{
-    border-color: orange;
-    color: orange;
+    border-color: rgb(246,133,17);
+    color: rgb(246,133,17);
 }

--- a/hlx_statics/blocks/inlinealert/inlinealert.css
+++ b/hlx_statics/blocks/inlinealert/inlinealert.css
@@ -151,4 +151,4 @@ main .inlinealert img {
 main .spectrum-InLineAlert--warning{
     border-color: orange;
     color: orange;
-  }
+}

--- a/hlx_statics/blocks/inlinealert/inlinealert.css
+++ b/hlx_statics/blocks/inlinealert/inlinealert.css
@@ -147,3 +147,8 @@ main .inlinealert img {
     width: 100%;
     height: 100%;
 }
+
+main .spectrum-InLineAlert--warning{
+    border-color: orange;
+    color: orange;
+  }

--- a/hlx_statics/blocks/inlinealert/inlinealert.js
+++ b/hlx_statics/blocks/inlinealert/inlinealert.js
@@ -2,6 +2,7 @@ import {
     createTag,
     getBlockSectionContainer
   } from '../../scripts/lib-adobeio.js';
+import { getMetadata } from '../../scripts/scripts.js';
 
 function NeutralMedium() {
     // no image 
@@ -49,12 +50,18 @@ function getVariant(classList) {
  */
 export default async function decorate(block) {
     const container = getBlockSectionContainer(block);
-
+    let classVariant;
     block.querySelectorAll('.inlinealert > div').forEach((inlineAlert) => {
         inlineAlert.classList.add('spectrum-InLineAlert'); 
         // figure out variant based on parent element or on the block itself
         // TODO: may need to refactor this logic
-        let classVariant = getVariant(block.parentElement.parentElement.classList) ;
+        const source = getMetadata('source')
+        if(source === "github"){
+            classVariant = getVariant(block.classList);
+            console.log('block.classList: ', block.classList);
+        }else{
+            classVariant = getVariant(block.parentElement.parentElement.classList);
+        }
         if(classVariant) {
             const inlineClass = classVariant.class ? classVariant.class : 'spectrum-InLineAlert--info';
             const inlineIcon = classVariant.icon ? classVariant.icon : infoIcon;

--- a/hlx_statics/blocks/inlinealert/inlinealert.js
+++ b/hlx_statics/blocks/inlinealert/inlinealert.js
@@ -55,10 +55,8 @@ export default async function decorate(block) {
         inlineAlert.classList.add('spectrum-InLineAlert'); 
         // figure out variant based on parent element or on the block itself
         // TODO: may need to refactor this logic
-        const source = getMetadata('source')
-        if(source === "github"){
+        if(getMetadata('template') === 'documentation'){
             classVariant = getVariant(block.classList);
-            console.log('block.classList: ', block.classList);
         }else{
             classVariant = getVariant(block.parentElement.parentElement.classList);
         }

--- a/hlx_statics/blocks/inlinealert/inlinealert.js
+++ b/hlx_statics/blocks/inlinealert/inlinealert.js
@@ -50,11 +50,11 @@ function getVariant(classList) {
  */
 export default async function decorate(block) {
     const container = getBlockSectionContainer(block);
-    let classVariant;
     block.querySelectorAll('.inlinealert > div').forEach((inlineAlert) => {
         inlineAlert.classList.add('spectrum-InLineAlert'); 
         // figure out variant based on parent element or on the block itself
         // TODO: may need to refactor this logic
+        let classVariant;
         if(getMetadata('template') === 'documentation'){
             classVariant = getVariant(block.classList);
         }else{

--- a/hlx_statics/styles/prism.css
+++ b/hlx_statics/styles/prism.css
@@ -180,5 +180,7 @@ div.code-toolbar>.toolbar>.toolbar-item>button {
     padding: 0.6em;
     background: rgba(0, 0, 0, 0);
 }
-
+main li .code-toolbar {
+  max-width: 750px;
+}
 

--- a/hlx_statics/styles/prism.css
+++ b/hlx_statics/styles/prism.css
@@ -180,7 +180,3 @@ div.code-toolbar>.toolbar>.toolbar-item>button {
     padding: 0.6em;
     background: rgba(0, 0, 0, 0);
 }
-main li .code-toolbar {
-  max-width: 750px;
-}
-

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -973,7 +973,3 @@ main li h3{
 main .code-wrapper{
   max-width: 830px;
 }
-
-.default-content-wrapper .code-toolbar{
-  max-width: 830px;
-}

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -937,22 +937,14 @@ main .default-content-wrapper strong{
 main .content-header {
   display:flex;
   gap: 32px;
-}
-
-main .content-header .breadcrumbs-container {
-  flex: 1;
-}
-
-main .github-actions-wrapper{
-  padding: 40px 20px 20px 0px;
-  display: flex;
-  justify-content: flex-end;
-  width: 100%;
+  align-items: center;
+  justify-content: space-between;
 }
 
 main .github-actions-block{
   display: flex;
   gap: 20px;
+  min-width: 250px;
 }
 
 main .action-buttons{
@@ -976,4 +968,12 @@ main .default-content-wrapper img{
 
 main li h3{
   color: black;
+}
+
+main .code-wrapper{
+  max-width: 830px;
+}
+
+.default-content-wrapper .code-toolbar{
+  max-width: 830px;
 }

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -881,11 +881,7 @@ main .heading6 h6>span {
   color: inherit !important;
 }
 
-.info-icon {
-  color: rgb(20, 122, 243);
-}
-
-.help-icon {
+.help-icon, .info-icon{
   color: rgb(0, 84, 182);
 }
 
@@ -894,11 +890,11 @@ main .heading6 h6>span {
 }
 
 .error-icon {
-  color: rgb(203, 93, 0);
+  color: rgb(209 10 10);
 }
 
 .warning-icon {
-  color: rgb(110, 110, 110);
+  color: rgb(246,133,17);
 }
 
 .spectrum-Divider {

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -970,13 +970,6 @@ main .code-wrapper{
   max-width: 830px;
 }
 @media screen and (max-width: 1024px) {
-  main {
-      grid-template-areas: "main main" "main footer" !important;
-      grid-template-columns: auto !important;
-  }
-  .side-nav-container, .aside {
-      display: none !important;
-  }
   main .code-wrapper{
     max-width: 900px !important;
   }

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -969,3 +969,20 @@ main li h3{
 main .code-wrapper{
   max-width: 830px;
 }
+@media screen and (max-width: 1024px) {
+  main {
+      grid-template-areas: "main main" "main footer" !important;
+      grid-template-columns: auto !important;
+  }
+  .side-nav-container, .aside {
+      display: none !important;
+  }
+  main .code-wrapper{
+    max-width: 900px !important;
+  }
+}
+@media screen and (max-width: 768px) {
+  main .code-wrapper{
+    max-width: 650px !important;
+  }
+}


### PR DESCRIPTION
1. On some pages, page scrolling occurred due to the code block and content header, so I have fixed that.

2.  In the documentation, the variants were not being applied at this [line](https://github.com/AdobeDocs/adp-devsite/blob/2772ec02ba801ea0ecb0d710b14469478679218a/hlx_statics/blocks/inlinealert/inlinealert.js#L61), so I have added this condition.

**Test URl** : https://fix-inline-alert--adp-devsite--adobedocs.aem.page/events/docs/guides/using/aem/aem-addon-module/