### PR TITLE
Fixed resize issue for blocks column and summary

### DIFF
--- a/hlx_statics/blocks/columns/columns.css
+++ b/hlx_statics/blocks/columns/columns.css
@@ -186,9 +186,9 @@ main div.columns-container div.columns.center .button-container {
     margin-bottom: 0;
 }
 
-main div.columns-wrapper div.columns div.first-column img {
+/* main div.columns-wrapper div.columns div.first-column img {
     height: 350px !important;
-}
+} */
 
 @media screen and (max-width: 1280px) {
     main div.columns-wrapper  div.columns div.second-column {

--- a/hlx_statics/blocks/summary/summary.css
+++ b/hlx_statics/blocks/summary/summary.css
@@ -1,3 +1,7 @@
+main .section {
+  padding: 0px;
+}
+
 main div.summary-container {
   background: rgb(245, 245, 245);
   background-position: center;
@@ -23,7 +27,12 @@ main div.summary-wrapper div.summary > div {
 }
 
 main div.summary-wrapper  div.summary.no-image > div {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   width: 100%;
+  padding: 32px;
+  /* margin: 32px; */
 }
 
 @media screen and (max-width: 1280px) {
@@ -46,6 +55,9 @@ main div.summary-wrapper  div.summary.no-image > div {
   }
   main div.summary-wrapper div.summary picture{
     height: 500px;
+  }
+  main div.summary-wrapper div.summary img{
+    height: 500px !important;
   }
   main div.summary-wrapper div.summary > div {
     width: 100%;

--- a/hlx_statics/blocks/summary/summary.js
+++ b/hlx_statics/blocks/summary/summary.js
@@ -21,6 +21,11 @@ export default async function decorate(block) {
       block.classList.add('background-color-gray');
     }
 
+    let outerDiv = block.querySelector('.no-image > div');
+    let innerDiv = outerDiv.firstElementChild;
+    if (outerDiv) {
+      outerDiv.replaceWith(innerDiv); // Replace outer div with its inner div
+    }
   }
 
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((heading) => {
@@ -47,8 +52,12 @@ export default async function decorate(block) {
       }
     });
   });
-  const overlayStyle = 'position: absolute; display: flex; left: 0%; z-index: 1000;';
-  rearrangeHeroPicture(block, overlayStyle);
+
+  if (block.querySelector('picture')) {
+    //if there is an image as the background set up the overlay style
+    const overlayStyle = 'position: absolute; display: flex; left: 0%; z-index: 1000;';
+    rearrangeHeroPicture(block, overlayStyle);
+  }
 }
 
 

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -374,7 +374,7 @@ export function rearrangeHeroPicture(block, overlayStyle) {
   const div = block.querySelector('div');
   div.setAttribute('style', overlayStyle);
   const img = picture.querySelector('img');
-  img.setAttribute('style', 'width: 100% !important; max-height: 350px');
+  img.setAttribute('style', 'width: 100% !important; height: 350px');
   emptyDiv.remove();
 }
 


### PR DESCRIPTION
Fix for these issues: https://jira.corp.adobe.com/browse/DEVSITE-1555 and https://jira.corp.adobe.com/browse/DEVSITE-1556

Columns image was distorting when window size got smaller and summary block height was not increasing to 500px when window size was smaller. Summary block was also not working correctly for blocks with no images so fixed that too

Before: https://main--adp-devsite--adobedocs.aem.page/test/diane/devsite-1556-resize-columns

After: https://resize-blocks--adp-devsite--adobedocs.aem.page/test/diane/devsite-1556-resize-columns

Doc: https://docs.google.com/document/d/15EcvIpD4Rb-K8oaBeJPkyDXdYvhA0FaRrZ-7_iHRpoU/edit?tab=t.0