### PR TITLE
Hide onthispage when it doesn't fit

### DIFF
--- a/hlx_statics/blocks/onthispage/onthispage.css
+++ b/hlx_statics/blocks/onthispage/onthispage.css
@@ -8,8 +8,8 @@ html {
   top: 128px;
   bottom: 0;
   left: 0;
-  width: 330px;
-  margin: 128px 0 0 32px;
+  width: 256px;
+  margin: 128px 32px 0 32px;
   height: calc(100vh - 128px);
   overflow: auto;
   box-sizing: border-box;
@@ -35,7 +35,7 @@ html {
   color: rgb(109, 109, 109);
 }
 
-@media screen and (max-width: 1024px) {
+@media screen and (max-width: 1228px) {
   .onthispage-wrapper {
     display: none !important;
   }


### PR DESCRIPTION
### Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1579

### Description

Changes to `onthispage`:
- Hide when it doesn't fit the screen
- Make width match `side-nav`'s
- Add a right margin equal to the left

URL for testing:
- https://devsite-1579-responsive-onthispage--adp-devsite--adobedocs.aem.page/developer-distribution/creative-cloud/docs/guides/submission/overview

### Before
If screen too narrow to fit `onthispage`, you can scroll to the right to see squished `onthispage`:
<img width="1114" alt="before" src="https://github.com/user-attachments/assets/80c96957-4043-4d4d-8862-b084a12b0a66" />


### After
If screen too narrow to fit `onthispage`, `onthispage` gets hidden and no horizontal scrollbar appears:
<img width="1115" alt="Screenshot 2025-03-18 at 11 50 09 AM" src="https://github.com/user-attachments/assets/e1aadd59-fab7-40e6-b6e5-e97749ecae64" />

