### PR TITLE
fix: sidenav collapse animation width

### DIFF
--- a/hlx_statics/blocks/side-nav/side-nav.css
+++ b/hlx_statics/blocks/side-nav/side-nav.css
@@ -235,13 +235,12 @@ main div.section.side-nav-container {
   }
 
   main div.side-nav-wrapper div.side-nav {
-    transform: translateX(-100%);
+    transform: translateX(-256px);
     transition: transform 0.3s ease-out;
     position: fixed;
     top: 64px;
     left: 0;
     bottom: 0;
-    width: 100vw !important;
     background: #fafafa;
     z-index: 1000;
     overflow-y: auto;


### PR DESCRIPTION
### Description
Make collapse animation start from the right edge of the sidenav, rather than the right edge of the entire window.

### Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1650

### Before
https://stage--adp-devsite-stage--adobedocs.aem.page/developer-console/docs/guides/authentication/ServerToServerAuthentication/migration

![before](https://github.com/user-attachments/assets/32f96003-3123-4cac-b398-ca278ddfe1c2)



### After
https://devsite-1650--adp-devsite-stage--adobedocs.aem.page/developer-console/docs/guides/authentication/ServerToServerAuthentication/migration

![after](https://github.com/user-attachments/assets/1ef6eee2-c7a0-4e60-bfa0-a58b245c92ae)


