### PR TITLE
fix : DEVSITE- 1575 CodeBlock Loading issue

### DIFF
--- a/hlx_statics/blocks/codeblock/codeblock.js
+++ b/hlx_statics/blocks/codeblock/codeblock.js
@@ -78,6 +78,9 @@ export default function decorate(block) {
     tab.innerHTML = tabContent.innerHTML;
     tab.addEventListener('click', handleTabClick);
 
+    if (i === 0) tab.setAttribute('aria-selected', 'true');
+    else tab.setAttribute('aria-selected', 'false');
+
     const isGroupAdded = [...tabs.children].find(existingTab => tab.textContent === existingTab.textContent);
     if(!areTabsGrouped || !isGroupAdded) {
       tabs.append(tab);
@@ -106,6 +109,7 @@ export default function decorate(block) {
     panel.setAttribute('aria-labelledby', `tab-${i} option-${i}`);
     panel.setAttribute('role', 'tabpanel');
     decoratePreformattedCode(panel);
+    if (i !== 0) panel.classList.add('hidden');
   });
 
   // initialize by simulating a click on the first tab

--- a/hlx_statics/blocks/codeblock/codeblock.js
+++ b/hlx_statics/blocks/codeblock/codeblock.js
@@ -78,9 +78,6 @@ export default function decorate(block) {
     tab.innerHTML = tabContent.innerHTML;
     tab.addEventListener('click', handleTabClick);
 
-    if (i === 0) tab.setAttribute('aria-selected', 'true');
-    else tab.setAttribute('aria-selected', 'false');
-
     const isGroupAdded = [...tabs.children].find(existingTab => tab.textContent === existingTab.textContent);
     if(!areTabsGrouped || !isGroupAdded) {
       tabs.append(tab);
@@ -109,9 +106,11 @@ export default function decorate(block) {
     panel.setAttribute('aria-labelledby', `tab-${i} option-${i}`);
     panel.setAttribute('role', 'tabpanel');
     decoratePreformattedCode(panel);
-    if (i !== 0) panel.classList.add('hidden');
   });
 
   // initialize by simulating a click on the first tab
-  document.getElementById('tab-0').click();
+    const firstTab = block.querySelector('[role=tab]');
+    if (firstTab) {
+      firstTab.click();
+    }
 }


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/DEVSITE-1575
fix : worked out & fix  code blocks don't show tabs properly in on-load & their codes.
previous  : https://stage--adp-devsite--adobedocs.aem.page/express/add-ons/docs/guides/tutorials/grids-addon
updated  : https://devsite-1575--adp-devsite--adobedocs.aem.page/express/add-ons/docs/guides/tutorials/grids-addon