### PR TITLE
fix: anchor link ids

### DIFF
--- a/hlx_statics/blocks/onthispage/onthispage.js
+++ b/hlx_statics/blocks/onthispage/onthispage.js
@@ -33,18 +33,15 @@ export default async function decorate(block) {
     let isClick = false;
 
     headings.forEach((heading, index) => {
-        const textContent = heading.textContent.trim();
-        const anchorText = textContent.replace(/\s+/g, '-').replace(/[()]/g, '').toLowerCase();
         const anchor = document.createElement('a');
-        anchor.href = `#${anchorText}`;
-        anchor.textContent = textContent;
+        anchor.href = `#${heading.id}`;
+        anchor.textContent = heading.textContent;
         aside.appendChild(anchor);
         anchors.push(anchor);
 
         if (heading.tagName === 'H3') {
             anchor.style.paddingLeft = '16px';
         }
-        heading.id = anchorText;
         if (index === 0) {
             anchor.classList.add('active');
         }

--- a/hlx_statics/blocks/onthispage/onthispage.js
+++ b/hlx_statics/blocks/onthispage/onthispage.js
@@ -35,7 +35,7 @@ export default async function decorate(block) {
     headings.forEach((heading, index) => {
         const anchor = document.createElement('a');
         anchor.href = `#${heading.id}`;
-        anchor.textContent = heading.textContent;
+        anchor.textContent = heading.textContent.trim();
         aside.appendChild(anchor);
         anchors.push(anchor);
 


### PR DESCRIPTION
### Description

**Issue**
When document has two headings with the same text:
- scrolling down to `heading2` jumps back to `link1` in `onthispage` 
- `link1` and `link2` in `onthispage` both point to `heading1`

**Fix** 
Use `heading.id` instead of `heading.text` as `href`

### Test
- https://devsite-1627-anchor-link-ids--adp-devsite-stage--adobedocs.aem.page/developer-distribution/creative-cloud/docs/guides/getting-started#overview
- This has two "Overview" links in `onthispage`

### Before
![before](https://github.com/user-attachments/assets/e4d25cb6-b800-4466-8011-8334d8000453)


### After
![after](https://github.com/user-attachments/assets/1ed53225-5fcf-4d34-a66b-e40082d3ad46)


