### PR TITLE
Inline alert with coding blocks.

### DIFF
--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -211,12 +211,16 @@ export function decorateNestedCodes(element) {
  * @param {*} container The container to inspect
  */
 export function buildCodes(container) {
-  const codes = [...container.querySelectorAll('main > div > pre > code')];
-  codes.forEach((code) => {
+  const allCodes = [...container.querySelectorAll('main > div > pre > code')];
+
+  allCodes.forEach((code) => {
     const block = buildBlock('code', code.outerHTML);
-    const parentContainer = code.parentElement.parentElement;
-    const pre = parentContainer.querySelector('pre');
-    pre.replaceWith(block);
+    const allPreElements = [...document.querySelectorAll('main > div > pre')];
+    const validPreElements = allPreElements.filter(pre => {
+      // Check if the closest div ancestor has the class 'inlinealert'
+      return !pre.closest('div.inlinealert');
+    });
+    validPreElements[0].replaceWith(block);
   });
 }
 


### PR DESCRIPTION
Problem: Some random code blocks are injected as inline alert. 
Solve:  The problem is building code is getting the wrong parentElement to replace with the building code.  Because the inline alert also have PRE element, it selected the wrong element to replace the code block.  Now I used the correct element as the replacement block, it resolved the issues. 
Before:
<img width="1378" alt="Screen Shot 2024-12-18 at 10 32 23 AM" src="https://github.com/user-attachments/assets/b80071c4-eb70-45a3-a8fb-ef6bc5fef55a" />
Now:
<img width="1519" alt="Screen Shot 2024-12-18 at 10 33 10 AM" src="https://github.com/user-attachments/assets/67237aba-eccd-4c2a-9ceb-3bc4872db18c" />

https://louisa-devsite-1463-code--adp-devsite--adobedocs.aem.page/events/docs/guides/#troubleshooting-unstabledisabled-registration-status
