### PR TITLE
fix: codeblock select keyboard accessibility

### DIFF
--- a/hlx_statics/blocks/codeblock/codeblock.css
+++ b/hlx_statics/blocks/codeblock/codeblock.css
@@ -63,11 +63,6 @@ main div.codeblock-wrapper div.codeblock .control-bar select:hover::picker-icon 
   color: rgb(255, 255, 255);
 }
 
-main div.codeblock-wrapper div.codeblock .control-bar select:focus-visible
-{
-  outline: none;
-}
-
 main div.codeblock-wrapper div.codeblock .control-bar .tabs-list button p {
   margin: 0;
 }


### PR DESCRIPTION
## Description
Put focus outline back for keyboard accessibility.

We removed the focus outline previously (in https://github.com/AdobeDocs/adp-devsite/pull/83) thinking it was a bug, but it turns out it's a feature.

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1518

## Test
1. Go to https://devsite-1518-codeblock-a11y--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/code-block-with-picklist
2. Press `Tab` (to go forward) or `Shift + Tab` (to go backward) repeatedly until you get to `select`, and then press `up` or `down` to choose options from the dropdown list.

## Before
Notice how there's an outline for the tabs and tab panel, but not for select.

![before](https://github.com/user-attachments/assets/169dac3b-7867-4586-8856-42a7c3410c8b)

## After
Notice how there's an outline for tabs, select, and tab panel.

![after](https://github.com/user-attachments/assets/49e0bf3f-0768-4af3-a87a-e8bb6c5aabca)
