### PR TITLE
Fix redirect parsing

### DIFF
--- a/hlx_statics/scripts/lib-helix.js
+++ b/hlx_statics/scripts/lib-helix.js
@@ -137,7 +137,11 @@ export async function fetchRedirectJson() {
   const redirectJSONHash = `${hashCode(redirectFile)}`;
 
   if (sessionStorage.getItem(redirectJSONHash)) {
-    redirectJSON = JSON.parse(sessionStorage.getItem(redirectJSONHash));
+    try {
+      redirectJSON = JSON.parse(sessionStorage.getItem(redirectJSONHash));
+    } catch (error) {
+      console.error('Unable to parse: redirect json');
+    }
   } else {
     redirectJSON = await fetch(redirectFile)
       .then(response => {


### PR DESCRIPTION
Wrap a try catch around parsing the redirects json in case it is malformed. This should fix the navs breaking since it relies on the redirects json. 