### PR TITLE
fix: show sidenav if path exists in config subpages

### DIFF
--- a/hlx_statics/blocks/side-nav/side-nav.css
+++ b/hlx_statics/blocks/side-nav/side-nav.css
@@ -330,7 +330,7 @@ main div.side-nav-wrapper .side-nav-subpages-section .side-nav-section-label {
   padding: 0 8px;
 }
 
-main div.side-nav-wrapper .side-nav .side-nav-subpages-section .hide-sidenav {
+main div.side-nav-wrapper .side-nav .side-nav-subpages-section .hidden {
     display:none;
 }
 

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -488,12 +488,12 @@ function activeSubNav(actTab) {
   if (actTab) {
     const navLinksUl = document.querySelector(".side-nav-subpages-section");
     const firstLevelItems = navLinksUl.querySelectorAll(':scope > ul > li');
-    const currentPath = actTab.pathname;
+    const topNavPath = actTab.pathname;
     firstLevelItems.forEach(li => {
       const link = li.querySelector(':scope > a');
       if (link) {
         const linkPath = new URL(link.href, window.location.origin).pathname;
-        if (currentPath === linkPath || linkPath.startsWith(currentPath)) {
+        if (topNavPath === linkPath || linkPath.startsWith(topNavPath)) {
           li.classList.add('active-sidenav-item');
         } else {
           li.classList.add('hidden');

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -487,15 +487,17 @@ function activateTab(tabItem, isMainPage) {
 function activeSubNav(actTab) {
   if (actTab) {
     const navLinksUl = document.querySelector(".side-nav-subpages-section");
-    const firstLevelItems = navLinksUl.querySelectorAll(':scope > ul > li');
+    const sidenavItems = navLinksUl.querySelectorAll(':scope > ul li');
     const topNavPath = actTab.pathname;
-    firstLevelItems.forEach(li => {
+    const pagePath = window.location.pathname;
+    sidenavItems.forEach(li => {
       const link = li.querySelector(':scope > a');
       if (link) {
         const linkPath = new URL(link.href, window.location.origin).pathname;
-        if (topNavPath === linkPath || linkPath.startsWith(topNavPath)) {
+        if (linkPath === pagePath) {
           li.classList.add('active-sidenav-item');
-        } else {
+        } 
+        if (!linkPath.startsWith(topNavPath)) {
           li.classList.add('hidden');
         }
       } else {

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -496,10 +496,10 @@ function activeSubNav(actTab) {
         if (currentPath === linkPath || linkPath.startsWith(currentPath)) {
           li.classList.add('active-sidenav');
         } else {
-          li.classList.add('hide-sidenav');
+          li.classList.add('hidden');
         }
       } else {
-        li.classList.add('hide-sidenav');
+        li.classList.add('hidden');
       }
     });
   }

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -494,7 +494,7 @@ function activeSubNav(actTab) {
       if (link) {
         const linkPath = new URL(link.href, window.location.origin).pathname;
         if (currentPath === linkPath || linkPath.startsWith(currentPath)) {
-          li.classList.add('active-sidenav');
+          li.classList.add('active-sidenav-item');
         } else {
           li.classList.add('hidden');
         }
@@ -503,7 +503,7 @@ function activeSubNav(actTab) {
       }
     });
   }
-  if (document.querySelectorAll(".active-sidenav")?.length === 0 ) {
+  if (document.querySelectorAll(".active-sidenav-item")?.length === 0 ) {
     document.querySelector("main").classList.add("no-sidenav");
     const gridAreaMain = document.querySelector('main > div[style*="grid-area: main"]');
     const hasHero = Boolean(document.querySelector('.hero, .herosimple'));

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -485,6 +485,7 @@ function activateTab(tabItem, isMainPage) {
 }
 
 function activeSubNav(actTab) {
+  let showSidenav = false;
   if (actTab) {
     const navLinksUl = document.querySelector(".side-nav-subpages-section");
     const sidenavItems = navLinksUl.querySelectorAll(':scope > ul li');
@@ -495,7 +496,7 @@ function activeSubNav(actTab) {
       if (link) {
         const linkPath = new URL(link.href, window.location.origin).pathname;
         if (linkPath === pagePath) {
-          li.classList.add('active-sidenav-item');
+          showSidenav = true;
         } 
         if (!linkPath.startsWith(topNavPath)) {
           li.classList.add('hidden');
@@ -505,7 +506,7 @@ function activeSubNav(actTab) {
       }
     });
   }
-  if (document.querySelectorAll(".active-sidenav-item")?.length === 0 ) {
+  if (!showSidenav) {
     document.querySelector("main").classList.add("no-sidenav");
     const gridAreaMain = document.querySelector('main > div[style*="grid-area: main"]');
     const hasHero = Boolean(document.querySelector('.hero, .herosimple'));


### PR DESCRIPTION
## Description
Show sidenav if page exists in `config.md`'s `subPages`

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1723

## Test
- without sidenav: https://devsite-1723-show-sidenav--adp-devsite--adobedocs.aem.live/github-actions-test/test/no-sidenav-2
- with sidenav: https://devsite-1723-show-sidenav--adp-devsite--adobedocs.aem.live/github-actions-test/test/code
- config.md: https://devsite-1723-show-sidenav--adp-devsite--adobedocs.aem.live/github-actions-test/config.md

## Before
<img width="1728" alt="before" src="https://github.com/user-attachments/assets/02523174-dce1-4fb1-99f5-788a25d8e1e7" />

## After
<img width="1728" alt="Screenshot 2025-06-05 at 11 25 47 AM" src="https://github.com/user-attachments/assets/1c2ecfe5-24cd-4cb7-859d-42528774e4ed" />



