### PR TITLE
fix: insert container styles

### DIFF
--- a/hlx_statics/blocks/contributors/contributors.css
+++ b/hlx_statics/blocks/contributors/contributors.css
@@ -43,7 +43,7 @@ main div.contributors-wrapper .imageList {
     padding-left: 16px;
 }
 
-.model-comp-contributors {
+.contributor-modal .model-comp-contributors {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -56,7 +56,7 @@ main div.contributors-wrapper .imageList {
     height: 100vh;
 }
 
-.show-model-contributors {
+.contributor-modal .show-model-contributors {
     background-color: white;
     z-index: 2;
     position: absolute;
@@ -65,20 +65,20 @@ main div.contributors-wrapper .imageList {
     justify-content: center;
 }
 
-.wrapper-model {
+.contributor-modal .wrapper-model {
     width: 100%;
     display: flex;
     flex-direction: column;
     gap: 10px;
 }
 
-.content-wrapper-contributors {
+.contributor-modal .content-wrapper-contributors {
     display: flex;
     flex-direction: column;
     gap: 10px;
 }
 
-.button-wrapper-contributor {
+.contributor-modal .button-wrapper-contributor {
     display: flex;
     grid-area: "buttonGroup";
     justify-content: flex-end;
@@ -86,7 +86,7 @@ main div.contributors-wrapper .imageList {
     padding-left: 16px;
 }
 
-.close-button {
+.contributor-modal .close-button {
     cursor: pointer;
     color: #fff;
     border: none;
@@ -140,7 +140,7 @@ main .contributors-container {
         gap: 20px;
     }
 
-    .button-wrapper-contributor {
+    .contributor-modal .button-wrapper-contributor {
         flex-direction: column;
     }
 

--- a/hlx_statics/blocks/contributors/contributors.css
+++ b/hlx_statics/blocks/contributors/contributors.css
@@ -108,12 +108,12 @@ hr {
     border: none;
 }
 
-.image-contributor {
+main div.contributors-wrapper .image-contributor {
     width: 100%;
     transition: opacity 0.5s;
 }
 
-.span-Image-contributor {
+main div.contributors-wrapper .span-Image-contributor {
     margin-left: -17px;
     position: relative;
     border: 3px solid rgb(255, 255, 255);
@@ -152,7 +152,7 @@ main .contributors-container {
 }
 
 @media screen and (min-width : 320px) and (max-width : 767px) {
-    .contibutors-wrapper-comp {
+    main div.contributors-wrapper .contibutors-wrapper-comp {
         gap: 20px;
     }
 

--- a/hlx_statics/blocks/contributors/contributors.css
+++ b/hlx_statics/blocks/contributors/contributors.css
@@ -128,11 +128,12 @@ main div.contributors-wrapper .span-Image-contributor {
     transform: translateY(0);
 }
 
-main .contributors-container {
-    position: sticky;
+main .contributors-wrapper-container {
+    position: fixed;
     bottom: 3px;
     background: white;
     padding: .75rem;
+    width: 100%;
 }
 
 @media screen and (min-width : 320px) and (max-width : 767px) {

--- a/hlx_statics/blocks/contributors/contributors.css
+++ b/hlx_statics/blocks/contributors/contributors.css
@@ -143,12 +143,4 @@ main .contributors-container {
     .contributor-modal .button-wrapper-contributor {
         flex-direction: column;
     }
-
-    main .contributors-container {
-        padding: 15px !important;
-    }
-
-    a {
-        gap: 15px;
-    }
 }

--- a/hlx_statics/blocks/contributors/contributors.css
+++ b/hlx_statics/blocks/contributors/contributors.css
@@ -72,22 +72,6 @@ main div.contributors-wrapper .imageList {
     gap: 10px;
 }
 
-h1 {
-    margin: 0;
-    font-size: 1.25rem;
-    font-weight: 600;
-}
-
-hr {
-    border-radius: 2px;
-    height: 1px;
-    border-color: rgb(213, 213, 213);
-    background-color: rgb(213, 213, 213);
-    border-top: 0;
-    border-left: 0;
-    width: 100%;
-}
-
 .content-wrapper-contributors {
     display: flex;
     flex-direction: column;

--- a/hlx_statics/blocks/contributors/contributors.js
+++ b/hlx_statics/blocks/contributors/contributors.js
@@ -1,8 +1,12 @@
+import insertWrapperContainer from '../../components/wrapperContainer.js';
+
 /**
  * Decorates the contributors block
  * @param {Element} block The contributors block element
  */
 export default async function decorate(block) {
+
+  insertWrapperContainer(block);
 
   const isBorder = block?.parentElement?.parentElement?.getAttribute("data-isborder");
 

--- a/hlx_statics/blocks/discoverblock/discoverblock.css
+++ b/hlx_statics/blocks/discoverblock/discoverblock.css
@@ -41,7 +41,7 @@ main div.discoverblock-wrapper div.discover-img-child-container {
 }
 
 @media screen and (max-width : 650px) {
-    .discoverblock {
+    main div.discoverblock-wrapper .discoverblock {
         width: 370px !important;
     }
 

--- a/hlx_statics/blocks/embed/embed.css
+++ b/hlx_statics/blocks/embed/embed.css
@@ -1,8 +1,8 @@
-main div.embed-container:has(.embed.background-color-white) {
+main div.embed-wrapper:has(.embed.background-color-white) {
   background-color: white;
 }
 
-main div.embed-container {
+main div.embed-wrapper {
   align-items: center;
   justify-content: center;
   background: rgb(245, 245, 245);

--- a/hlx_statics/blocks/embed/embed.css
+++ b/hlx_statics/blocks/embed/embed.css
@@ -6,9 +6,6 @@ main div.embed-wrapper {
   align-items: center;
   justify-content: center;
   background: rgb(245, 245, 245);
-}
-
-main div.embed-wrapper {
   max-width: 1280px;
   padding-left: 32px;
   padding-right: 32px;

--- a/hlx_statics/blocks/embed/embed.js
+++ b/hlx_statics/blocks/embed/embed.js
@@ -227,7 +227,6 @@ export default function decorate(block) {
   }
   else {
     link = block.querySelector('.embed > div > div').innerText;
-    getParent.parentElement.classList.remove("embed-container");
     block.style.maxWidth = "800px";
   }
 

--- a/hlx_statics/blocks/herosimple/herosimple.css
+++ b/hlx_statics/blocks/herosimple/herosimple.css
@@ -30,10 +30,6 @@ main div.herosimple-wrapper div.herosimple h1 {
   font-size: 36px !important;
 }
 
-main div.herosimple-container {
-  padding: 0;
-}
-
 @media screen and (max-width: 1024px) {
   main div.herosimple-wrapper div.herosimple {
     height: auto;

--- a/hlx_statics/blocks/herosimple/herosimple.css
+++ b/hlx_statics/blocks/herosimple/herosimple.css
@@ -1,14 +1,14 @@
 main div.herosimple-wrapper {
   width: 100%;
 }
-main div.herosimple {
+main div.herosimple-wrapper div.herosimple {
   height: 272px;
   overflow: hidden;
   color: rgb(255, 255, 255);
   position: relative;
 }
 
-main div.herosimple > div {
+main div.herosimple-wrapper div.herosimple > div {
   max-width: 1000px;
   margin: 0 auto;
   width: 100%;
@@ -19,12 +19,12 @@ main div.herosimple > div {
   height: 100%;
 }
 
-main div.herosimple > div > div{
+main div.herosimple-wrapper div.herosimple > div > div{
   width: calc(5* 100% / 12);
   font-size: 20px;
 }
 
-main div.herosimple h1 {
+main div.herosimple-wrapper div.herosimple h1 {
   color: rgb(255, 255, 255);
   margin-top: 0;
   font-size: 36px !important;
@@ -35,11 +35,11 @@ main div.herosimple-container {
 }
 
 @media screen and (max-width: 1024px) {
-  main div.herosimple {
+  main div.herosimple-wrapper div.herosimple {
     height: auto;
     padding: 50px 0px;
   }
-  main div.herosimple > div{
+  main div.herosimple-wrapper div.herosimple > div{
     max-width: 800px;
     margin: auto;
     margin-left: 90px;
@@ -47,13 +47,13 @@ main div.herosimple-container {
 }
 
 @media screen and (max-width: 768px) {
-  main div.herosimple {
+  main div.herosimple-wrapper div.herosimple {
     height: auto;
     padding: 32px;
   }
 }
 
-main .herosimple .herosimple-button-container {
+main div.herosimple-wrapper .herosimple .herosimple-button-container {
   display: flex;
   margin-top: 24px;
   gap: 16px;

--- a/hlx_statics/blocks/iframe/iframe.css
+++ b/hlx_statics/blocks/iframe/iframe.css
@@ -9,14 +9,14 @@ main div.iframe-wrapper iframe.iframe-container {
   border: none;
 }
 
-main div.iframe-container {
+main div.iframe-wrapper {
   align-items: center;
   justify-content: center;
   text-align: center;
   background: rgb(248, 248, 248);
 }
 
-main div.iframe-container > div{
+main div.iframe-wrapper > div{
   max-width: 1280px;
   padding-top: 16px;
   margin: auto;

--- a/hlx_statics/blocks/iframe/iframe.css
+++ b/hlx_statics/blocks/iframe/iframe.css
@@ -3,7 +3,7 @@ main div.iframe-wrapper {
   border: none;
 }
 
-main iframe.iframe-container {
+main div.iframe-wrapper iframe.iframe-container {
   width: 100%;
   height: 85vh;
   border: none;
@@ -22,19 +22,19 @@ main div.iframe-container > div{
   margin: auto;
 }
 
-main div.iframe-container p {
+main div.iframe-wrapper p {
   margin-top: 0;
   margin-bottom: 0!important;
 }
 
-main div.iframe {
+main div.iframe-wrapper div.iframe {
   margin-top: 32px;
   max-width: 1280px;
   display: flex;
   justify-content: center;
 }
 
-main div.iframe iframe {
+main div.iframe-wrapper div.iframe iframe {
   position: absolute;
   top: 0;
   left: 0;
@@ -44,7 +44,7 @@ main div.iframe iframe {
 }
 
 @media screen and (max-width: 1280px) {
-  main div.iframe-container div.iframe-wrapper {
+  main div.iframe-wrapper {
     padding: 0;
     display: flex;
     justify-content: center;
@@ -58,7 +58,7 @@ main div.iframe iframe {
   }
 }
 
-main div.iframe-container .iframe-custom-width{
+main div.iframe-wrapper .iframe-custom-width{
   display: flex;
   align-items: center;
   justify-content: center;

--- a/hlx_statics/blocks/image-text/image-text.css
+++ b/hlx_statics/blocks/image-text/image-text.css
@@ -1,8 +1,8 @@
-main div.image-text-container:has(.image-text.background-color-white) {
+main div.image-text-wrapper-container:has(.image-text.background-color-white) {
   background-color: white;
 }
 
-main div.image-text-container > .image-text-wrapper {
+main div.image-text-wrapper-container > .image-text-wrapper {
   width: 80%;
   margin: auto;
 }
@@ -40,7 +40,7 @@ main div.image-text-wrapper > .image-text > div > div {
   justify-content: center;
 }
 
-main div.image-text-container p {
+main div.image-text-wrapper-container p {
   text-align: center;
 }
 

--- a/hlx_statics/blocks/image-text/image-text.css
+++ b/hlx_statics/blocks/image-text/image-text.css
@@ -7,15 +7,14 @@ main div.image-text-container > .image-text-wrapper {
   margin: auto;
 }
 
-main div.image-text-container > .image-text-wrapper > .image-text {
+main div.image-text-wrapper > .image-text {
   display: flex;
   gap: 100px;
   justify-content: center;
 }
 
 main
-  div.image-text-container
-  > .image-text-wrapper
+  div.image-text-wrapper
   > .image-text
   > div
   > div:last-child {
@@ -26,17 +25,17 @@ main
   align-items: center;
 }
 
-main div.image-text-container div.image-text-wrapper img {
+main div.image-text-wrapper img {
   width: 600px;
   height: 400px;
 }
 
-main div.image-text-container div.image-text-wrapper .image-text-button-container {
+main div.image-text-wrapper .image-text-button-container {
   display: flex;
   gap: 20px;
 }
 
-main div.image-text-container > .image-text-wrapper > .image-text > div > div {
+main div.image-text-wrapper > .image-text > div > div {
   display: flex;
   justify-content: center;
 }
@@ -46,14 +45,14 @@ main div.image-text-container p {
 }
 
 @media screen and (min-width: 320px) and (max-width: 767px) {
-  main div.image-text-container div.image-text-wrapper img {
+  main div.image-text-wrapper img {
     width: 350px;
     height: auto;
   }
 }
 
 @media screen and (min-width: 320px) and (max-width: 1023px) {
-  main div.image-text-container > .image-text-wrapper > .image-text {
+  main div.image-text-wrapper > .image-text {
     flex-direction: column !important;
     gap: 50px;
   }

--- a/hlx_statics/blocks/image-text/image-text.js
+++ b/hlx_statics/blocks/image-text/image-text.js
@@ -1,4 +1,5 @@
 import { decorateButtons } from '../../scripts/lib-adobeio.js';
+import insertWrapperContainer from '../../components/wrapperContainer.js';
 
 /**
  * Rearranges the links into a image-text-button-container div
@@ -26,6 +27,7 @@ function rearrangeLinks(block) {
  * @param {Element} block The image-text block element
  */
 export default async function decorate(block) {
+  insertWrapperContainer(block);
   decorateButtons(block);
   block.setAttribute('daa-lh', 'image-text');
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {

--- a/hlx_statics/components/wrapperContainer.js
+++ b/hlx_statics/components/wrapperContainer.js
@@ -1,0 +1,9 @@
+import { createTag } from '../../hlx_statics/scripts/lib-adobeio.js'
+
+export default function insertWrapperContainer(block) {
+    const wrapper = block.parentElement;
+    const name = block.getAttribute('data-block-name');
+    const wrapperContainer = createTag('div', { class: `${name}-wrapper-container` });
+    wrapper.replaceWith(wrapperContainer);
+    wrapperContainer.appendChild(wrapper);
+}

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -87,6 +87,22 @@ img {
   font-family: "adobe-clean", sans-serif;
 }
 
+h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+hr {
+  border-radius: 2px;
+  height: 1px;
+  border-color: rgb(213, 213, 213);
+  background-color: rgb(213, 213, 213);
+  border-top: 0;
+  border-left: 0;
+  width: 100%;
+}
+
 main {
   background-color: rgb(245,245,245);
 }


### PR DESCRIPTION
#### Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1590

#### Description
We decided on an approach where we merge styles from `container` (shared) to `wrapper` (not shared). However that doesn't work for some blocks that need style applied to a parent div.

This PR inserts a div between `container` and `wrapper` called a `wrapper-container`, and merge styles from `container` (shared) to `wrapper-container` (not shared).

URL for testing:
- https://devsite-1590-insert-container-styles--adp-devsite--adobedocs.aem.page/test/contributors
- https://devsite-1590-insert-container-styles--adp-devsite--adobedocs.aem.page/developer-distribution/experience-cloud/docs/guides/
- https://devsite-1590-insert-container-styles--adp-devsite--adobedocs.aem.page/tools/sidekick/blocks/embed
- https://devsite-1590-insert-container-styles--adp-devsite--adobedocs.aem.page/app-builder/docs/guides/
- https://devsite-1590-insert-container-styles--adp-devsite--adobedocs.aem.page/developer-console/docs/guides/
- https://devsite-1590-insert-container-styles--adp-devsite--adobedocs.aem.page/express/add-ons/docs/guides/design/ux-guidelines/resources-and-references
- https://devsite-1590-insert-container-styles--adp-devsite--adobedocs.aem.page/tools/sidekick/blocks/image-text
- https://devsite-1590-insert-container-styles--adp-devsite--adobedocs.aem.page/developer-distribution/creative-cloud/docs/support/

#### Notes
- Embed background color will be fixed in [DEVSITE-1584](https://jira.corp.adobe.com/browse/DEVSITE-1584)
- HeroSimple seems to need the container style: https://github.com/AdobeDocs/adp-devsite/pull/134/files