### PR TITLE
Update info card css to match other components

### DIFF
--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -8,7 +8,7 @@ main div.info-card-wrapper div.info-card > ul {
   max-width: 1280px;
   justify-content: center;
   grid-template-columns: repeat(auto-fit, minmax(375px, 400px));
-  grid-gap: 24px;
+  grid-gap: 40px;
   padding: 0;
 }
 


### PR DESCRIPTION
The issue was the info card is limited to 400px and that makes the gap doesn't fit into the whole 1280px width.  I've increased the gap to fit for the width. 

Fix: 
https://louisa-devsite-1460-infocard--adp-devsite--adobedocs.aem.page/commerce/