### PR TITLE
update on breadcrumbs

### DIFF
--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -78,6 +78,11 @@ function loadHeader(header) {
   header.append(headerBlock);
   decorateBlock(headerBlock);
   loadBlock(headerBlock);
+  const contentHeader = document.querySelector('.content-header');
+  if (document.querySelector('.breadcrumbs').clientWidth > 750) {
+    contentHeader.classList.add('block-display');
+  }
+
 }
 
 function loadFooter(footer) {

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -942,6 +942,10 @@ main .content-header {
   justify-content: space-between;
 }
 
+main .content-header.block-display {
+  display: block;
+}
+
 main .github-actions-block{
   display: flex;
   gap: 20px;
@@ -987,4 +991,17 @@ main a{
 
 main a:hover{
   text-decoration: underline;
+}
+
+main .content-header.block-display .github-actions-wrapper{
+  padding-top: 0px;
+}
+
+@media screen and (max-width: 768px) {
+  main .content-header {
+    display: block;
+  }
+  main .content-header .github-actions-wrapper{
+    padding-top: 0px;
+  }
 }


### PR DESCRIPTION
If long breadcrumbs and in mobile version, we need to make the github action to display under the breadcrumbs. 

old: 
https://developer-dev.adobe.com/developer-console/docs/guides/projects/projects-empty

fixed:
https://devsite-1500-long-breadcrumbs--adp-devsite--adobedocs.aem.page/developer-console/docs/guides/projects/projects-empty