### PR TITLE
fix: column checkmark

### DIFF
--- a/hlx_statics/blocks/columns/columns.css
+++ b/hlx_statics/blocks/columns/columns.css
@@ -28,18 +28,18 @@ main div.columns-wrapper  div.columns > div:nth-child(even) {
     flex-direction: row-reverse;
 }
 
-main div.columns-container.section[data-list-class="checkmark"] ul {
+main div.columns-wrapper .checkmark ul {
     list-style: none;
     font-size: 16px;
     padding-top: 24px;
     padding-left: 0px;
 }
 
-main div.columns-container.section[data-list-class="checkmark"] ul > li {
+main div.columns-wrapper .checkmark ul > li {
     margin-bottom: 12px;
 }
 
-main div.columns-container.section[data-list-class="checkmark"] ul > li:before{
+main div.columns-wrapper .checkmark ul > li:before{
     color: #096;
     content: "\2714\0020";
 }


### PR DESCRIPTION
**Description**
Fix selector so that checkmark bulletpoints get shown when specified by user

**Test Google doc**
https://docs.google.com/document/d/1fKHTmZ8G_SDcxMBM3r03w-KYUONw53eSP78ZRn4Lok8/edit?tab=t.0


**Before**
https://stage--adp-devsite--adobedocs.aem.page/test/melissa/columns?nocache=1743631853759
<img width="1211" alt="Screenshot 2025-04-02 at 3 24 58 PM" src="https://github.com/user-attachments/assets/82ff8d8c-7c1c-406d-8434-56b73f16342e" />


**After**
https://column-checkmark--adp-devsite--adobedocs.aem.page/test/melissa/columns?nocache=1743631853759
<img width="1211" alt="Screenshot 2025-04-02 at 3 25 15 PM" src="https://github.com/user-attachments/assets/5afd5b4b-9ab7-4760-bdc0-e90cb97c152e" />

