### PR TITLE
fix: info card border

### DIFF
--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -20,7 +20,7 @@ main div.info-card-wrapper div.info-card .button-container {
 }
 
 main div.info-card-wrapper div.info-card > ul > li {
-  max-width: 400px;
+  max-width: 402px;
   border: 1px solid transparent;
   border-radius: 4px;
   border-color: rgb(235,235,235);


### PR DESCRIPTION
### Description
Part of the info card's border is overlapped by the image

### Root cause
- [box-sizing: border-box](https://github.com/AdobeDocs/adp-devsite/blob/stage/hlx_statics/styles/styles.css#L18) was added recently to address overflow issues. This means that padding and border are now included in the width and height.
- Both the [image width](https://github.com/AdobeDocs/adp-devsite/blob/stage/hlx_statics/blocks/info-card/info-card.css#L80-L82) and [box width](https://github.com/AdobeDocs/adp-devsite/blob/stage/hlx_statics/blocks/info-card/info-card.css#L22-L23) were 400px, and so the image overlapped with the box border.

### Fix
Set the [box-width to 402px](https://github.com/AdobeDocs/adp-devsite/blob/devsite-1667-info-card-border/hlx_statics/blocks/info-card/info-card.css#L23). (401px, so that it fully contains the 400px image, +1px for the border).

### Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1667

### Before
<img width="586" alt="Screenshot 2025-04-24 at 8 13 11 AM" src="https://github.com/user-attachments/assets/1f59e4b8-758f-4106-91d8-733d56256426" />

### After
<img width="726" alt="Screenshot 2025-04-24 at 8 13 45 AM" src="https://github.com/user-attachments/assets/107ddded-f03e-4a7b-8aa9-4492eb751691" />

### Tests
- https://devsite-1667-info-card-border--adp-devsite-stage--adobedocs.aem.page/developer-champion/
- https://devsite-1667-info-card-border--adp-devsite-stage--adobedocs.aem.page/express/community/

