### PR TITLE
fix: apply DevDocs layout to landing pages

### DIFF
--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -1,4 +1,4 @@
-import { buildBlock, getMetadata, loadCSS } from './lib-helix.js';
+import { buildBlock, getMetadata, IS_DEV_DOCS, loadCSS } from './lib-helix.js';
 import decoratePreformattedCode from '../components/code.js';
 
 /**
@@ -430,7 +430,7 @@ export function setActiveTab(isMainPage) {
     if (actTab) {
       activateTab(actTab);
     }
-    if (getMetadata('template') === 'documentation') {
+    if (IS_DEV_DOCS) {
       activeSubNav(actTab);
     }
   }

--- a/hlx_statics/scripts/lib-helix.js
+++ b/hlx_statics/scripts/lib-helix.js
@@ -107,6 +107,11 @@ export function getMetadata(name) {
   return meta || null;
 }
 
+// Normally,we would check for DevDocs is using getMetadata('template') === 'documentation'.
+// However, the first landing pages don't go to documentation mode, which matches the same behavior as Gatsby.
+// To ensure DevDocs layout also gets applied to landing pages, we use Boolean(getMetadata('githubblobpath')) instead. 
+export const IS_DEV_DOCS = Boolean(getMetadata('githubblobpath'));
+
 /**
  * Retrieves the top nav from the config.
  * @returns {string} The top nav HTML
@@ -374,7 +379,7 @@ export function decorateBlock(block) {
     const blockWrapper = block.parentElement;
     blockWrapper.classList.add(`${shortBlockName}-wrapper`);
     const childBlock = blockWrapper.querySelector('div')
-    if(getMetadata('template') === 'documentation'){
+    if(IS_DEV_DOCS){
       // ensure all documentation blocks are having white background.
       childBlock?.classList.add('background-color-white');
     }

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -13,6 +13,7 @@ import {
   loadCSS,
   addFavIcon,
   getMetadata,
+  IS_DEV_DOCS,
   toCamelCase,
   toClassName,
   githubActionsBlock,
@@ -176,20 +177,20 @@ async function loadEager(doc) {
     await waitForLCP(LCP_BLOCKS);
   }
 
-  if (getMetadata('githubblobpath')){
+  if (IS_DEV_DOCS) {
     // check if this page is from dev docs, then change the main container to white background.
     const mainContainer = document.querySelector('main');
     mainContainer.classList.add('white-background');
   }
 
 
-  if (getMetadata('template') === 'documentation') {
+  if (IS_DEV_DOCS) {
     buildGrid(main);
   }
 
   buildSideNav(main);
 
-  if (getMetadata('template') === 'documentation') {
+  if (IS_DEV_DOCS) {
     buildBreadcrumbs(main);
   }
 
@@ -437,7 +438,7 @@ async function loadLazy(doc) {
   decorateIcons(main);
   loadFooter(doc.querySelector('footer'));
 
-  if (getMetadata('template') === 'documentation') {
+  if (IS_DEV_DOCS) {
     // rearrange footer and append to main when in doc mode
     const footer = doc.querySelector('footer');
     footer.style.gridArea = 'footer';
@@ -478,7 +479,7 @@ function loadDelayed() {
   // eslint-disable-next-line import/no-cycle
   window.setTimeout(() => import('./delayed.js'), 3000);
   // load anything that can be postponed to the latest here
-  if (getMetadata('template') === 'documentation') {
+  if (IS_DEV_DOCS) {
     githubActionsBlock(document);
   }
 


### PR DESCRIPTION
### Description
Apply DevDocs layout logic to DevDocs landing page

### Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1664

### Slack
https://adobeio.slack.com/archives/C06M1C7UBV3/p1745442031683219

### Before
https://stage--adp-devsite-stage--adobedocs.aem.page/developer-distribution/creative-cloud/docs/
<img width="1728" alt="Screenshot 2025-04-23 at 4 14 44 PM" src="https://github.com/user-attachments/assets/31d79f38-ea6d-43f0-87e7-72911d162ddf" />


### After
https://devsite-1664-landing-page-layout--adp-devsite-stage--adobedocs.aem.page/developer-distribution/creative-cloud/docs/
<img width="1728" alt="Screenshot 2025-04-23 at 4 14 21 PM" src="https://github.com/user-attachments/assets/6bf47398-2fc6-42bf-a4cf-d0f5b4226082" />

### Tests
- https://stage--adp-devsite-stage--adobedocs.aem.page/developer-distribution/creative-cloud/docs/
- https://stage--adp-devsite-stage--adobedocs.aem.page/express/add-ons/docs/samples
- https://stage--adp-devsite-stage--adobedocs.aem.page/developer-distribution/creative-cloud/docs/support/
- https://stage--adp-devsite-stage--adobedocs.aem.page/developer-distribution/experience-cloud/docs/guides/
- https://stage--adp-devsite--adobedocs.aem.page/app-builder/docs/guides/