### PR TITLE
feat: code block picklist

### DIFF
--- a/hlx_statics/blocks/codeblock/codeblock.css
+++ b/hlx_statics/blocks/codeblock/codeblock.css
@@ -22,9 +22,15 @@ main div.codeblock-wrapper div.codeblock .inline-code {
   border: none;
 }
 
+main div.codeblock-wrapper div.codeblock .control-bar {
+  display: flex;
+  justify-content: space-between;
+}
+
 /* copied from https://raw.githubusercontent.com/adobe/aem-block-collection/main/blocks/tabs/tabs.css, then edited */
 
-main div.codeblock-wrapper div.codeblock .tabs-list {
+main div.codeblock-wrapper div.codeblock .control-bar,
+main div.codeblock-wrapper div.codeblock .control-bar .tabs-list {
   display: flex;
   gap: 16px;
   max-width: 100%;
@@ -32,7 +38,8 @@ main div.codeblock-wrapper div.codeblock .tabs-list {
   margin: 0 16px;
 }
 
-main div.codeblock-wrapper div.codeblock .tabs-list button {
+main div.codeblock-wrapper div.codeblock .control-bar select,
+main div.codeblock-wrapper div.codeblock .control-bar .tabs-list button {
   flex: 0 0 max-content;
   border: 0px;
   border-radius: 0;
@@ -51,15 +58,16 @@ main div.codeblock-wrapper div.codeblock .tabs-list button {
   padding: 16px 0;
 }
 
-main div.codeblock-wrapper div.codeblock .tabs-list button:hover {
+main div.codeblock-wrapper div.codeblock .control-bar select:hover,
+main div.codeblock-wrapper div.codeblock .control-bar .tabs-list button:hover {
   color: rgb(255, 255, 255);
 }
 
-main div.codeblock-wrapper div.codeblock .tabs-list button p {
+main div.codeblock-wrapper div.codeblock .control-bar .tabs-list button p {
   margin: 0;
 }
 
-main div.codeblock-wrapper div.codeblock .tabs-list button[aria-selected="true"] {
+main div.codeblock-wrapper div.codeblock .control-bar .tabs-list button[aria-selected="true"] {
   border-bottom: 3px solid rgb(255, 255, 255);
 }
 
@@ -68,6 +76,6 @@ main div.codeblock-wrapper div.codeblock .tabs-panel {
   overflow: auto;
 }
 
-main div.codeblock-wrapper div.codeblock .tabs-panel[aria-hidden="true"] {
+main div.codeblock-wrapper div.codeblock .hidden {
   display: none;
 }

--- a/hlx_statics/blocks/codeblock/codeblock.js
+++ b/hlx_statics/blocks/codeblock/codeblock.js
@@ -1,65 +1,113 @@
 import { toClassName } from '../../scripts/lib-helix.js';
 import decoratePreformattedCode from '../../components/code.js';
 
-// Function to create a button element for tabs
-function createTabButton(tab, id, isSelected, onClick) {
-  const button = document.createElement('button');
-  button.className = 'tabs-tab';
-  button.id = `tab-${id}`;
-  button.innerHTML = tab.innerHTML;
-  button.setAttribute('aria-controls', `tabpanel-${id}`);
-  button.setAttribute('aria-selected', isSelected);
-  button.setAttribute('role', 'tab');
-  button.setAttribute('type', 'button');
-  button.addEventListener('click', onClick);
-  return button;
-}
-
-// Function to initialize tabs and their associated panels
-function decorateTabs(block) {
-  const tablist = document.createElement('div');
-  tablist.className = 'tabs-list';
-  tablist.setAttribute('role', 'tablist');
-
-  const tabs = [...block.children].map(child => child.firstElementChild);
-
-  tabs.forEach((tab, i) => {
-    const id = toClassName(tab.textContent);
-    const tabpanel = block.children[i];
-
-    // Set up tabpanel attributes
-    tabpanel.className = 'tabs-panel';
-    tabpanel.id = `tabpanel-${id}`;
-    tabpanel.setAttribute('aria-hidden', i !== 0);
-    tabpanel.setAttribute('aria-labelledby', `tab-${id}`);
-    tabpanel.setAttribute('role', 'tabpanel');
-
-    // Create and append the tab button
-    const button = createTabButton(tab, id, i === 0, () => {
-      // Hide all tab panels and reset buttons
-      block.querySelectorAll('[role=tabpanel]').forEach(panel => {
-        panel.setAttribute('aria-hidden', true);
-      });
-      tablist.querySelectorAll('button').forEach(btn => {
-        btn.setAttribute('aria-selected', false);
-      });
-      // Show the selected tab panel and update the button state
-      tabpanel.setAttribute('aria-hidden', false);
-      button.setAttribute('aria-selected', true);
+export default function decorate(block) {
+  const handleSelectChange = () => {
+    // show tabpanel associated with selected option
+    const panels = [...block.querySelectorAll('[role=tabpanel]')];
+    panels.forEach((panel, i) => {
+      panel.classList.toggle('hidden', i !== select.selectedIndex);
     });
+  }
 
-    tablist.append(button);
-    tab.remove();
+  const filterSelectOptions = (clickedTabId) => {
+    const clickedTab = block.querySelector(`[role=tab][id='${clickedTabId}']`);
+    const clickedTabIndex = clickedTab.getAttribute('index');
+    let panelIndexToShow;
+    if(areTabsGrouped) {
+      // one (grouped) tab maps to many options
+      const options = [...select.options];   
+      // show options associated with the clicked tab
+      const clickedTabHeading = options[clickedTabIndex].getAttribute('heading');   
+      options.forEach((option, i) => { 
+        const heading =  options[i].getAttribute('heading');
+        option.classList.toggle('hidden', heading !== clickedTabHeading);
+      });
+      // select the first option 
+      const firstVisibleOptionIndex =  options.findIndex(option => !option.classList.contains('hidden'));
+      panelIndexToShow = firstVisibleOptionIndex;
+    } else {
+      // one (non-grouped) tab maps to one option
+      panelIndexToShow = clickedTabIndex;
+    }
+    select.selectedIndex = panelIndexToShow;
+    handleSelectChange();
+  }
+
+  const handleTabClick = (event) => {
+    const clickedTab = event.target.closest('[role=tab]');
+    const clickedTabIndex = clickedTab.getAttribute('index');
+    const tabs = [...block.querySelectorAll('[role=tab]')];
+    tabs.forEach(tab => {
+      const tabIndex = tab.getAttribute('index');
+      tab.setAttribute('aria-selected', tabIndex === clickedTabIndex);
+    });
+    filterSelectOptions(clickedTab.id);
+  }
+  
+  // remove from block as these divs will be recreated as buttons
+  const tabContents = [...block.children].map(child => child.firstElementChild);
+  tabContents.forEach((tabContent) => {
+    tabContent.remove();
   });
 
-  block.prepend(tablist);
-}
+  // get from block before additional children are added
+  const panels = [...block.children].slice(0, tabContents.length);
 
-// Main function to decorate the block and its code
-export default function decorate(block) {
-  decorateTabs(block);
+  const languages = block.getAttribute('data-languages')?.split(',').map(language => language.trim()) ?? [];
+  const areTabsGrouped = languages.length > 0;
+  const selectId = 'select-language';
+  
+  const controlBar = document.createElement('div');
+  controlBar.className = 'control-bar';
+  block.prepend(controlBar);
 
-  block.querySelectorAll('[role=tabpanel]').forEach(panel => {
+  const tabs = document.createElement('div');
+  tabs.className = 'tabs-list';
+  tabs.setAttribute('role', 'tablist');
+  controlBar.append(tabs);
+  
+  tabContents.forEach((tabContent, i) => {
+    const tab = document.createElement('button');
+    tab.className = 'tabs-tab';
+    tab.id = `tab-${i}`;
+    tab.setAttribute('index', i);
+    tab.setAttribute('aria-controls', selectId);
+    tab.setAttribute('role', 'tab');
+    tab.setAttribute('type', 'button');
+    tab.innerHTML = tabContent.innerHTML;
+    tab.addEventListener('click', handleTabClick);
+
+    const isGroupAdded = [...tabs.children].find(existingTab => tab.textContent === existingTab.textContent);
+    if(!areTabsGrouped || !isGroupAdded) {
+      tabs.append(tab);
+    }
+  });
+  
+  const select = document.createElement('select');
+  select.id = selectId;
+  select.classList.toggle('hidden', !areTabsGrouped);
+  select.addEventListener('change', handleSelectChange);
+  controlBar.append(select);
+
+  tabContents.forEach((tabContent, i) => {
+    const option = document.createElement('option');
+    option.id = `option-${i}`;
+    option.value = i;
+    option.setAttribute('heading', toClassName(tabContent.textContent));
+    option.setAttribute('aria-controls', `tabpanel-${i}`);
+    option.text = languages[i] ?? i;
+    select.append(option); 
+  })
+
+  panels.forEach((panel, i) => {
+    panel.className = 'tabs-panel';
+    panel.id = `tabpanel-${i}`;
+    panel.setAttribute('aria-labelledby', `tab-${i} option-${i}`);
+    panel.setAttribute('role', 'tabpanel');
     decoratePreformattedCode(panel);
   });
+
+  // initialize by simulating a click on the first tab
+  document.getElementById('tab-0').click();
 }


### PR DESCRIPTION
#### Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1495

#### Description
Implement the code block picklist as described in the [aio theme readme](https://github.com/adobe/aio-theme?tab=readme-ov-file#code-block):

> Use `languages` to define a language name for each code section. Code sections with the same heading are automatically grouped together. The number of languages should match the number of headings. If no language is present, each of the heading will render in each tab with even the same headings.

#### Implementation notes
 - Ensured the number of tabs, panels, and options always match
 - Mapped tabs, panels, and options are via indices
 - Hid tabs, panels, and options are based on current selection 

#### Tests
- code block with picklist 
  - page: https://code-block-picklist--adp-devsite--adobedocs.aem.page/express/add-ons/docs/guides/tutorials/grids-addon
  -  md: https://github.com/AdobeDocs/express-add-ons-docs/blob/main/src/pages/guides/tutorials/grids-addon.md?plain=1#L163
- code block without picklist: 
  - page: https://code-block-picklist--adp-devsite--adobedocs.hlx.page/github-actions-test/test/code-block-without-picklist
  - md: https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/code-block-without-picklist.md?plain=1#L1