### PR TITLE
adding a nobox-design for the miniresource cards

### DIFF
--- a/hlx_statics/blocks/mini-resource-card/mini-resource-card.css
+++ b/hlx_statics/blocks/mini-resource-card/mini-resource-card.css
@@ -40,6 +40,14 @@ main div.mini-resource-card-wrapper div.mini-resource-card .mini-resource-card-i
   width: 100px !important;
 }
 
+main div.mini-resource-card-wrapper div.mini-resource-card.nobox-design .mini-card {
+  box-shadow: none;
+}
+
+main div.mini-resource-card-wrapper div.mini-resource-card.nobox-design .mini-resource-card-image-container  img {
+  border-radius: 25px;
+}
+
 main div.mini-resource-card-wrapper div.mini-resource-card .image-mini {
   height: 100px !important;
   width: auto !important;

--- a/hlx_statics/blocks/mini-resource-card/mini-resource-card.js
+++ b/hlx_statics/blocks/mini-resource-card/mini-resource-card.js
@@ -43,6 +43,9 @@ function getMiniResourceCard(linkHref, heading, text) {
 export default async function decorate(block) {
     let containerParent;
     block.setAttribute('daa-lh', 'mini resource card');
+    if (block.classList.contains('nobox-design')) {
+        block.classList.add('background-color-white');
+    }
     if (block.classList.contains('primarybutton')) {
         const primaryButton = block.querySelectorAll('a')[0];
         const up = primaryButton.parentElement;


### PR DESCRIPTION
Adding a nobox design for flexibility for some marketing pages. 

https://devsite-1544-mini-resource-card--adp-devsite--adobedocs.aem.page/test/hackathon/louisa/test-mini-resource-card
