### PR TITLE
Fixed issues with columns and summary

### DIFF
--- a/hlx_statics/blocks/columns/columns.css
+++ b/hlx_statics/blocks/columns/columns.css
@@ -70,7 +70,11 @@ main div.columns-wrapper div.columns div.first-column {
 }
 
 main div.columns-wrapper div.columns div.first-column img {
-    width: 100%;
+    max-width: 100%;
+    max-height: 350px;
+    height: auto;
+    width: auto;
+    object-fit: contain;
 }
 
 main div.columns-wrapper div.second-column {

--- a/hlx_statics/blocks/summary/summary.css
+++ b/hlx_statics/blocks/summary/summary.css
@@ -1,6 +1,6 @@
-main .section {
+/* main .section {
   padding: 0px;
-}
+} */
 
 main div.summary-container {
   background: rgb(245, 245, 245);
@@ -30,8 +30,9 @@ main div.summary-wrapper  div.summary.no-image > div {
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: start;
   width: 100%;
-  padding: 32px;
+  padding: 0px 64px 0px calc((100vw - 1280px)/2)  
   /* margin: 32px; */
 }
 
@@ -45,6 +46,9 @@ main div.summary-wrapper  div.summary.no-image > div {
     width: 100%;
   }
   main div.summary-wrapper  div.summary > div {
+    padding: 32px;
+  }
+  main div.summary-wrapper div.summary.no-image > div {
     padding: 32px;
   }
 }


### PR DESCRIPTION
Fixed issue that arose while trying to fix the issues in the tickets:

On main: https://main--adp-devsite--adobedocs.aem.page/test/diane/devsite-1556-resize-columns

Current issues: https://stage--adp-devsite--adobedocs.aem.page/test/diane/devsite-1556-resize-columns

Fixes: https://resize-blocks--adp-devsite--adobedocs.aem.page/test/diane/devsite-1556-resize-columns

Fixed it so image stayed contained within image container of columns and so that text is not centered in summary block without image. **Question for team: should the padding at the bottom of summary block be there?**