### PR TITLE
Remove background color from image portion of info card

### DIFF
--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -23,7 +23,6 @@ main div.info-card-wrapper div.info-card > ul > li {
   max-width: 400px;
   border: 1px solid transparent;
   border-radius: 4px;
-  background-color: rgb(255,255,255);
   border-color: rgb(235,235,235);
 }
 
@@ -32,7 +31,9 @@ main div.info-card-wrapper div.info-card > ul > li:hover{
 }
 
 main div.info-card-wrapper div.info-card .cards-card-body {
-  margin: 16px;
+  padding: 16px;
+  height: 125px;
+  background-color: white;
 }
 
 main div.info-card-wrapper div.info-card .cards-card-image {


### PR DESCRIPTION
Fix: https://diane-info-rm-background--adp-devsite--adobedocs.aem.page/test/diane/devsite-1644-info-card-background-color
Current: https://main--adp-devsite--adobedocs.aem.page/test/diane/devsite-1644-info-card-background-color

https://jira.corp.adobe.com/browse/DEVSITE-1644