### PR TITLE
fix: header responsiveness

### DIFF
--- a/hlx_statics/blocks/header/header.js
+++ b/hlx_statics/blocks/header/header.js
@@ -365,89 +365,54 @@ export default async function decorate(block) {
   // Handle navigation based on source
   if (isSourceGithub()) {
     // Create navigation for docs from github (desktop only)
-    if (window.innerWidth > 768) {
-      let navigationLinks = createTag('ul', { id: 'navigation-links', class: 'menu desktop-nav', style: 'list-style-type: none;'});
 
-      // Add Products link for documentation template
-      if (isTopLevelNav(window.location.pathname)) {
-        const homeLinkLi = createTag('li', {class: 'navigation-home'});
-        const homeLinkA = createTag('a', {href: 'https://developer.adobe.com', 'daa-ll': 'Home', 'fullPath': true});
-        homeLinkA.innerHTML = 'Products';
-        homeLinkLi.append(homeLinkA);
-        navigationLinks.append(homeLinkLi);
-      } else {
-        const productLi = createTag('li', {class: 'navigation-products'});
-        const productA = createTag('a', {href: 'https://developer.adobe.com/apis', 'daa-ll': 'Products',  'fullPath': true});
-        productA.innerHTML = 'Products';
-        productLi.append(productA);
-        navigationLinks.append(productLi);
-      }
+    let navigationLinks = createTag('ul', { id: 'navigation-links', class: 'menu desktop-nav', style: 'list-style-type: none;'});
 
-      const topNavHtml = await fetchTopNavHtml();
-      if (topNavHtml) {
-        navigationLinks.innerHTML += topNavHtml;
+    // Add Products link for documentation template
+    if (isTopLevelNav(window.location.pathname)) {
+      const homeLinkLi = createTag('li', {class: 'navigation-home'});
+      const homeLinkA = createTag('a', {href: 'https://developer.adobe.com', 'daa-ll': 'Home', 'fullPath': true});
+      homeLinkA.innerHTML = 'Products';
+      homeLinkLi.append(homeLinkA);
+      navigationLinks.append(homeLinkLi);
+    } else {
+      const productLi = createTag('li', {class: 'navigation-products'});
+      const productA = createTag('a', {href: 'https://developer.adobe.com/apis', 'daa-ll': 'Products',  'fullPath': true});
+      productA.innerHTML = 'Products';
+      productLi.append(productA);
+      navigationLinks.append(productLi);
+    }
 
-        // Process dropdowns for documentation template navigation
-        navigationLinks.querySelectorAll('li > ul').forEach((dropDownList, index) => {
-          let dropdownLinkDropdownHTML = '';
-          let dropdownLinksHTML = '';
+    const topNavHtml = await fetchTopNavHtml();
+    if (topNavHtml) {
+      navigationLinks.innerHTML += topNavHtml;
 
-          dropDownList.querySelectorAll('ul > li > a').forEach((dropdownLinks) => {
-            dropdownLinksHTML
-              += globalNavLinkItemDropdownItem(dropdownLinks.href, dropdownLinks.innerText);
-          });
+      // Process dropdowns for documentation template navigation
+      navigationLinks.querySelectorAll('li > ul').forEach((dropDownList, index) => {
+        let dropdownLinkDropdownHTML = '';
+        let dropdownLinksHTML = '';
 
-          dropdownLinkDropdownHTML = globalNavLinkItemDropdown(
-            index,
-            dropDownList.parentElement.firstChild.textContent.trim(),
-            dropdownLinksHTML,
-          );
-          dropDownList.parentElement.innerHTML = dropdownLinkDropdownHTML;
+        dropDownList.querySelectorAll('ul > li > a').forEach((dropdownLinks) => {
+          dropdownLinksHTML
+            += globalNavLinkItemDropdownItem(dropdownLinks.href, dropdownLinks.innerText);
         });
 
-        header.append(navigationLinks);
-      }
+        dropdownLinkDropdownHTML = globalNavLinkItemDropdown(
+          index,
+          dropDownList.parentElement.firstChild.textContent.trim(),
+          dropdownLinksHTML,
+        );
+        dropDownList.parentElement.innerHTML = dropdownLinkDropdownHTML;
+      });
+
+      header.append(navigationLinks);
     }
+    
 
     // Handle mobile menu button for side nav
-    if (window.innerWidth <= 768) {
-      handleMenuButton(header);
-    }
+    handleMenuButton(header);
+    
 
-    // Update navigation visibility on resize
-    window.addEventListener('resize', async () => {
-      let navigationLinks = header.querySelector('#navigation-links');
-      if (window.innerWidth > 768) {
-        if (!navigationLinks) {
-          navigationLinks = createTag('ul', { id: 'navigation-links', class: 'menu desktop-nav', style: 'list-style-type: none;'});
-
-          // Add Products link for documentation template
-          if (isTopLevelNav(window.location.pathname)) {
-            const homeLinkLi = createTag('li', {class: 'navigation-home'});
-            const homeLinkA = createTag('a', {href: 'https://developer.adobe.com', 'daa-ll': 'Home'});
-            homeLinkA.innerHTML = 'Products';
-            homeLinkLi.append(homeLinkA);
-            navigationLinks.append(homeLinkLi);
-          } else {
-            const productLi = createTag('li', {class: 'navigation-products'});
-            const productA = createTag('a', {href: 'https://developer.adobe.com/apis', 'daa-ll': 'Products'});
-            productA.innerHTML = 'Products';
-            productLi.append(productA);
-            navigationLinks.append(productLi);
-          }
-
-          const topNavHtml = await fetchTopNavHtml();
-          if (topNavHtml) {
-            navigationLinks.innerHTML += topNavHtml;
-            header.append(navigationLinks);
-          }
-        }
-      } else {
-        if (navigationLinks) {
-          navigationLinks.remove();
-        }
-      }
-    });
   } else {
     // Create navigation for non-documentation pages
     let navigationLinks = createTag('ul', { id: 'navigation-links', class: 'menu', style: 'list-style-type: none;'});


### PR DESCRIPTION
## Description
**Issue:** Resize to mobile > resize back to desktop > notice header is messed up
<img width="1154" alt="Screenshot 2025-05-30 at 12 57 14 PM" src="https://github.com/user-attachments/assets/fef6d042-5d74-447c-ba26-17a66976a27d" />


**Root-cause:** Appending `topNavHtml` on resize loses the buttons and icons etc.
- https://github.com/AdobeDocs/adp-devsite/blob/042aa9ed2439735d7c9ff842b918722c64f8debb/hlx_statics/blocks/header/header.js#L439-L443


**Fix:** Remove unnecessary code in `header.js` because `header.css` is already handling responsiveness
- https://github.com/AdobeDocs/adp-devsite/blob/042aa9ed2439735d7c9ff842b918722c64f8debb/hlx_statics/blocks/header/header.js#L368
- https://github.com/AdobeDocs/adp-devsite/blob/042aa9ed2439735d7c9ff842b918722c64f8debb/hlx_statics/blocks/header/header.js#L413
- https://github.com/AdobeDocs/adp-devsite/blob/042aa9ed2439735d7c9ff842b918722c64f8debb/hlx_statics/blocks/header/header.js#L417-L444

## Test
https://devsite-1668--adp-devsite-stage--adobedocs.aem.page/developer-distribution/creative-cloud/docs/

## Before
![before](https://github.com/user-attachments/assets/4e2a13e3-a62e-4973-b299-c4378bfa9bf0)



## After
![after](https://github.com/user-attachments/assets/f8a44e5b-9250-45c7-8f65-0d64ffa99a9a)

