### PR TITLE
Parse RedoclyAPIBlock attributes

### DIFF
--- a/hlx_statics/blocks/redoclyapiblock/redoclyapiblock.js
+++ b/hlx_statics/blocks/redoclyapiblock/redoclyapiblock.js
@@ -19,42 +19,18 @@ const DEFAULT_OPTIONS = {
   requestInterceptor: '',
 };
 
-const ATTRIBUTE_PREFIX = 'data-';
-
 function parseOptions(block) {
   // start with default options
   const options = Object.assign({}, DEFAULT_OPTIONS);
 
-  const blockChildrenToRemove = [];
-
   // overwrite with options from user
-  block.querySelectorAll('div > div > pre > code').forEach(code => {
-    if(code.textContent.startsWith(ATTRIBUTE_PREFIX)){
-      let [name, value] = code.textContent.split("=");
-      name = name.replace(ATTRIBUTE_PREFIX, '');
-      value = value.trim();
-
-      // JSX shorthand for passing true
-      if(value === '') {
-        value = true;
-      }
-      
-      options[name] = value;
-
-      // remove attribute row since already been parsed
-      blockChildrenToRemove.push(code.parentElement.parentElement.parentElement);
+  Object.keys(options).forEach((key) => {
+    const name = `data-${key}`;
+    const value = block.getAttribute(name);
+    if (value != null) {
+      options[key] = value;
     }
   });
-
-  block.querySelectorAll('div > div > strong').forEach(strong => {
-    if(strong.textContent.startsWith(ATTRIBUTE_PREFIX)) {
-       // remove comma-separated attributes row as this is redundant with the ones already parsed above
-      blockChildrenToRemove.push(strong.parentElement.parentElement);
-    } 
-  })
-
-  // clear attribute rows
-  blockChildrenToRemove.forEach(child => block.removeChild(child));
 
   return options;
 }


### PR DESCRIPTION
### Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1241

### Description
Parse attributes from the block's `<div>` (added in https://github.com/AdobeDocs/adp-devsite/pull/37)

### Test
1. Run adp-devsite locally (because redocly license doesn't work on test branch)
2. Go to http://localhost:3000/github-actions-test/test/redocly-api-block
3. Inspect
4. CTRL+F for `RedoclyReferenceDocs.init`
5. Confirm the attributes defined in the markdown file are passed to Redocly: https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/redocly-api-block.md?plain=1#L6-L22

### Screenshot
<img width="1728" alt="Screenshot 2024-12-17 at 5 37 22 PM" src="https://github.com/user-attachments/assets/66a6325e-98f7-4ff7-9e22-8d3cb3a5dadd" />

