### PR TITLE
retrieve redocly license key from config

### DIFF
--- a/hlx_statics/blocks/redoclyapiblock/redoclyapiblock.js
+++ b/hlx_statics/blocks/redoclyapiblock/redoclyapiblock.js
@@ -1,8 +1,5 @@
 import { createTag, getResourceUrl } from '../../scripts/lib-adobeio.js';
 
-// TODO - retrieve from secret or config file
-const REDOCLY_LICENSE_KEY = "eyJ0IjpmYWxzZSwiaSI6MTczMjEzNzQzNSwiZSI6MTc1OTI2NTQxNywiaCI6WyJyZWRvYy5seSIsImRldmVsb3Blci5hZG9iZS5jb20iLCJkZXZlbG9wZXItc3RhZ2UuYWRvYmUuY29tIiwiZGV2ZWxvcGVyLmZyYW1lLmlvIiwiZGV2ZWxvcGVyLmRldi5mcmFtZS5pbyIsImxvY2FsaG9zdC5jb3JwLmFkb2JlLmNvbSIsInJlZG9jbHktYXBpLWJsb2NrLS1hZHAtZGV2c2l0ZS0tYWRvYmVkb2NzLmFlbS5wYWdlIiwiZGV2ZWxvcGVyLWRldi5hZG9iZS5jb20iXSwicyI6InBvcnRhbCJ9.gf0tCrK+ApckZEqbuOlYJFlt19NU6UEWpiruC4VIMg9ZYUojkyDGde2aEKpBK2cm57r6yNNFNWHyIRljWAQnsg==";
-
 const DEFAULT_OPTIONS = {
   src: 'https://raw.githubusercontent.com/AdobeDocs/adp-devsite-github-actions-test/refs/heads/main/static/openapi.yaml',
   width: '500px',
@@ -77,7 +74,7 @@ export default function decorate(block) {
       RedoclyReferenceDocs.init(
         '${absoluteSrc}',
         {
-          licenseKey: '${REDOCLY_LICENSE_KEY}',
+          licenseKey: '${window.REDOCLY}',
           disableSidebar: ${disableSidebar}, 
           disableSearch: ${disableSearch},
           hideTryItPanel: ${hideTryItPanel},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Retrieve redocly license key from [config](https://github.com/AdobeDocs/adp-devsite/pull/70)

## Related Issue

https://jira.corp.adobe.com/browse/DEVSITE-1241

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested locally (http://localhost:3000/github-actions-test/test/redocly-api-block)

Can't test on branch (https://main--adp-devsite--adobedocs.hlx.page/github-actions-test/test/redocly-api-block) because that domain isn't in the list of allowed domains for Redocly on-premise license key. But once merged to main, can test on dev (https://developer-dev.adobe.com/github-actions-test/test/redocly-api-block)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
