### PR TITLE
update announcement to use background image

### DIFF
--- a/hlx_statics/blocks/announcement/announcement.js
+++ b/hlx_statics/blocks/announcement/announcement.js
@@ -72,8 +72,11 @@ export default async function decorate(block) {
     p.style.wordBreak = "break-all";
     p.style.whiteSpace = "normal";
   });
-  if (!block.classList.contains('background-color-white') && !block.classList.contains('background-color-navy') && !block.classList.contains('background-color-dark-gray')) {
-    block.classList.add('background-color-gray');
+  const imageExists = block.querySelector('picture img');
+  if (!imageExists) {
+    if (!block.classList.contains('background-color-white') && !block.classList.contains('background-color-navy') && !block.classList.contains('background-color-dark-gray')) {
+      block.classList.add('background-color-gray');
+    }
   }
   decorateButtons(block);
   removeEmptyPTags(block);


### PR DESCRIPTION
Original: 
https://main--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/announcement&index=1
<img width="877" alt="Screenshot 2025-04-15 at 12 07 59 PM" src="https://github.com/user-attachments/assets/83ba77b7-afa5-4193-a18e-11342da2a3e9" />

Fix: 
https://devsite-1639-announcement-sidekick--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/announcement&index=1
<img width="1590" alt="Screenshot 2025-04-15 at 12 08 14 PM" src="https://github.com/user-attachments/assets/713f3089-c192-4b35-b9e7-dcc3482a84f3" />
