### PR TITLE
Fix for Hero doesn't take entire width in mobile screen

### DIFF
--- a/hlx_statics/blocks/hero/hero.css
+++ b/hlx_statics/blocks/hero/hero.css
@@ -106,7 +106,6 @@ main div.hero-wrapper div.hero h1 + p.last-of-type {
 
 @media screen and (max-width: 768px) {
   main div.hero-wrapper div.hero {
-    max-width: calc(100% - 64px) ;
     padding: 32px;
     overflow: hidden;
   }


### PR DESCRIPTION
Before: https://stage--adp-devsite--adobedocs.aem.page/test/diane/devsite-1661-hero-width
After: https://diane-ticket-1661-hero-width--adp-devsite--adobedocs.aem.page/test/diane/devsite-1661-hero-width

Ticket: https://jira.corp.adobe.com/browse/DEVSITE-1661