### PR TITLE
fix: inline-code overflow

### DIFF
--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -252,7 +252,9 @@ main .inline-code {
   background-color: rgb(245, 245, 245);
   padding: 0 2px;
   margin: 0;
-  display: inline-block;
+  display: inline;
+  word-wrap: break-word;
+  white-space: pre-wrap;
   min-width: auto;
   border: 0.8px solid rgb(213, 213, 213);
   border-radius: 3px;


### PR DESCRIPTION
## Description
Long inline-codes overflow outside of grid

## Test
1. https://inline-code-overflow--adp-devsite-stage--adobedocs.aem.page/express/add-ons/docs/guides/build/design/implementation-guide
2. Scroll down to inline-code
3. Make screen width narrower than inline-code width

## Before
<img width="832" alt="before" src="https://github.com/user-attachments/assets/9a054cad-3ea7-4e3e-90e5-7dc3455bc897" />

## After
<img width="832" alt="after" src="https://github.com/user-attachments/assets/fa8b2c56-df0f-4767-99de-fefe9a197adb" />

