### PR TITLE
removing the unnecessary code

### DIFF
--- a/hlx_statics/components/code.js
+++ b/hlx_statics/components/code.js
@@ -1,24 +1,11 @@
 import { toClassName } from '../scripts/lib-helix.js';
 
-function getLanguageDecorateCode(code) {
-  return 'none';
-  // TODO - connector is stripping out the language, so nothing to parse here
-  // const index = code.innerHTML.indexOf('\n');
-  // const language = code.innerHTML.substring(0, index);
-  // code.innerHTML = code.innerHTML.substring(index + 1, code.innerHTML.length);
-  // return language;
-}
-
 export default function decoratePreformattedCode(block) {
   const pre = block.querySelector('pre');
   // see https://prismjs.com/plugins/line-numbers/#how-to-use
   pre.classList.add('line-numbers');
 
   const code = block.querySelector('code');
-  const language = getLanguageDecorateCode(code);
-  // see https://prismjs.com/#basic-usage
-  code.classList.add(`language-${toClassName(language)}`);
-  // see https://prismjs.com/plugins/copy-to-clipboard/#settings
   code.setAttribute('data-prismjs-copy', 'Copy');
   code.setAttribute('data-prismjs-copy-success', 'Copied to your clipboard');
   code.setAttribute('data-prismjs-copy-timeout', '3000');


### PR DESCRIPTION
The code language is already added as classname so we don't need to read the code from the code block anymore. 
The code block should already work.  Removing the unneeded code as cleanup. 
<img width="1671" alt="Screen Shot 2024-12-19 at 3 30 48 PM" src="https://github.com/user-attachments/assets/538f29b7-5ac3-4f38-9917-4a8f1e2db489" />
