### PR TITLE
fix: fixed discover block && inline alert block

### DIFF
--- a/hlx_statics/blocks/discoverblock/discoverblock.css
+++ b/hlx_statics/blocks/discoverblock/discoverblock.css
@@ -1,13 +1,9 @@
 main div.discover-container:has(.discover.background-color-white) {
     background-color: white !important;
 }
-
 .discover {
     display: flex;
     flex-wrap: wrap;
-}
-.discoverblock{
-    width: 100%;
 }
 /* main .discover-nonheading-child-container  div.button-container {
     padding-top: 23.4px;
@@ -78,9 +74,6 @@ main div.discover-container:has(.discover.background-color-white) {
         width: 100%;
     }
 }
-main .discoverblock-wrapper{
-    max-width: 290px;
- }
 main .discoverblock-container-wrapper{
     display: flex;
     flex-wrap: wrap;
@@ -97,4 +90,4 @@ main .discoverblock-column{
 }
 .discover-nonheading-child-container.discover-child-container {
     font-size: 16px; 
-  }
+}

--- a/hlx_statics/blocks/discoverblock/discoverblock.js
+++ b/hlx_statics/blocks/discoverblock/discoverblock.js
@@ -23,26 +23,41 @@ export default async function decorate(block) {
   const width = block.getAttribute('data-width')
   if(width === '100%'){
     block.classList.add('discoverblock-column');
-  }else{
+  }else {
+    let existingWrapper = document.querySelector('.discoverblock-container-wrapper') || null;
+    if (!existingWrapper) {
+      existingWrapper = createTag('div', { class: 'discoverblock-container-wrapper' });
+      const parentElement = block.parentElement;
+      parentElement.appendChild(existingWrapper);
+    }
+    existingWrapper.appendChild(block);
+    const firstHeading = existingWrapper.querySelector('h2, h3');
+    if (firstHeading) {
+      const parent = firstHeading.parentElement;
+      parent.style.marginBottom = '20px';
+      Array.from(existingWrapper.children).forEach((child,index) => {
+        if(index > 0) {
+          child.style.marginTop = '35px';
+        } 
+      });
+    }
+    const children = Array.from(existingWrapper.children);
+    children.forEach(child => {
+      child.style.maxWidth = '290px';
+    });
+    if (children.length === 4) {
+      children.forEach(child => {
+        child.style.setProperty('max-width', '310px', 'important');
+      });
+    }
     const discoverBlocks = document.querySelectorAll('.discoverblock-wrapper');
-    if (discoverBlocks.length > 0) {
-      const parentElement = discoverBlocks[0].parentNode;
-      let existingWrapper = document.querySelector('.discoverblock-container-wrapper');
-      if (!existingWrapper) {
-        existingWrapper = createTag('div', { class: 'discoverblock-container-wrapper' });
-        parentElement.insertBefore(existingWrapper, discoverBlocks[0]);
+    discoverBlocks.forEach(div => {
+      if (div.childElementCount === 0) {
+        div.remove();
       }
-      discoverBlocks.forEach(block => {
-        existingWrapper.appendChild(block);
-      });
-    }
-    if (discoverBlocks.length === 4) {
-      discoverBlocks.forEach(block => {
-        block.style.setProperty('max-width', '310px', 'important');
-      });
-    }
+    });
   }
-
+  
   Array.from(block.children).forEach(div => {
     const containsHeading = div.querySelector('h1, h2, h3, h4, h5, h6') !== null;
     if (containsHeading) {

--- a/hlx_statics/blocks/inlinealert/inlinealert.css
+++ b/hlx_statics/blocks/inlinealert/inlinealert.css
@@ -131,6 +131,7 @@ main .inlinealert{
     max-width: 1280px;
     margin: 0 auto;
     font-size: 16px;
+    width: 100%;
 }
 
 main .inlinealert>div{
@@ -151,4 +152,8 @@ main .inlinealert img {
 main .spectrum-InLineAlert--warning{
     border-color: rgb(246,133,17);
     color: rgb(246,133,17);
+}
+
+main .inlinealert-wrapper{
+    margin: 20px 0px;
 }

--- a/hlx_statics/blocks/inlinealert/inlinealert.js
+++ b/hlx_statics/blocks/inlinealert/inlinealert.js
@@ -50,11 +50,12 @@ function getVariant(classList) {
  */
 export default async function decorate(block) {
     const container = getBlockSectionContainer(block);
-    block.querySelectorAll('.inlinealert > div').forEach((inlineAlert) => {
-        inlineAlert.classList.add('spectrum-InLineAlert'); 
+
+        block.classList.add('spectrum-InLineAlert'); 
         // figure out variant based on parent element or on the block itself
         // TODO: may need to refactor this logic
         let classVariant;
+        const slots = block?.getAttribute('data-slots')?.split(',');
         if(getMetadata('template') === 'documentation'){
             classVariant = getVariant(block.classList);
         }else{
@@ -63,16 +64,21 @@ export default async function decorate(block) {
         if(classVariant) {
             const inlineClass = classVariant.class ? classVariant.class : 'spectrum-InLineAlert--info';
             const inlineIcon = classVariant.icon ? classVariant.icon : infoIcon;
-            inlineAlert.classList.add(inlineClass);
-            inlineAlert.insertAdjacentHTML("afterbegin", inlineIcon);
+            block.classList.add(inlineClass);
+            block.insertAdjacentHTML("afterbegin", inlineIcon);
         }
 
         // need to wrap content into p
-        inlineAlert.querySelectorAll('div').forEach((divContent) =>{
+        block.querySelectorAll('div').forEach((divContent) =>{
             const inlineP = createTag('p', { class: 'spectrum-InLineAlert-content' });
             inlineP.innerHTML = divContent.innerHTML;
-            inlineAlert.appendChild(inlineP);
+            block.appendChild(inlineP);
             divContent.replaceWith(inlineP);
         });
-    })
+        if (slots?.includes('title')) {
+            const firstPTag = block.querySelector('p');
+            if (firstPTag) {
+              firstPTag.remove();
+            }
+        }
 }

--- a/hlx_statics/blocks/link-block/link-block.css
+++ b/hlx_statics/blocks/link-block/link-block.css
@@ -13,7 +13,7 @@ main div.link-block-container p {
     gap: 4px;
 }
 
-main div.link-block-container p>a {
+main div.link-block-container li>a {
     text-decoration: none !important;
     font-weight:500;
     line-height: 38px;
@@ -32,6 +32,18 @@ main div.link-block-container a:hover {
     cursor: pointer;
 }
 
-main div.link-block-container .link-block-wrapper {
+main div.link-block-container{
     margin: 3%;
+}
+main div.link-block li{
+    list-style-type: none; 
+}
+main .link-icon{
+    display: flex;
+    align-items: baseline;
+    column-gap: 5px;
+}
+main .link-block-wrapper{
+    margin-top: 40px;
+    max-width: 280px;
 }

--- a/hlx_statics/blocks/link-block/link-block.css
+++ b/hlx_statics/blocks/link-block/link-block.css
@@ -1,39 +1,35 @@
-main div.link-block-container:has(.link-block.background-color-white) {
+main div.link-block-wrapper:has(.link-block.background-color-white) {
     background-color: white !important;
 }
 
-main div.link-block-container h1 {
+main div.link-block-wrapper h1 {
     font-size: 18px !important;
     padding-bottom: 9px;
 }
 
-main div.link-block-container p {
+main div.link-block-wrapper p {
     font-size: 16px !important;
     display: flex;
     gap: 4px;
 }
 
-main div.link-block-container li>a {
+main div.link-block-wrapper li>a {
     text-decoration: none !important;
     font-weight:500;
     line-height: 38px;
 }
 
-main div.link-block-container p>div {
+main div.link-block-wrapper p>div {
     margin-top: 0.7% !important;
 }
 
-main div.link-block-container a {
+main div.link-block-wrapper a {
     color: #0054b6;
 }
 
-main div.link-block-container a:hover {
+main div.link-block-wrapper a:hover {
     text-decoration: underline !important;
     cursor: pointer;
-}
-
-main div.link-block-container{
-    margin: 3%;
 }
 main div.link-block li{
     list-style-type: none; 

--- a/hlx_statics/blocks/link-block/link-block.js
+++ b/hlx_statics/blocks/link-block/link-block.js
@@ -10,16 +10,33 @@ export default async function decorate(block) {
     h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL', 'title-heading');
   });
   const icon = `<svg xmlns='http://www.w3.org/2000/svg' height="18" viewBox="0 0 18 18" width="18"><defs><style>.fill {fill: #464646;}</style> </defs><title>S LinkOut 18 N</title><rect id="Canvas" fill="#ff13dc" opacity="0" width="18" height="18" /><path class="fill" d="M16.5,9h-1a.5.5,0,0,0-.5.5V15H3V3H8.5A.5.5,0,0,0,9,2.5v-1A.5.5,0,0,0,8.5,1h-7a.5.5,0,0,0-.5.5v15a.5.5,0,0,0,.5.5h15a.5.5,0,0,0,.5-.5v-7A.5.5,0,0,0,16.5,9Z" /><path class="fill" d="M16.75,1H11.377A.4.4,0,0,0,11,1.4a.392.392,0,0,0,.1175.28l1.893,1.895L9.4895,7.096a.5.5,0,0,0-.00039.70711l.00039.00039.707.707a.5.5,0,0,0,.707,0l3.5215-3.521L16.318,6.882A.39051.39051,0,0,0,16.6,7a.4.4,0,0,0,.4-.377V1.25A.25.25,0,0,0,16.75,1Z" /></svg>`
-  block.querySelectorAll('p').forEach((p) => {
-    p.querySelectorAll('a').forEach((a) => {
+  block.querySelectorAll('li').forEach((li) => {
+    li.querySelectorAll('a').forEach((a) => {
       // get rid of empty anchor tags
       if (!a.hasChildNodes()) {
         a.remove();
       }
     });
-    p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
+    li.classList.add('spectrum-Body', 'spectrum-Body--sizeL', 'link-icon');
     const division = createTag('div');
     division.innerHTML=icon;
-    p.append(division);
+    li.append(division);
   });
+  
+  const subParent = document.querySelector('.sub-parent');
+      const linkBlockWrapper = document.querySelector('.link-block-wrapper');
+      if (linkBlockWrapper) {
+          const linkBlockDiv = createTag('div', { class: 'linkblock-container' });
+          linkBlockWrapper.parentNode.insertBefore(linkBlockDiv, linkBlockWrapper);
+          linkBlockDiv.appendChild(linkBlockWrapper);
+          const relatedBlocksDiv = createTag('div', { class: 'relatedBlocksDiv' });
+          Array.from(subParent.children).forEach(child => {
+              if (!child.classList.contains('linkblock-container')) {
+                relatedBlocksDiv.appendChild(child);
+              }
+          });
+          subParent.appendChild(relatedBlocksDiv);
+          subParent.style.display = 'flex';
+          subParent.style.flexDirection = 'row-reverse';
+  }
 }

--- a/hlx_statics/blocks/table/table.css
+++ b/hlx_statics/blocks/table/table.css
@@ -13,7 +13,6 @@ main div.table-container {
 }
 
 main div.table {
-  width: 100vw;
   max-width: 1280px;
   padding: 80px 32px;
   box-sizing: border-box;


### PR DESCRIPTION
The "Discover" block was not displaying properly, so I have fixed it.

Before: https://main--adp-devsite--adobedocs.aem.page/app-builder-template-registry/

After: https://fix-discover-link--adp-devsite--adobedocs.aem.page/app-builder-template-registry/

I removed the table's width: 100vw style to control the page scroll.

The Inlinealert block was creating multiple blocks, which I have now fixed.

Before: https://main--adp-devsite--adobedocs.aem.page/events/docs/guides/api/eventsingress-api

After: https://fix-discover-link--adp-devsite--adobedocs.aem.page/events/docs/guides/api/eventsingress-api

Link-Block Added: https://fix-discover-link--adp-devsite--adobedocs.aem.page/app-builder-template-registry/