### PR TITLE
refactor: clean up because sidenav is only devdocs

### DIFF
--- a/hlx_statics/blocks/side-nav/side-nav.js
+++ b/hlx_statics/blocks/side-nav/side-nav.js
@@ -4,37 +4,13 @@ import {
 import {
   fetchSideNavHtml,
   fetchTopNavHtml,
-  getMetadata,
 } from "../../scripts/lib-helix.js";
-
-function isDocumentationTemplate() {
-  return getMetadata("template") === "documentation";
-}
-
-function isMobileView() {
-  return window.innerWidth <= 768;
-}
 
 /**
  * Decorates the side-nav
  * @param {Element} block The site-nav block element
  */
 export default async function decorate(block) {
-  // Handle visibility of side nav container based on template and screen size
-  const sideNavContainer = block.closest('.side-nav-container');
-  if (!isDocumentationTemplate() && sideNavContainer) {
-    // For non-documentation pages, only show on mobiles
-    const updateVisibility = () => {
-      sideNavContainer.style.display = isMobileView() ? 'block' : 'none';
-    };
-
-    // Initial visibility
-    updateVisibility();
-
-    // Update visibility on resize
-    window.addEventListener('resize', updateVisibility);
-  }
-
   const navigationLinks = createTag("nav", { role: "navigation" });
   navigationLinks.setAttribute("aria-label", "Primary");
 


### PR DESCRIPTION
## Description
Clean up unused sidenav logic
- remove `if (isSourceGithub()) {` condition and else statement because sidenav is only DevDocs
- remove unneeded event listener to hide sidenav in mobile view because it's being already hidden without it

## Context
- [isSourceGithub()](https://github.com/aemsites/devsite-runtime-connector/blob/ec0fbe99c7f387151a72b04571ec9c87e3d52139/src/steps/stringify.ts#L31) is a way to check for DevDocs (which goes through the connector), else is for DevBiz (which doesn't go through the connector) 
- Sidenav is [only DevDocs](https://adobeio.slack.com/archives/C06M1C7UBV3/p1749154072767309)

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1723

## Test
1. Go to a page with a sidenav such as https://main--adp-devsite-stage--adobedocs.aem.page/express/add-ons/docs/samples
2. 