### PR TITLE
refactor: layout

### DIFF
--- a/hlx_statics/blocks/herosimple/herosimple.js
+++ b/hlx_statics/blocks/herosimple/herosimple.js
@@ -43,11 +43,19 @@ export default async function decorate(block) {
   }
 
   const heroSimpleContainer = document.querySelector('.herosimple-container');
+  if (heroSimpleContainer) {
+    heroSimpleContainer.style.margin = '0px';
+    heroSimpleContainer.style.maxWidth = 'none';
+  }
+
   const sideNav = document.querySelector('.side-nav-container');
+  if(!sideNav){
+    const heroSimpleDiv = block.querySelector('.herosimple > div');
+    heroSimpleDiv.style.setProperty('max-width', '1280px', 'important');
+  }
+
   const subParent = createTag('div',{class:'sub-parent'});
     if (heroSimpleContainer) {
-      heroSimpleContainer.style.margin = '0px';
-      heroSimpleContainer.style.maxWidth = 'none';
       const children = Array.from(heroSimpleContainer.children);
       children.forEach(child => {
         if (!child.classList.contains('herosimple-wrapper')) {
@@ -64,8 +72,6 @@ export default async function decorate(block) {
       subParent.style.maxWidth = '1000px';
     }
     if(!sideNav){
-      const heroSimpleDiv = block.querySelector('.herosimple > div');
-      heroSimpleDiv.style.setProperty('max-width', '1280px', 'important');
       subParent.style.margin = '0 auto';
       subParent.style.maxWidth = '1280px';
     }

--- a/hlx_statics/blocks/herosimple/herosimple.js
+++ b/hlx_statics/blocks/herosimple/herosimple.js
@@ -68,11 +68,7 @@ export default async function decorate(block) {
       } else {
         heroSimpleContainer.appendChild(subParent);
       }
-      subParent.style.margin = '0 auto';
-      subParent.style.maxWidth = '1000px';
     }
-    if(!sideNav){
-      subParent.style.margin = '0 auto';
-      subParent.style.maxWidth = '1280px';
-    }
+    subParent.style.margin = '0 auto';
+    subParent.style.maxWidth = sideNav ? '1000px' : '1280px';
 }

--- a/hlx_statics/blocks/herosimple/herosimple.js
+++ b/hlx_statics/blocks/herosimple/herosimple.js
@@ -54,21 +54,21 @@ export default async function decorate(block) {
     heroSimpleDiv.style.setProperty('max-width', '1280px', 'important');
   }
 
-  const subParent = createTag('div',{class:'sub-parent'});
-    if (heroSimpleContainer) {
-      const children = Array.from(heroSimpleContainer.children);
-      children.forEach(child => {
-        if (!child.classList.contains('herosimple-wrapper')) {
-          subParent.appendChild(child);
-        }
-      });
-      const herosimpleWrapper = block?.parentElement;
-      if (herosimpleWrapper) {
-        heroSimpleContainer.insertBefore(subParent, herosimpleWrapper.nextSibling);
-      } else {
-        heroSimpleContainer.appendChild(subParent);
+  const subParent = createTag("div", { class: "sub-parent" });
+  if (heroSimpleContainer) {
+    const children = Array.from(heroSimpleContainer.children);
+    children.forEach((child) => {
+      if (!child.classList.contains("herosimple-wrapper")) {
+        subParent.appendChild(child);
       }
+    });
+    const herosimpleWrapper = block?.parentElement;
+    if (herosimpleWrapper) {
+      heroSimpleContainer.insertBefore(subParent, herosimpleWrapper.nextSibling);
+    } else {
+      heroSimpleContainer.appendChild(subParent);
     }
-    subParent.style.margin = '0 auto';
-    subParent.style.maxWidth = sideNav ? '1000px' : '1280px';
+  }
+  subParent.style.margin = "0 auto";
+  subParent.style.maxWidth = sideNav ? "1000px" : "1280px";  
 }

--- a/hlx_statics/blocks/herosimple/herosimple.js
+++ b/hlx_statics/blocks/herosimple/herosimple.js
@@ -1,7 +1,3 @@
-import {
-  createTag,
-} from '../../scripts/lib-adobeio.js';
-
 /**
  * decorates the herosimple
  * @param {Element} block The herosimple block element
@@ -53,22 +49,4 @@ export default async function decorate(block) {
     const heroSimpleDiv = block.querySelector('.herosimple > div');
     heroSimpleDiv.style.setProperty('max-width', '1280px', 'important');
   }
-
-  const subParent = createTag("div", { class: "sub-parent" });
-  if (heroSimpleContainer) {
-    const children = Array.from(heroSimpleContainer.children);
-    children.forEach((child) => {
-      if (!child.classList.contains("herosimple-wrapper")) {
-        subParent.appendChild(child);
-      }
-    });
-    const herosimpleWrapper = block?.parentElement;
-    if (herosimpleWrapper) {
-      heroSimpleContainer.insertBefore(subParent, herosimpleWrapper.nextSibling);
-    } else {
-      heroSimpleContainer.appendChild(subParent);
-    }
-  }
-  subParent.style.margin = "0 auto";
-  subParent.style.maxWidth = sideNav ? "1000px" : "1280px";  
 }

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -321,7 +321,17 @@ export function buildGridAreaMain(main, hasSideNav) {
     gridAreaMain.appendChild(subParent);
   }
   subParent.style.margin = "0 auto";
-  subParent.style.maxWidth = hasSideNav ? "1000px" : "1280px";  
+  subParent.style.maxWidth = hasSideNav ? "1000px" : "1280px"; 
+
+  const newGridAreaMain = createTag('div');
+  newGridAreaMain.style.gridArea = 'main';  
+  gridAreaMain.style.removeProperty('gridArea');
+  gridAreaMain.replaceWith(newGridAreaMain);
+  newGridAreaMain.appendChild(gridAreaMain);
+
+  if(herosimpleWrapper) {
+    div.style.width = "100%";
+  }
 }
 
 /**

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -301,6 +301,32 @@ export function buildGrid(main) {
 }
 
 /**
+ * Builds the div with style*="grid-area: main"
+ * @param {*} main The grid container
+ * @param {*} hasSideNav whether main has a side nav
+ */
+export function buildGridAreaMain(main, hasSideNav) {
+  const heroSimpleContainer = main.querySelector('.herosimple-container');
+  const subParent = createTag("div", { class: "sub-parent" });
+  if (heroSimpleContainer) {
+    const children = Array.from(heroSimpleContainer.children);
+    children.forEach((child) => {
+      if (!child.classList.contains("herosimple-wrapper")) {
+        subParent.appendChild(child);
+      }
+    });
+    const herosimpleWrapper = main.querySelector('.herosimple-wrapper');
+    if (herosimpleWrapper) {
+      heroSimpleContainer.insertBefore(subParent, herosimpleWrapper.nextSibling);
+    } else {
+      heroSimpleContainer.appendChild(subParent);
+    }
+  }
+  subParent.style.margin = "0 auto";
+  subParent.style.maxWidth = hasSideNav ? "1000px" : "1280px";  
+}
+
+/**
  * Builds the side nav
  * @param {*} main The grid container
  */
@@ -328,12 +354,8 @@ export function buildOnThisPage(main) {
  */
 export function buildNextPrev(main) {
   let nextPrevWrapper = createTag('div', { class: 'next-prev-wrapper block', 'data-block-name': 'next-prev' });
-  if (!document.querySelector('.herosimple-wrapper')) {
-    main.children[1].appendChild(nextPrevWrapper)
-  }
-  else {
-    main.children[1].children[1].appendChild(nextPrevWrapper)
-  }
+  const gridAreaMain = main.querySelector('div[style*="grid-area: main"]');
+  gridAreaMain.appendChild(nextPrevWrapper)
 }
 
 /**
@@ -474,7 +496,7 @@ function activeSubNav(actTab) {
   }
   if (document.querySelectorAll(".active-sidenav")?.length === 0 ) {
     document.querySelector("main").classList.add("no-sidenav");
-    const sectionDivision = document.querySelector('main > div[style*="grid-area: main"]');
+    const sectionDivision = document.querySelector('main div[style*="grid-area: main"]');
     sectionDivision.style.margin = "0 auto"
   }
   const sidecontainer = document.querySelector(".side-nav-container");

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -306,21 +306,19 @@ export function buildGrid(main) {
  * @param {*} hasSideNav whether main has a side nav
  */
 export function buildGridAreaMain(main, hasSideNav) {
-  const heroSimpleContainer = main.querySelector('.herosimple-container');
+  const herosimpleWrapper = main.querySelector('.herosimple-wrapper');
+  const gridAreaMain = main.querySelector('main > div[style*="grid-area: main"]');
   const subParent = createTag("div", { class: "sub-parent" });
-  if (heroSimpleContainer) {
-    const children = Array.from(heroSimpleContainer.children);
+  if (herosimpleWrapper) {
+    const children = Array.from(gridAreaMain.children);
     children.forEach((child) => {
       if (!child.classList.contains("herosimple-wrapper")) {
         subParent.appendChild(child);
       }
     });
-    const herosimpleWrapper = main.querySelector('.herosimple-wrapper');
-    if (herosimpleWrapper) {
-      heroSimpleContainer.insertBefore(subParent, herosimpleWrapper.nextSibling);
-    } else {
-      heroSimpleContainer.appendChild(subParent);
-    }
+    gridAreaMain.insertBefore(subParent, herosimpleWrapper.nextSibling);
+  } else {
+    gridAreaMain.appendChild(subParent);
   }
   subParent.style.margin = "0 auto";
   subParent.style.maxWidth = hasSideNav ? "1000px" : "1280px";  

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -404,9 +404,10 @@ async function loadLazy(doc) {
     main.append(footer);
 
     // turn off this page when in doc mode and there's no hero
-    const headings = main.querySelectorAll('h2:not(.side-nav h2):not(footer h2), h3:not(.side-nav h3):not(footer h3)');
-    const hasSideNav = document.querySelector('.side-nav')?.children;
-    if (!document.querySelector('.hero, .herosimple') && headings.length !== 0 && hasSideNav.length !== 0) {
+    const hasHero = Boolean(document.querySelector('.hero, .herosimple'));
+    const hasHeading = main.querySelectorAll('h2:not(.side-nav h2):not(footer h2), h3:not(.side-nav h3):not(footer h3)').length !== 0;
+    const hasSideNav = document.querySelector('.side-nav')?.children.length !== 0;
+    if (!hasHero && hasHeading && hasSideNav) {
       buildOnThisPage(main);
       loadOnThisPage(doc.querySelector('.onthispage-wrapper'));
     }

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -23,6 +23,7 @@ import {
   buildCodes,
   buildEmbeds,
   buildGrid,
+  buildGridAreaMain,
   buildHeadings,
   buildSideNav,
   buildOnThisPage,
@@ -415,6 +416,7 @@ async function loadLazy(doc) {
       buildNextPrev(main);
       loadNextPrev(doc.querySelector('.next-prev-wrapper'));
     }
+    buildGridAreaMain(main, hasSideNav);
   }
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);


### PR DESCRIPTION
#### Description
Move layout logic out of `herosimple` block

#### Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1590

#### Test
- https://devsite-1590-refactor-layout-code--adp-devsite-stage--adobedocs.aem.page/express/add-ons/docs/samples
- https://devsite-1590-refactor-layout-code--adp-devsite-stage--adobedocs.aem.page/developer-distribution/creative-cloud/docs/support/
- https://devsite-1590-refactor-layout-code--adp-devsite-stage--adobedocs.aem.page/developer-distribution/experience-cloud/docs/guides/
- https://devsite-1590-refactor-layout-code--adp-devsite--adobedocs.aem.page/app-builder/docs/guides/