### PR TITLE
fix: nested codes

### DIFF
--- a/hlx_statics/blocks/code/code.css
+++ b/hlx_statics/blocks/code/code.css
@@ -1,3 +1,8 @@
 pre[class*=language-] {
     border-radius: 4px;
 }
+
+main div.nested-code-wrapper {
+    margin-top:  20px;
+    margin-bottom:  20px;
+}

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -194,9 +194,14 @@ export function decorateInlineCodes(element) {
  */
 export function decorateNestedCodes(element) {
   element.querySelectorAll('div.default-content-wrapper pre > code').forEach((code) => {
+    const pre = code.parentElement;
+
+    const wrapper = createTag('div', { class: 'nested-code-wrapper' });
+    pre.replaceWith(wrapper);
+    wrapper.append(pre);
+
     loadCSS(`${window.hlx.codeBasePath}/blocks/code/code.css`);
-    const container = code.parentElement.parentElement;
-    decoratePreformattedCode(container);
+    decoratePreformattedCode(wrapper);
   });
 
 }


### PR DESCRIPTION
#### Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1454

#### Issue
`decoratePreformattedCode` was grabbing the wrong `<code>` within the container

#### Fix
Wrap `<pre><code>` in `nested-code-wrapper` so that `decoratePreformattedCode` grabs the correct `<code>`

#### Before

<img width="1407" alt="before" src="https://github.com/user-attachments/assets/59ce19d1-cf45-465b-a8b7-3c520f32822f" />


#### After

<img width="1404" alt="after" src="https://github.com/user-attachments/assets/a323bd8d-6e8f-4a9d-91ae-ea2ed5ab45fa" />

#### Test

- url: https://fix-nested-codes--adp-devsite--adobedocs.aem.page/developer-console/docs/guides/authentication/ServerToServerAuthentication/implementation

- compare to prod: https://developer.adobe.com/developer-console/docs/guides/authentication/ServerToServerAuthentication/implementation/
