### PR TITLE
fix: nested code

### DIFF
--- a/hlx_statics/blocks/code/code.js
+++ b/hlx_statics/blocks/code/code.js
@@ -3,9 +3,6 @@ import decoratePreformattedCode from '../../components/code.js';
 export default function decorate(block) {
   const pre = document.createElement('pre');
   const code = block.querySelector('code');
-  if (!code.className.match(/language-/)) {
-    code.classList.add('language-none');
-  }
   code.parentElement.replaceChild(pre, code);
   pre.appendChild(code);
   decoratePreformattedCode(block);

--- a/hlx_statics/blocks/heading1/heading1.js
+++ b/hlx_statics/blocks/heading1/heading1.js
@@ -3,7 +3,7 @@ import decorateHeading from '../../components/heading.js';
 export default function decorate(block) {
   const heading1Wrapper = document.querySelector('.heading1-wrapper');
   const nextWrapper = heading1Wrapper.nextElementSibling;
-  const p = nextWrapper.querySelector('p');
-  p.classList.add('header-content');
+  const p = nextWrapper?.querySelector('p');
+  p?.classList.add('header-content');
   decorateHeading({ level: 1, block });
 }

--- a/hlx_statics/blocks/tab/tab.js
+++ b/hlx_statics/blocks/tab/tab.js
@@ -23,7 +23,7 @@ const handleCode = (contentDiv) => {
   const isTable = contentDiv.querySelector('table');
 
   if (codeBlock && !isTable) {
-    const language = contentDiv.querySelector('p')?.textContent || '';
+    const language = contentDiv.querySelector('p')?.textContent || 'none';
     const preContainer = createCodeBlock(codeBlock, language);
     contentDiv.innerHTML = preContainer.innerHTML;
   }

--- a/hlx_statics/blocks/tab/tab.js
+++ b/hlx_statics/blocks/tab/tab.js
@@ -9,7 +9,9 @@ import { getMetadata } from "../../scripts/scripts.js";
 const createCodeBlock = (codeBlock, language) => {
   const preContainer = document.createElement('div');
   const pre = document.createElement('pre');
-  pre.className = `language-${language.toLowerCase()}`;
+  if (language) {
+    pre.className = `language-${language.toLowerCase()}`;
+  }
   pre.innerHTML = codeBlock.outerHTML;
 
   preContainer.appendChild(pre);
@@ -23,7 +25,7 @@ const handleCode = (contentDiv) => {
   const isTable = contentDiv.querySelector('table');
 
   if (codeBlock && !isTable) {
-    const language = contentDiv.querySelector('p')?.textContent || 'none';
+    const language = contentDiv.querySelector('p')?.textContent.trim();
     const preContainer = createCodeBlock(codeBlock, language);
     contentDiv.innerHTML = preContainer.innerHTML;
   }
@@ -41,7 +43,7 @@ const createSubTabs = (table) => {
   table.querySelectorAll('tbody tr').forEach((row) => {
     const subTabTitle = row.querySelector('td:first-child')?.textContent.trim();
     const codeBlock = row.querySelector('pre code');
-    const language = row.querySelector('p')?.textContent.trim() || 'none';
+    const language = row.querySelector('p')?.textContent.trim();
 
     if (subTabTitle && codeBlock) {
       subTabCount++;

--- a/hlx_statics/components/code.js
+++ b/hlx_statics/components/code.js
@@ -1,5 +1,3 @@
-import { toClassName } from '../scripts/lib-helix.js';
-
 export default function decoratePreformattedCode(block) {
   const pre = block.querySelector('pre');
   // see https://prismjs.com/plugins/line-numbers/#how-to-use

--- a/hlx_statics/components/code.js
+++ b/hlx_statics/components/code.js
@@ -4,6 +4,9 @@ export default function decoratePreformattedCode(block) {
   pre.classList.add('line-numbers');
 
   const code = block.querySelector('code');
+  if (!code.className.match(/language-/)) {
+    code.classList.add('language-none');
+  }
   code.setAttribute('data-prismjs-copy', 'Copy');
   code.setAttribute('data-prismjs-copy-success', 'Copied to your clipboard');
   code.setAttribute('data-prismjs-copy-timeout', '3000');


### PR DESCRIPTION
### Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1514

### Issue
Code block in list isn't decorated

### Root cause
Language wasn't specified, and so prism didn't syntax highlight because it was expecting `language-*` class in `code`

### Fix
Ensured `language-none` is set if language isn't specified

### Other changes
- removed unused import statement
- guarded against null
- moved setting of `language-none` to one place

### Before
<img width="1531" alt="Screenshot 2025-02-04 at 6 39 40 PM" src="https://github.com/user-attachments/assets/559df81e-95b6-44fd-bf1a-74f72107507f" />

### After
<img width="1533" alt="Screenshot 2025-02-04 at 6 39 10 PM" src="https://github.com/user-attachments/assets/e6119862-65a0-4e93-9143-6a2962dff8a1" />


### Test
https://fix-nested-code--adp-devsite--adobedocs.aem.page/developer-console/docs/guides/authentication/JWT/jwt-certificate

### Other tests to ensure no regression on `decoratePreformattedCode`
- https://fix-nested-code--adp-devsite--adobedocs.aem.page/github-actions-test/test/code
- https://fix-nested-code--adp-devsite--adobedocs.aem.page/github-actions-test/test/code-block