### PR TITLE
fix: herosimple, details and code block

### DIFF
--- a/hlx_statics/blocks/code/code.js
+++ b/hlx_statics/blocks/code/code.js
@@ -3,6 +3,9 @@ import decoratePreformattedCode from '../../components/code.js';
 export default function decorate(block) {
   const pre = document.createElement('pre');
   const code = block.querySelector('code');
+  if (!code.className.match(/language-/)) {
+    code.classList.add('language-bash');
+  }
   code.parentElement.replaceChild(pre, code);
   pre.appendChild(code);
   decoratePreformattedCode(block);

--- a/hlx_statics/blocks/code/code.js
+++ b/hlx_statics/blocks/code/code.js
@@ -4,7 +4,7 @@ export default function decorate(block) {
   const pre = document.createElement('pre');
   const code = block.querySelector('code');
   if (!code.className.match(/language-/)) {
-    code.classList.add('language-bash');
+    code.classList.add('language-none');
   }
   code.parentElement.replaceChild(pre, code);
   pre.appendChild(code);

--- a/hlx_statics/blocks/detailsblock/detailsblock.css
+++ b/hlx_statics/blocks/detailsblock/detailsblock.css
@@ -1,3 +1,8 @@
 main details {
     font-size: 16px ;
 }
+
+main .detailsblock details > div > div, 
+main .detailsblock-wrapper {
+    margin: 20px 0px;
+}

--- a/hlx_statics/blocks/herosimple/herosimple.js
+++ b/hlx_statics/blocks/herosimple/herosimple.js
@@ -30,13 +30,10 @@ export default async function decorate(block) {
   const sourceElement = block.querySelector('source[type="image/webp"]');
   const srcsetValue = sourceElement ? sourceElement?.getAttribute('srcset') : null;
   const url = srcsetValue?.split(' ')[0];
-  const imgElement = block.querySelector('img');
-  const heroFirstDiv = block.querySelector('.herosimple > div');
-  const heroSecondDiv = block.querySelector('.herosimple > div:nth-of-type(2)');
-  if (srcsetValue) {
-    imgElement.style.display = 'none';
-    heroFirstDiv.style.marginBottom = '0px';
-    heroSecondDiv.style.marginTop = '0px';
+  const pictureElement = block.querySelector('picture');
+  if(pictureElement){
+    const parentDiv = pictureElement.parentElement;
+    parentDiv.remove();
     Object.assign(block.style, {
       backgroundImage: `url(${url})`,
       backgroundSize: 'cover',
@@ -47,10 +44,10 @@ export default async function decorate(block) {
 
   const heroSimpleContainer = document.querySelector('.herosimple-container');
   const sideNav = document.querySelector('.side-nav-container');
+  const subParent = createTag('div',{class:'sub-parent'});
     if (heroSimpleContainer) {
       heroSimpleContainer.style.margin = '0px';
       heroSimpleContainer.style.maxWidth = 'none';
-      const subParent = createTag('div',{class:'sub-parent'});
       const children = Array.from(heroSimpleContainer.children);
       children.forEach(child => {
         if (!child.classList.contains('herosimple-wrapper')) {
@@ -63,11 +60,13 @@ export default async function decorate(block) {
       } else {
         heroSimpleContainer.appendChild(subParent);
       }
-      subParent.style.margin = '0 164px';
-      subParent.style.maxWidth = '1280px';
+      subParent.style.margin = '0 auto';
+      subParent.style.maxWidth = '1000px';
     }
     if(!sideNav){
       const heroSimpleDiv = block.querySelector('.herosimple > div');
       heroSimpleDiv.style.setProperty('max-width', '1280px', 'important');
+      subParent.style.margin = '0 auto';
+      subParent.style.maxWidth = '1280px';
     }
 }

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -967,7 +967,7 @@ main li h3{
   color: black;
 }
 
-main .code-wrapper{
+main .code-wrapper, main .nested-code-wrapper{
   max-width: 60vw;
   margin: 10px 0px;
 }


### PR DESCRIPTION
1. Fixed the hero-simple section to properly set the background image and added responsiveness.

Before: https://main--adp-devsite--adobedocs.aem.page/app-builder/docs/overview/
After: https://fix-detailsblock--adp-devsite--adobedocs.aem.page/app-builder/docs/overview/
![image](https://github.com/user-attachments/assets/67b8af4e-1238-474f-b984-101655756b94)
![image](https://github.com/user-attachments/assets/7c1cb7ba-130c-4cf2-861b-a8b0231246cc)

2. Added the width for the nested-code block.

3.  code block.
In some cases, if the language is not specified for a code block, it gets converted to a code block but doesn't produce the desired output. So, I have set bash as the default language. Let me know if this is fine or if it should be handled differently.

E.g: https://github.com/AdobeDocs/app-builder/blob/7601d31f46c308aa0664da8cb6bf2ebb9f5ba311/src/pages/guides/extensions/extension-migration-guide.md?plain=1#L98

Before: https://main--adp-devsite--adobedocs.aem.page/app-builder/docs/guides/extensions/extension-migration-guide
After: https://fix-detailsblock--adp-devsite--adobedocs.aem.page/app-builder/docs/guides/extensions/extension-migration-guide

5. details block:
Before: https://main--adp-devsite--adobedocs.aem.page/events/docs/guides/using/asset-events/asset-events-properties
After: https://fix-detailsblock--adp-devsite--adobedocs.aem.page/events/docs/guides/using/asset-events/asset-events-properties
