### PR TITLE
Fix: use source metadata to select config or nav file for navigation

### DIFF
--- a/hlx_statics/blocks/header/header.js
+++ b/hlx_statics/blocks/header/header.js
@@ -374,6 +374,25 @@ export default async function decorate(block) {
       const topNavHtml = await fetchTopNavHtml();
       if (topNavHtml) {
         navigationLinks.innerHTML += topNavHtml;
+        
+        // Process dropdowns for documentation template navigation
+        navigationLinks.querySelectorAll('li > ul').forEach((dropDownList, index) => {
+          let dropdownLinkDropdownHTML = '';
+          let dropdownLinksHTML = '';
+
+          dropDownList.querySelectorAll('ul > li > a').forEach((dropdownLinks) => {
+            dropdownLinksHTML
+              += globalNavLinkItemDropdownItem(dropdownLinks.href, dropdownLinks.innerText);
+          });
+
+          dropdownLinkDropdownHTML = globalNavLinkItemDropdown(
+            index,
+            dropDownList.parentElement.firstChild.textContent.trim(),
+            dropdownLinksHTML,
+          );
+          dropDownList.parentElement.innerHTML = dropdownLinkDropdownHTML;
+        });
+        
         header.append(navigationLinks);
       }
     }

--- a/hlx_statics/blocks/header/header.js
+++ b/hlx_statics/blocks/header/header.js
@@ -12,6 +12,10 @@ import {
 import { readBlockConfig, getMetadata, fetchTopNavHtml } from '../../scripts/lib-helix.js';
 import { loadFragment } from '../fragment/fragment.js';
 
+function isSourceGithub() {
+  return getMetadata('source') === 'github';
+}
+
 function globalNavSearchButton() {
   const div = createTag('div', { class: 'nav-console-search-button' });
   div.innerHTML = `<button class="nav-dropdown-search" aria-label="search" class="spectrum-ActionButton spectrum-ActionButton--sizeM spectrum-ActionButton--emphasized spectrum-ActionButton--quiet">
@@ -350,9 +354,9 @@ export default async function decorate(block) {
   iconContainer.appendChild(siteLink);
   header.append(iconContainer);
 
-  // Handle navigation based on template
-  if (getMetadata('template') === 'documentation') {
-    // Create navigation for documentation template (desktop only)
+  // Handle navigation based on source
+  if (isSourceGithub()) {
+    // Create navigation for docs from github (desktop only)
     if (window.innerWidth > 768) {
       let navigationLinks = createTag('ul', { id: 'navigation-links', class: 'menu desktop-nav', style: 'list-style-type: none;'});
 

--- a/hlx_statics/blocks/side-nav/side-nav.js
+++ b/hlx_statics/blocks/side-nav/side-nav.js
@@ -116,6 +116,70 @@ export default async function decorate(block) {
     class: "spectrum-SideNav spectrum-SideNav--multiLevel main-menu",
   });
 
+  function processNestedNavigation(menuUl) {
+    menuUl.querySelectorAll('li').forEach((li) => {
+      const nestedUl = li.querySelector('ul');
+      if (nestedUl) {
+        // Get the text node or link that precedes the nested ul
+        const label = li.childNodes[0];
+        const text = label.nodeType === Node.TEXT_NODE ? label.textContent.trim() : label.textContent;
+        
+        // Create the expandable link
+        const expandableLink = createTag('button', {
+          class: 'spectrum-SideNav-itemLink',
+          type: 'button',
+          'aria-expanded': 'false'
+        });
+        expandableLink.innerHTML = text;
+        
+        // Replace the text/link with the expandable link
+        if (label.nodeType === Node.TEXT_NODE) {
+          li.removeChild(label);
+        } else {
+          li.removeChild(label);
+        }
+        li.insertBefore(expandableLink, nestedUl);
+        
+        // Set up proper nesting structure
+        li.setAttribute('role', 'treeitem');
+        li.classList.add('header');
+        nestedUl.setAttribute('role', 'group');
+        nestedUl.classList.add('spectrum-SideNav');
+        nestedUl.style.display = 'none';
+        
+        // Process nested links
+        nestedUl.querySelectorAll('li').forEach(nestedLi => {
+          const nestedLink = nestedLi.querySelector('a');
+          if (nestedLink) {
+            nestedLink.style.fontWeight = '400';
+            if (!nestedLi.querySelector('ul')) {
+              nestedLink.innerHTML = nestedLink.textContent.trim();
+              nestedLi.classList.add('no-chevron');
+            }
+          }
+        });
+        
+        // Add click handler
+        expandableLink.onclick = (e) => {
+          e.preventDefault();
+          const isExpanded = li.getAttribute('aria-expanded') === 'true';
+          
+          li.setAttribute('aria-expanded', !isExpanded);
+          li.classList.toggle('is-expanded', !isExpanded);
+          nestedUl.style.display = isExpanded ? 'none' : 'block';
+          
+          updateIcon(expandableLink, !isExpanded, true);
+        };
+        
+        // Initialize icon
+        updateIcon(expandableLink, false, true);
+      } else {
+        // For non-expandable items, ensure they don't get chevrons
+        li.classList.add('no-chevron');
+      }
+    });
+  }
+
   if (isDocumentationTemplate()) {
     // Fetch and populate main menu for documentation template
     // Add Products link first
@@ -128,69 +192,7 @@ export default async function decorate(block) {
     const topNavHtml = await fetchTopNavHtml();
     if (topNavHtml) {
       menuUl.innerHTML += topNavHtml;
-
-      // Process nested lists to make them expandable (same as non-doc pages)
-      menuUl.querySelectorAll('li').forEach((li) => {
-        const nestedUl = li.querySelector('ul');
-        if (nestedUl) {
-          // Get the text node or link that precedes the nested ul
-          const label = li.childNodes[0];
-          const text = label.nodeType === Node.TEXT_NODE ? label.textContent.trim() : label.textContent;
-          
-          // Create the expandable link
-          const expandableLink = createTag('button', {
-            class: 'spectrum-SideNav-itemLink',
-            type: 'button',
-            'aria-expanded': 'false'
-          });
-          expandableLink.innerHTML = text;
-          
-          // Replace the text/link with the expandable link
-          if (label.nodeType === Node.TEXT_NODE) {
-            li.removeChild(label);
-          } else {
-            li.removeChild(label);
-          }
-          li.insertBefore(expandableLink, nestedUl);
-          
-          // Set up proper nesting structure
-          li.setAttribute('role', 'treeitem');
-          li.classList.add('header');
-          nestedUl.setAttribute('role', 'group');
-          nestedUl.classList.add('spectrum-SideNav');
-          nestedUl.style.display = 'none';
-          
-          // Process nested links
-          nestedUl.querySelectorAll('li').forEach(nestedLi => {
-            const nestedLink = nestedLi.querySelector('a');
-            if (nestedLink) {
-              nestedLink.style.fontWeight = '400';
-              if (!nestedLi.querySelector('ul')) {
-                nestedLink.innerHTML = nestedLink.textContent.trim();
-                nestedLi.classList.add('no-chevron');
-              }
-            }
-          });
-          
-          // Add click handler
-          expandableLink.onclick = (e) => {
-            e.preventDefault();
-            const isExpanded = li.getAttribute('aria-expanded') === 'true';
-            
-            li.setAttribute('aria-expanded', !isExpanded);
-            li.classList.toggle('is-expanded', !isExpanded);
-            nestedUl.style.display = isExpanded ? 'none' : 'block';
-            
-            updateIcon(expandableLink, !isExpanded, true);
-          };
-          
-          // Initialize icon
-          updateIcon(expandableLink, false, true);
-        } else {
-          // For non-expandable items, ensure they don't get chevrons
-          li.classList.add('no-chevron');
-        }
-      });
+      processNestedNavigation(menuUl);
     }
   } else {
     // Handle regular pages
@@ -208,72 +210,7 @@ export default async function decorate(block) {
       const fragmentUl = fragment.querySelector("ul");
       if (fragmentUl) {
         menuUl.innerHTML = fragmentUl.innerHTML;
-        
-        // Process nested lists to make them expandable
-        menuUl.querySelectorAll('li').forEach((li) => {
-          const nestedUl = li.querySelector('ul');
-          if (nestedUl) {
-            // Get the text node or link that precedes the nested ul
-            const label = li.childNodes[0];
-            const text = label.nodeType === Node.TEXT_NODE ? label.textContent.trim() : label.textContent;
-            
-            // Create the expandable link (using anchor instead of button to match TOC style)
-            const expandableLink = createTag('button', {
-              class: 'spectrum-SideNav-itemLink',
-              type: 'button',
-              'aria-expanded': 'false'
-            });
-            expandableLink.innerHTML = text;
-            
-            // Replace the text/link with the expandable link
-            if (label.nodeType === Node.TEXT_NODE) {
-              li.removeChild(label);
-            } else {
-              li.removeChild(label);
-            }
-            li.insertBefore(expandableLink, nestedUl);
-            
-            // Set up proper nesting structure
-            li.setAttribute('role', 'treeitem');
-            li.classList.add('header');
-            nestedUl.setAttribute('role', 'group');
-            nestedUl.classList.add('spectrum-SideNav');
-            nestedUl.style.display = 'none';
-            
-            // Process nested links to have normal font weight and proper indentation
-            nestedUl.querySelectorAll('li').forEach(nestedLi => {
-              const nestedLink = nestedLi.querySelector('a');
-              if (nestedLink) {
-                nestedLink.style.fontWeight = '400';
-                // Make sure nested links don't have any icons unless they're expandable
-                if (!nestedLi.querySelector('ul')) {
-                  nestedLink.innerHTML = nestedLink.textContent.trim();
-                  // Prevent assignLayerNumbers from adding icons later
-                  nestedLi.classList.add('no-chevron');
-                }
-              }
-            });
-            
-            // Add click handler
-            expandableLink.onclick = (e) => {
-              e.preventDefault();
-              const isExpanded = li.getAttribute('aria-expanded') === 'true';
-              
-              li.setAttribute('aria-expanded', !isExpanded);
-              li.classList.toggle('is-expanded', !isExpanded);
-              nestedUl.style.display = isExpanded ? 'none' : 'block';
-              
-              // Update icon using the same approach as table of contents
-              updateIcon(expandableLink, !isExpanded, true);
-            };
-            
-            // Initialize icon using the same approach as table of contents
-            updateIcon(expandableLink, false, true);
-          } else {
-            // For non-expandable items, ensure they don't get chevrons
-            li.classList.add('no-chevron');
-          }
-        });
+        processNestedNavigation(menuUl);
 
         // Apply the same layer numbering and styling as table of contents
         const originalUpdateIcon = updateIcon;


### PR DESCRIPTION
Use `source` instead of `template` metadata for nav source selection.

Testing urls: 
https://fix-nav-origin-select--adp-devsite--adobedocs.aem.page/github-actions-test/
https://fix-nav-origin-select--adp-devsite--adobedocs.aem.page/
https://fix-nav-origin-select--adp-devsite--adobedocs.aem.page/github-actions-test/