### PR TITLE
fix: herosimple, inlinealert and onthispage

### DIFF
--- a/hlx_statics/blocks/herosimple/herosimple.css
+++ b/hlx_statics/blocks/herosimple/herosimple.css
@@ -13,15 +13,14 @@ main div.herosimple > div {
   margin: 0 auto;
   margin-top: 20px;
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  row-gap: 30px;
 }
 
 main div.herosimple > div > div{
   width: calc(5* 100% / 12);
-}
-
-main div.herosimple > div > p{
-  width: calc(5* 100% / 12);
-  color: rgb(255, 255, 255);
+  font-size: 20px;
 }
 
 main div.herosimple h1 {
@@ -44,9 +43,6 @@ main div.herosimple-container {
     margin: auto;
     margin-left: 90px;
   }
-  main div.herosimple > div > div, main div.herosimple > div > p{
-    width: calc(5* 100% / 6);
-  }
 }
 
 @media screen and (max-width: 768px) {
@@ -54,14 +50,6 @@ main div.herosimple-container {
     height: auto;
     padding: 32px;
   }
-}
-
-main .herosimple p.spectrum-Body--sizeL {
-  font-size: 20px;
-}
-
-main .herosimple h1 + p.last-of-type {
-  margin-bottom: 0 !important;
 }
 
 main .herosimple .herosimple-button-container {

--- a/hlx_statics/blocks/herosimple/herosimple.js
+++ b/hlx_statics/blocks/herosimple/herosimple.js
@@ -26,29 +26,7 @@ export default async function decorate(block) {
     }
 
   });
-
-  // arrange divs
-  let firstDiv = block.firstElementChild;
-  let secondDiv = block.lastElementChild;
-
-  let wrapperDiv = createTag('div');
-  wrapperDiv.appendChild(firstDiv);
-  wrapperDiv.appendChild(secondDiv);
-
-  block.appendChild(wrapperDiv);
-
-  // second child inner div make it a p
-  let descriptionP = secondDiv.innerText;
-  let descriptionPElement = createTag('p', { class: 'spectrum-Body spectrum-Body--sizeL' });
-  descriptionPElement.innerText = descriptionP;
-
-  secondDiv.replaceWith(descriptionPElement);
-  // Paragraph decoration
-  block.querySelectorAll('p').forEach((p) => {
-    if (p.innerText) {
-      p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
-    }
-  });
+  
   const sourceElement = block.querySelector('source[type="image/webp"]');
   const srcsetValue = sourceElement ? sourceElement?.getAttribute('srcset') : null;
   const url = srcsetValue?.split(' ')[0];

--- a/hlx_statics/blocks/inlinealert/inlinealert.js
+++ b/hlx_statics/blocks/inlinealert/inlinealert.js
@@ -76,9 +76,10 @@ export default async function decorate(block) {
             divContent.replaceWith(inlineP);
         });
         if (slots?.includes('title')) {
-            const firstPTag = block.querySelector('p');
-            if (firstPTag) {
-              firstPTag.remove();
+            const paragraphTag = block.querySelector('p');
+            const firstDiv = paragraphTag.querySelector('div');
+            if (firstDiv) {
+                firstDiv.remove();
             }
         }
 }

--- a/hlx_statics/blocks/onthispage/onthispage.js
+++ b/hlx_statics/blocks/onthispage/onthispage.js
@@ -47,10 +47,6 @@ export default async function decorate(block) {
             anchor.classList.add('active');
         }
     });
-    if (headings.length === 0) {
-        const onThisPageWrapper = document.querySelector('.onthispage-wrapper');
-        onThisPageWrapper.style.display = 'none';
-    }
 
     const observer = new IntersectionObserver((entries) => {
         if (isClick) return;

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -243,6 +243,7 @@ export function decorateHR(container) {
  */
 export function buildEmbeds(container) {
   const embeds = [...container.querySelectorAll('div > p > a[href^="https://www.youtube.com"], div > p > a[href^="https://youtu.be"]')];
+  if(!getMetadata('template') === 'documentation'){
   embeds.forEach((embed) => {
     const block = buildBlock('embed', embed.outerHTML);
     embed.replaceWith(block);
@@ -251,6 +252,7 @@ export function buildEmbeds(container) {
     parentContainer.prepend(block);
     removeEmptyPTags(parentContainer);
   });
+ }
 }
 
 /**
@@ -282,7 +284,15 @@ export function buildHeadings(container) {
  */
 export function buildGrid(main) {
   main.style.display = 'grid';
-  main.style.gridTemplateAreas = '"sidenav main aside" "sidenav footer aside"';
+  const mainContainer = document.querySelector('main');
+  const headings = mainContainer.querySelectorAll('h2:not(.side-nav h2):not(footer h2), h3:not(.side-nav h3):not(footer h3)');
+  const heroSimpleContainer = document.querySelector('.herosimple-container');
+  if (heroSimpleContainer || headings.length === 0) {
+    console.log('headings: ', headings);
+    main.style.gridTemplateAreas = '"sidenav main" "sidenav footer"';
+  } else {
+    main.style.gridTemplateAreas = '"sidenav main aside" "sidenav footer aside"';
+  }
 
   const gridAreaMain = main.querySelector(".section");
   gridAreaMain.style.gridArea = 'main';

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -364,7 +364,8 @@ async function loadLazy(doc) {
     main.append(footer);
 
     // turn off this page when in doc mode and there's no hero
-    if(!document.querySelector('.hero, .herosimple')) {
+    const headings = main.querySelectorAll('h2:not(.side-nav h2):not(footer h2), h3:not(.side-nav h3):not(footer h3)');
+    if(!document.querySelector('.hero, .herosimple') && headings.length !== 0) {
       buildOnThisPage(main);
       loadOnThisPage(doc.querySelector('.onthispage-wrapper'));
     }

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -967,15 +967,10 @@ main li h3{
 }
 
 main .code-wrapper{
-  max-width: 830px;
+  max-width: 60vw;
+  margin: 10px 0px;
 }
-@media screen and (max-width: 1024px) {
-  main .code-wrapper{
-    max-width: 900px !important;
-  }
-}
-@media screen and (max-width: 768px) {
-  main .code-wrapper{
-    max-width: 650px !important;
-  }
+main:not(:has(.onthispage-wrapper)) .code-wrapper {
+  max-width: none;
+  width: 100%;
 }


### PR DESCRIPTION
1. **Code block width issue when the "On This Page" section is not present:**

**before**: https://main--adp-devsite--adobedocs.aem.page/runtime/docs/guides/getting-started/deploy
**after**: https://fix-embedblock--adp-devsite--adobedocs.aem.page/runtime/docs/guides/getting-started/deploy

2. **Hersosimple issue:**

I don't know why the Herosimple was not looking the same as before. The structure was messed up, so I fixed it now.

**before**: https://main--adp-devsite--adobedocs.aem.page/runtime/docs/
**after**: https://fix-embedblock--adp-devsite--adobedocs.aem.page/runtime/docs/

  3.  **The "On This Page" block created empty spaces even when it was not present.**
  
  **before**:
![Screenshot 2025-01-03 193458](https://github.com/user-attachments/assets/94d0e12e-cce8-4aa9-9b9d-6cca5d8c23e5)

**after**:
![Screenshot 2025-01-03 193422](https://github.com/user-attachments/assets/4ac3d3f0-3f2b-4a9d-ae96-b7f2e8ec0b62)

4. **Inlinealert block issue**:

This is similar to Herosimple. The structure was messed up, so I fixed it now.

**before**: https://main--adp-devsite--adobedocs.aem.page/events/docs/guides/api/eventsingress-api

**after**: https://fix-embedblock--adp-devsite--adobedocs.aem.page/events/docs/guides/api/eventsingress-api

5. **Embed block**:

The embed block was created unnecessarily because of the buildEmbeds function in adb-devsite. This function creates a block if it encounters content like this: [YouTube](https://www.youtube.com/channel/UCDtYqOjS9Eq9gacLcbMwhhQ) ([repo](https://github.com/AdobeDocs/adobe-io-runtime/blob/fc3ec034615161d7422917abebed447fdd02670d/src/pages/guides/index.md?plain=1#L137)).

**Before**: https://main--adp-devsite--adobedocs.aem.page/runtime/docs/guides/

**After**: https://fix-embedblock--adp-devsite--adobedocs.aem.page/runtime/docs/guides/