### PR TITLE
fix : mini-resource-card responsive design issue

### DIFF
--- a/hlx_statics/blocks/mini-resource-card/mini-resource-card.css
+++ b/hlx_statics/blocks/mini-resource-card/mini-resource-card.css
@@ -63,41 +63,45 @@ main div.mini-resource-card-container div.mini-resource-card-wrapper .section-ti
 
 @media screen and (max-width: 1280px) {
   main div.mini-resource-card-wrapper div.mini-resource-card .card-container {
-    /* grid-template-columns: repeat(2, 1fr); */
-    width: 90% !important;
-    column-gap: 10px;
-    row-gap: 20px;
-    margin: auto !important;
-  }
-
-  main div.mini-resource-card-wrapper div.mini-resource-card .mini-card {
-    width: 100%;
-    height: 100px !important;
-  }
-
-  main div.mini-resource-card-wrapper div.mini-resource-card .mini-resource-card-body {
-    height: 100px !important;
-    width: auto !important;
-  }
-}
-
-@media screen and (max-width: 1280px) {
-  main div.mini-resource-card-wrapper div.mini-resource-card .card-container {
     grid-template-columns: repeat(1, 1fr);
     margin: auto auto 50px auto !important;
     width: 70% !important;
     grid-row-gap: 30px;
   }
 
-  main div.mini-resource-card-wrapper div.mini-resource-card .mini-card {
-    height: 100px !important;
+  main div.mini-resource-card-wrapper div.mini-resource-card .mini-card { 
+    width: 100% !important; 
+    height: 100px !important;  
   }
 
   main div.mini-resource-card-wrapper div.mini-resource-card .mini-resource-card-body {
     height: 100px !important;
     width: auto !important;
+    padding-right: 10px !important;
   }
+
+  main div.title-container>.title-wrapper>div {
+    margin: auto !important;
+  } 
 }
+
+@media screen and (max-width: 767px) {
+  main div.mini-resource-card .mini-resource-card-body h3 {
+    font-size: 18px !important;
+  } 
+  
+  main div.mini-resource-card .mini-resource-card-body p {
+    font-size: 14px !important;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  main div.title-container>.title-wrapper>div {
+    margin: 0 20px !important;
+  } 
+}
+
 @media screen and (max-width: 425px) {
   main div.mini-resource-card-wrapper div.mini-resource-card .card-container {
     width: 80% !important;

--- a/hlx_statics/blocks/mini-resource-card/mini-resource-card.js
+++ b/hlx_statics/blocks/mini-resource-card/mini-resource-card.js
@@ -82,4 +82,10 @@ export default async function decorate(block) {
     if (block.classList.contains('primarybutton')) {
         block.appendChild(containerParent);
     }
+    
+    document.querySelectorAll(".mini-resource-card-body p").forEach((para) => {
+        if (para.scrollHeight > para.clientHeight) {
+            para.setAttribute("title", para.innerText);
+        }
+    });
 }


### PR DESCRIPTION
fix : mini-resource-card responsive design issue
previous : https://main--adp-devsite--adobedocs.aem.page/express/add-ons/trending/
updated : https://fix-mini-resource-card--adp-devsite--adobedocs.aem.page/express/add-ons/trending/

found a mistake in the mini-resource card. In the mobile responsive view, when the text is large, the padding gets reduced. So, we need to add padding specifically for mobile responsiveness