### PR TITLE
fix: block spacing

### DIFF
--- a/hlx_statics/blocks/accordion/accordion.css
+++ b/hlx_statics/blocks/accordion/accordion.css
@@ -11,10 +11,6 @@ main div.accordion-wrapper div.accordion .accordion-div {
     margin: auto !important;
 }
 
-main div.accordion-container.accordion-whole {
-    padding: 32px 0;
-}
-
 main div.accordion-container.accordion-whole .accordion-wrapper {
     display: flex;
     align-items: center;

--- a/hlx_statics/blocks/code/code.css
+++ b/hlx_statics/blocks/code/code.css
@@ -1,8 +1,3 @@
 pre[class*=language-] {
     border-radius: 4px;
 }
-
-main div.nested-code-wrapper {
-    margin-top:  20px;
-    margin-bottom:  20px;
-}

--- a/hlx_statics/blocks/discoverblock/discoverblock.css
+++ b/hlx_statics/blocks/discoverblock/discoverblock.css
@@ -55,7 +55,6 @@ main div.discoverblock-container-wrapper{
     display: flex;
     flex-wrap: wrap;
     column-gap: 50px;
-    margin: 20px 0;
     row-gap: 40px;
 }
 main div.discoverblock-wrapper div.discoverblock-column .discover-child-container{

--- a/hlx_statics/blocks/embed/embed.css
+++ b/hlx_statics/blocks/embed/embed.css
@@ -8,9 +8,10 @@ main div.embed-container {
   background: rgb(245, 245, 245);
 }
 
-main div.embed-container > div{
+main div.embed-container > div.embed-wrapper{
   max-width: 1280px;
-  padding: 0px 32px;
+  padding-left: 32px;
+  padding-right: 32px;
   margin: auto;
 }
 

--- a/hlx_statics/blocks/inlinealert/inlinealert.css
+++ b/hlx_statics/blocks/inlinealert/inlinealert.css
@@ -8,7 +8,6 @@ main div.inlinealert-wrapper .spectrum-InLineAlert {
     box-sizing: border-box;
     min-width: 368px;
     min-height: 38px;
-    margin: 8px 0;
     padding: 20px;
     border-width: 2px;
     border-style: solid;
@@ -159,10 +158,6 @@ main .inlinealert img {
 main .inlinealert-wrapper .inlinealert.warning{
     border-color: rgb(246,133,17);
     color: rgb(203, 93, 0);
-}
-
-main .inlinealert-wrapper{
-    margin: 20px 0px;
 }
 
 main div.inlinealert > p.spectrum-InLineAlert-content{

--- a/hlx_statics/blocks/table/table.css
+++ b/hlx_statics/blocks/table/table.css
@@ -4,7 +4,8 @@ main div.table-container:has(.table.background-color-white) {
 }
 
 main div.table-wrapper {
-  padding: 0px 32px;
+  padding-left: 32px;
+  padding-right: 32px;
 }
 
 main div.table-container {

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -99,8 +99,45 @@ main.no-sidenav > div.onthispage-wrapper {
   display: none;
 }
 
-main .section {
-  padding: 20px 0;
+main div.accordion-wrapper,
+main div.announcement-wrapper,
+main div.api-browser-wrapper,
+main div.banner-wrapper,
+main div.breadcrumbs-wrapper,
+main div.calendar-wrapper,
+main div.cards-wrapper,
+main div.carousel-wrapper,
+main div.code-wrapper,
+main div.codeblock-wrapper,
+main div.columns-wrapper,
+main div.contributors-wrapper,
+main div.default-content-wrapper img,
+main div.detailsblock-wrapper,
+main div.discoverblock-wrapper,
+main div.edition-wrapper,
+main div.embed-wrapper,
+main div.github-actions-wrapper,
+main div.hr-wrapper,
+main div.image-text-wrapper,
+main div.info-wrapper,
+main div.info-card-wrapper,
+main div.info-columns-wrapper,
+main div.inline-nested-alert-wrapper,
+main div.inlinealert-wrapper,
+main div.link-wrapper,
+main div.link-block-wrapper,
+main div.list-wrapper,
+main div.nested-code-wrapper,
+main div.mini-resource-card-wrapper,
+main div.product-card-wrapper,
+main div.profile-card-wrapper,
+main div.summary-wrapper,
+main div.tab-wrapper,
+main div.table-wrapper,
+main div.text-wrapper,
+main div.title-wrapper {
+  padding-top: 20px;
+  padding-bottom: 20px;
 }
 
 main .section .section-title {
@@ -985,7 +1022,6 @@ main li h3{
 
 main .code-wrapper, main .nested-code-wrapper{
   max-width: 60vw;
-  margin: 10px 0px;
 }
 main:not(:has(.onthispage-wrapper)) .code-wrapper {
   max-width: none;


### PR DESCRIPTION
#### Issue
Original spacing fix was applied to `section` to ensure spacing is consistent across all blocks. This worked when each block are in their own section. While this is the case with our DevBiz pages today, user is still allowed to add multiple blocks within a section. In DevDocs, the original spacing fix doesn't work because all blocks are in the same section.

#### Fix
- Refactor spacing fix so that it's applied to the block  (i.e. wrapper) rather than section (i.e. container) - [DEVSITE-1590](https://jira.corp.adobe.com/browse/DEVSITE-1590)
- Ensure spacing is consistent across blocks - [DEVSITE-1554](https://jira.corp.adobe.com/browse/DEVSITE-1554)

#### Tests
- https://devsite-1590-block-spacing--adp-devsite--adobedocs.aem.page/test/diane/devsite-1415-background-color
- https://devsite-1590-block-spacing--adp-devsite--adobedocs.aem.page/commerce/docs/
- https://devsite-1590-block-spacing--adp-devsite--adobedocs.aem.page/express/add-ons/docs/guides/tutorials/stats-addon
























