### PR TITLE
fix: discoverblock responsive layout

### DIFF
--- a/hlx_statics/blocks/discoverblock/discoverblock.css
+++ b/hlx_statics/blocks/discoverblock/discoverblock.css
@@ -18,45 +18,13 @@ main div.discoverblock-wrapper div.discover-img-child-container {
     width: 50%;
 }
 
-@media screen and (max-width : 1300px) {
-    main div.discoverblock-wrapper .discoverblock {
-        width: 768px !important;
-    }
-
-    main div.discoverblock-wrapper div.discover-child-container {
-        width: 33.3%;
-        padding: 20px;
-    }
-}
-
-@media screen and (max-width : 800px) {
-    main div.discoverblock-wrapper .discoverblock {
-        width: 600px !important;
-    }
-
-    main div.discoverblock-wrapper div.discover-child-container {
-        width: 50%;
-        padding:20px;
-    }
-}
-
-@media screen and (max-width : 650px) {
-    main div.discoverblock-wrapper .discoverblock {
-        width: 370px !important;
-    }
-
-    main div.discoverblock-wrapper div.discover-child-container {
-        width: 100%;
-        padding: 20px;
-    }
-}
-main div.discoverblock-wrapper div.discoverblock-container-wrapper{
-    max-width: 800px;
+main div.discoverblock-wrapper div.discoverblock-container-wrapper {
     display: flex;
     flex-wrap: wrap;
-    column-gap: 50px;
-    row-gap: 40px;
+    column-gap: 30px;
+    row-gap: 30px;
 }
+
 main div.discoverblock-wrapper div.discoverblock-column .discover-child-container{
     width: 650px;
     display: flex;


### PR DESCRIPTION
## Description
**Issue:** discoverBlock is too narrow for smaller breakpoints and not reflowing to use available space
**Fix:** make layout more fluid by removing hard-coded widths, make gaps smaller to allocate more space to content

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1630

## Test
- before: https://main--adp-devsite-stage--adobedocs.aem.page/developer-console/docs/guides/
- after: https://devsite-1630--adp-devsite-stage--adobedocs.aem.page/developer-console/docs/guides/
- compare with gatsby: https://developer.adobe.com/photoshop/uxp/2022/

## Before
![before](https://github.com/user-attachments/assets/59837074-8ecb-4565-92f0-96977d3fba4c)


## After
![after](https://github.com/user-attachments/assets/eb59eb6b-97a1-429d-acb6-d267f4eb1e64)
