### PR TITLE
Change width behavior of columns and announcement word break behavior 

### DIFF
--- a/hlx_statics/blocks/announcement/announcement.css
+++ b/hlx_statics/blocks/announcement/announcement.css
@@ -45,6 +45,7 @@ main div.announcement-wrapper>.block>div>div {
   gap: 15px;
   width: 95%;
   align-items: center;
+  margin: auto;
 }
 
 main div.announcement-wrapper>.block>div {

--- a/hlx_statics/blocks/announcement/announcement.js
+++ b/hlx_statics/blocks/announcement/announcement.js
@@ -64,12 +64,10 @@ export default async function decorate(block) {
   block.setAttribute('daa-lh', 'announcement');
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeL', 'announcement-heading');
-    h.style.wordBreak = "break-all";
     h.style.whiteSpace = "normal";
   });
   block.querySelectorAll('p').forEach((p) => {
     p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
-    p.style.wordBreak = "break-all";
     p.style.whiteSpace = "normal";
   });
   const imageExists = block.querySelector('picture img');

--- a/hlx_statics/blocks/columns/columns.css
+++ b/hlx_statics/blocks/columns/columns.css
@@ -20,13 +20,8 @@ main div.columns-wrapper div.columns > div {
     padding: 80px 0;
 }
 
-/* main div.columns-wrapper .first-column-div {
-    width: 75vw;
-} */
-
 main div.columns-wrapper div.columns .first-column-div, main div.columns-wrapper div.columns .last-column-div {
     padding: 0 0;
-    /* margin: auto; */
 }
 
 main div.columns-wrapper  div.columns > div:nth-child(even) {
@@ -75,7 +70,6 @@ main div.columns-wrapper div.columns div.first-column {
 }
 
 main div.columns-wrapper div.columns div.first-column img {
-    /* max-width: 100%; */
     max-height: 350px;
     height: auto;
     width: auto;
@@ -201,10 +195,6 @@ main div.columns-wrapper div.columns.center .button-container {
     margin: 16px 8px;
     margin-bottom: 0;
 }
-
-/* main div.columns-wrapper div.columns div.first-column img {
-    height: 350px !important;
-} */
 
 @media screen and (max-width: 1280px) {
     main div.columns-wrapper  div.columns div.second-column {

--- a/hlx_statics/blocks/columns/columns.css
+++ b/hlx_statics/blocks/columns/columns.css
@@ -20,8 +20,13 @@ main div.columns-wrapper div.columns > div {
     padding: 80px 0;
 }
 
+/* main div.columns-wrapper .first-column-div {
+    width: 75vw;
+} */
+
 main div.columns-wrapper div.columns .first-column-div, main div.columns-wrapper div.columns .last-column-div {
     padding: 0 0;
+    /* margin: auto; */
 }
 
 main div.columns-wrapper  div.columns > div:nth-child(even) {
@@ -196,8 +201,10 @@ main div.columns-wrapper div.columns.center .button-container {
 
 @media screen and (max-width: 1280px) {
     main div.columns-wrapper  div.columns div.second-column {
-        width: 100%;
-        margin: 40px 0;
+        width: 75vw;
+        margin: auto;
+        margin-top: 40px;
+        margin-bottom: 40px;
         text-align: center;
     }
 

--- a/hlx_statics/blocks/columns/columns.css
+++ b/hlx_statics/blocks/columns/columns.css
@@ -208,7 +208,7 @@ main div.columns-wrapper div.columns.center .button-container {
 
 @media screen and (max-width: 1280px) {
     main div.columns-wrapper  div.columns div.second-column {
-        width: 75vw;
+        width: 75%;
         margin: auto;
         margin-top: 40px;
         margin-bottom: 40px;

--- a/hlx_statics/blocks/columns/columns.css
+++ b/hlx_statics/blocks/columns/columns.css
@@ -75,7 +75,7 @@ main div.columns-wrapper div.columns div.first-column {
 }
 
 main div.columns-wrapper div.columns div.first-column img {
-    max-width: 100%;
+    /* max-width: 100%; */
     max-height: 350px;
     height: auto;
     width: auto;
@@ -147,6 +147,13 @@ main div.columns-wrapper div.second-column div.product-link-container {
     }
     main div.columns div.first-column {
         width: 100% !important;
+    }
+    main div.columns-wrapper div.columns div.first-column img {
+        max-width: 100%;
+        max-height: 350px;
+        height: auto;
+        width: auto;
+        object-fit: contain;
     }
 }
 


### PR DESCRIPTION
Width resizes down to 75% when in tablet view which really helps when columns have lists and fixed images resizing for now reason in tablet view. Also changed word break behavior in announcement block to the behavior that every other block has: Smaller widths cause entire words to drop to the next line, but the words aren't split up.

Before: https://main--adp-devsite--adobedocs.aem.page/test/diane/devsite-1558-columns-width
Before stage: https://stage--adp-devsite--adobedocs.aem.page/test/diane/devsite-1558-columns-width

Fix: https://diane-ticket-57-58--adp-devsite--adobedocs.aem.page/test/diane/devsite-1558-columns-width

Tickets: 
https://jira.corp.adobe.com/browse/DEVSITE-1557
https://jira.corp.adobe.com/browse/DEVSITE-1558
