### PR TITLE
refactor: grid-template-columns

### DIFF
--- a/hlx_statics/blocks/side-nav/side-nav.css
+++ b/hlx_statics/blocks/side-nav/side-nav.css
@@ -226,10 +226,6 @@ main div.section.side-nav-container {
 
 /* Mobile behavior */
 @media screen and (max-width: 768px) {
-  /* Adjust grid layout */
-  body.template-documentation main {
-    grid-template-columns: 0 100% !important;
-  }
   main div.section.side-nav-container {
       visibility: visible;
   }

--- a/hlx_statics/blocks/side-nav/side-nav.js
+++ b/hlx_statics/blocks/side-nav/side-nav.js
@@ -42,25 +42,6 @@ export default async function decorate(block) {
   navigationLinksContainer.append(subPagesSection);
   subPagesSection.append(navigationLinksUl);
 
-  // Set grid layout based on screen size
-  const main = document.querySelector("main");
-  if (main) {
-    if (window.innerWidth <= 768) {
-      main.style.gridTemplateColumns = "0 100%";
-    } else {
-      main.style.gridTemplateColumns = "256px minmax(0, 1fr)";
-    }
-
-    // Update grid on window resize
-    window.addEventListener("resize", () => {
-      if (window.innerWidth <= 768) {
-        main.style.gridTemplateColumns = "0 100%";
-      } else {
-        main.style.gridTemplateColumns = "256px minmax(0, 1fr)";
-      }
-    });
-  }
-
   const rightIcon = `<svg xmlns="http://www.w3.org/2000/svg" height="18" viewBox="0 0 18 18" width="18">
     <rect id="Canvas" fill="#ff13dc" opacity="0" width="18" height="18" />
     <path class="fill" d="M12,9a.994.994,0,0,1-.2925.7045l-3.9915,3.99a1,1,0,1,1-1.4355-1.386l.0245-.0245L9.5905,9,6.3045,5.715A1,1,0,0,1,7.691,4.28l.0245.0245,3.9915,3.99A.994.994,0,0,1,12,9Z" />

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -181,16 +181,9 @@ async function loadEager(doc) {
     // check if this page is from dev docs, then change the main container to white background.
     const mainContainer = document.querySelector('main');
     mainContainer.classList.add('white-background');
-  }
 
-
-  if (IS_DEV_DOCS) {
     buildGrid(main);
-  }
-
-  buildSideNav(main);
-
-  if (IS_DEV_DOCS) {
+    buildSideNav(main);
     buildBreadcrumbs(main);
   }
 

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -161,6 +161,17 @@ main {
 main.white-background {
   background-color: white;
 }
+
+body.documentation main {
+  grid-template-columns: 256px minmax(0, 1fr);
+}
+
+@media screen and (max-width: 768px) {
+  body.documentation main {
+    grid-template-columns: 0 100%;
+  }
+}
+
 main.no-sidenav{
   grid-template-areas: "main" "footer" !important;
   grid-template-columns: 100% 100% !important;


### PR DESCRIPTION
## Description
- replace resize handlers in `sidenav.js` with media queries in `styles.css`
- move `grid-template-columns` for `main` out of `sidenav.js` and `sidenav.css` and into `styles.css`
- combine checks for `if (IS_DEV_DOCS)` and include `buildSideNav()` because sidenav is only DevDocs (follow-up to  https://github.com/AdobeDocs/adp-devsite/pull/208)

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1723

## Test
1. Go to a DevDocs page with a sidenav such as https://devsite-1723-grid-cols--adp-devsite-stage--adobedocs.aem.page/express/add-ons/docs/samples
2. Resize window to mobile
3. Confirm sidenav is hidden
4. Resize window to desktop
5. Confirm sidenav is shown
6. Go to a DevBiz page such as https://devsite-1723-grid-cols--adp-devsite-stage--adobedocs.aem.page/commerce/index-onerepo
7. Open up chrome dev tools > elements tab > select `main` > in computed tab, confirm [sidenav style](https://github.com/AdobeDocs/adp-devsite/blob/9463c101350ba185bce744af9d89a1a4a51df2cb/hlx_statics/styles/styles.css#L165-L173) isn't applied

## Screenshot
![Untitled](https://github.com/user-attachments/assets/60348663-3a7e-4f1a-82ef-fbd44459c1f1)

<img width="1728" alt="Screenshot 2025-06-06 at 1 56 16 PM" src="https://github.com/user-attachments/assets/d43dcfa3-b314-4e2e-a424-2b4de0133bd3" />
<img width="1728" alt="Screenshot 2025-06-06 at 1 53 54 PM" src="https://github.com/user-attachments/assets/e7a1f3fa-b397-4fb9-8c74-7f4364881463" />


