### PR TITLE
feat: codeblock customized select

### DIFF
--- a/hlx_statics/blocks/codeblock/codeblock.css
+++ b/hlx_statics/blocks/codeblock/codeblock.css
@@ -38,8 +38,8 @@ main div.codeblock-wrapper div.codeblock .control-bar .tabs-list {
   margin: 0 16px;
 }
 
-main div.codeblock-wrapper div.codeblock .control-bar select,
-main div.codeblock-wrapper div.codeblock .control-bar .tabs-list button {
+main div.codeblock-wrapper div.codeblock .control-bar .tabs-list button,
+main div.codeblock-wrapper div.codeblock .control-bar select {
   flex: 0 0 max-content;
   border: 0px;
   border-radius: 0;
@@ -57,8 +57,9 @@ main div.codeblock-wrapper div.codeblock .control-bar .tabs-list button {
   border-bottom: 3px solid transparent;
 }
 
-main div.codeblock-wrapper div.codeblock .control-bar select:hover,
-main div.codeblock-wrapper div.codeblock .control-bar .tabs-list button:hover {
+main div.codeblock-wrapper div.codeblock .control-bar .tabs-list button:hover,
+main div.codeblock-wrapper div.codeblock .control-bar select:hover selectedcontent,
+main div.codeblock-wrapper div.codeblock .control-bar select:hover::picker-icon {
   color: rgb(255, 255, 255);
 }
 
@@ -73,6 +74,44 @@ main div.codeblock-wrapper div.codeblock .control-bar .tabs-list button p {
 
 main div.codeblock-wrapper div.codeblock .control-bar .tabs-list button[aria-selected="true"] {
   border-bottom: 3px solid rgb(255, 255, 255);
+}
+
+/* opt in to custom select rendering as described in https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select */
+main div.codeblock-wrapper div.codeblock .control-bar select,
+main div.codeblock-wrapper div.codeblock .control-bar select::picker(select) {
+  appearance: base-select;
+}
+
+main div.codeblock-wrapper div.codeblock .control-bar select {
+  border: none;
+}
+
+main div.codeblock-wrapper div.codeblock .control-bar select selectedcontent {
+  margin: auto;
+}
+
+main div.codeblock-wrapper div.codeblock .control-bar select::picker-icon {
+  content: "⌄";
+  margin: auto;
+  padding-bottom: 6px;
+  font-weight: bold;
+  transform: scaleX(1.5);
+}
+
+main div.codeblock-wrapper div.codeblock .control-bar select::picker(select) {
+  border-radius: 4px;
+  border: 1px solid rgb(112, 112, 112);
+  background-color: rgb(0, 0, 0);
+  color: rgb(209, 209, 209);
+}
+
+main div.codeblock-wrapper div.codeblock .control-bar select option::checkmark {
+  font-weight: bold;
+  color: rgb(84, 163, 246);
+}
+
+main div.codeblock-wrapper div.codeblock .control-bar select option:hover {
+  background: rgba(255, 255, 255, 0.2);
 }
 
 main div.codeblock-wrapper div.codeblock .tabs-panel {

--- a/hlx_statics/blocks/codeblock/codeblock.js
+++ b/hlx_statics/blocks/codeblock/codeblock.js
@@ -90,6 +90,11 @@ export default function decorate(block) {
   select.addEventListener('change', handleSelectChange);
   controlBar.append(select);
 
+  // set up customizable select (as opposed to classic which can't be styled) as described in https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select
+  const selectButton = document.createElement('button');
+  selectButton.append(document.createElement('selectedcontent'));
+  select.append(selectButton);
+
   tabContents.forEach((tabContent, i) => {
     const option = document.createElement('option');
     option.id = `option-${i}`;


### PR DESCRIPTION
## Description
Customize `select` element in `codeblock` so it looks more like in Gatsby

## Context
Previously we were using "classic" `select` which contain internals that are styled at the operating system level, and can't be targeted using CSS.

This PR uses "customizable" `select` as described in https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select, which can be targeted using CSS. This is fairly new and may not be supported by all browsers, but will fallback gracefully to "classic" mode.

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1518

## Before
https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/code-block-with-picklist
<img width="1524" alt="Screenshot 2025-05-14 at 12 40 23 PM" src="https://github.com/user-attachments/assets/b2cbca9d-9104-4c68-9912-03ebf5b08690" />


## After

https://devsite-1518-codeblock-select--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/code-block-with-picklist
<img width="1533" alt="Screenshot 2025-05-14 at 12 40 46 PM" src="https://github.com/user-attachments/assets/651eff54-f25b-4c9d-a7e0-4f1c083b75eb" />

## Gatsby
https://developer.adobe.com/express/add-ons/docs/guides/tutorials/grids-addon/
<img width="1727" alt="Screenshot 2025-05-14 at 12 51 03 PM" src="https://github.com/user-attachments/assets/001c3bdd-7d0c-4dbf-bf34-3095bb269216" />

