### PR TITLE
Devsite 1716

### DIFF
--- a/hlx_statics/blocks/herosimple/herosimple.css
+++ b/hlx_statics/blocks/herosimple/herosimple.css
@@ -52,6 +52,25 @@ main div.herosimple-wrapper div.halfWidth>div.herosimple-container-wrapper {
   flex-direction: row;
 }
 
+main div.herosimple-wrapper div.fullWidth>div {
+  align-items: center;
+  text-align: center;
+}
+
+main div.herosimple-wrapper div.fullWidth>div>div {
+  width: unset;
+}
+
+main div.herosimple-wrapper div.button-container > p ,
+main div.herosimple-wrapper .all-button-container > p {
+  margin: 0;
+}
+
+main div.herosimple-wrapper .all-button-container {
+  display: inline-flex;
+  gap: 16px;
+}
+
 @media screen and (min-width: 320px) and (max-width: 767px) {
   main div.herosimple-wrapper div.herosimple div.hero-right-image img {
     width: 300px;

--- a/hlx_statics/blocks/herosimple/herosimple.css
+++ b/hlx_statics/blocks/herosimple/herosimple.css
@@ -4,7 +4,7 @@ main div.herosimple-wrapper {
 main div.herosimple-wrapper div.herosimple {
   height: 272px;
   overflow: hidden;
-  color: rgb(255, 255, 255);
+  /* color: rgb(255, 255, 255); */
   position: relative;
 }
 
@@ -21,6 +21,41 @@ main div.herosimple-wrapper div.herosimple > div {
 main div.herosimple-wrapper div.herosimple > div > div{
   width: calc(5* 100% / 12);
   font-size: 20px;
+}
+
+main div.herosimple-wrapper div.herosimple .hero-left-content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+main div.herosimple-wrapper div.herosimple div.hero-left-content>div {
+  display: flex;
+  gap: 30px;
+  flex-direction: column;
+}
+
+main div.herosimple-wrapper div.herosimple div.hero-left-content,
+main div.herosimple-wrapper div.herosimple div.hero-right-image {
+  width: 50%;
+}
+
+main div.herosimple-wrapper div.herosimple div.hero-right-image img {
+  width: 600px;
+}
+
+main div.herosimple-wrapper div.halfWidth {
+  height: unset;
+}
+
+main div.herosimple-wrapper div.halfWidth>div.herosimple-container-wrapper {
+  flex-direction: row;
+}
+
+@media screen and (min-width: 320px) and (max-width: 767px) {
+  main div.herosimple-wrapper div.herosimple div.hero-right-image img {
+    width: 300px;
+  }
 }
 
 @media screen and (max-width: 1280px) {

--- a/hlx_statics/blocks/herosimple/herosimple.js
+++ b/hlx_statics/blocks/herosimple/herosimple.js
@@ -1,14 +1,30 @@
-import { createTag } from "../../scripts/lib-adobeio.js";
+import { createTag, decorateButtons } from "../../scripts/lib-adobeio.js";
 
 /**
  * decorates the herosimple
  * @param {Element} block The herosimple block element
  */
+
+function normalizeButtonContainer(block) {
+  block.querySelectorAll('a').forEach((anchor, i) => {
+    const p = createTag('p');
+    const node = i === 0 ? createTag('strong') : p;
+    node.appendChild(anchor.cloneNode(true));
+    p.appendChild(node === p ? node.firstChild : node);
+    anchor.replaceWith(p);
+  });
+
+  const lastGroup = block.lastElementChild?.lastElementChild;
+  if (lastGroup && [...lastGroup.children].every(child => child.tagName === 'P')) {
+    lastGroup.classList.add('all-button-container');
+  }
+}
+
 export default async function decorate(block) {
   const background = block.getAttribute('data-background') || 'rgb(29, 125, 238)';
   block.style.background = background;
 
-  const variant = block.getAttribute('data-variant') || 'fullWidth';
+  const variant = block.getAttribute('data-variant') || 'default';
   block.classList.add(variant);
 
   const textColor = block.getAttribute('data-textcolor') || 'rgb(44, 44, 44)';
@@ -22,6 +38,7 @@ export default async function decorate(block) {
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     const fontFamily = block?.parentElement?.parentElement?.getAttribute('data-font-family');
     const headerFontSize = block?.parentElement?.parentElement?.getAttribute('data-HeaderFontSize');
+    h.style.color = textColor;
     if (fontFamily) {
       h.style.fontFamily = fontFamily;
       h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeXXL');
@@ -38,9 +55,13 @@ export default async function decorate(block) {
   const srcsetValue = sourceElement ? sourceElement?.getAttribute('srcset') : null;
   const url = srcsetValue?.split(' ')[0];
   const pictureElement = block.querySelector('picture');
-  if (pictureElement && variant === "fullWidth") {
-    const parentDiv = pictureElement.parentElement;
-    parentDiv.remove();
+
+  if (pictureElement && variant === "fullWidth" || variant === "default") {
+    const parentDiv = pictureElement?.parentElement;
+
+    if (parentDiv)
+      parentDiv.remove();
+    
     Object.assign(block.style, {
       backgroundImage: `url(${url})`,
       backgroundSize: 'cover',
@@ -60,5 +81,8 @@ export default async function decorate(block) {
     layoutWrapper.append(contentContainer, imageContainer);
     block.appendChild(layoutWrapper);
   }
+
+  normalizeButtonContainer(block);
+  decorateButtons(block);
 
 }

--- a/hlx_statics/blocks/herosimple/herosimple.js
+++ b/hlx_statics/blocks/herosimple/herosimple.js
@@ -1,11 +1,22 @@
+import { createTag } from "../../scripts/lib-adobeio.js";
+
 /**
  * decorates the herosimple
  * @param {Element} block The herosimple block element
  */
 export default async function decorate(block) {
+  const background = block.getAttribute('data-background') || 'rgb(29, 125, 238)';
+  block.style.background = background;
 
-  const backgroundColor = block.getAttribute('data-background') || 'rgb(29, 125, 238)';
-  block.style.backgroundColor = backgroundColor;
+  const variant = block.getAttribute('data-variant') || 'fullWidth';
+  block.classList.add(variant);
+
+  const textColor = block.getAttribute('data-textcolor') || 'rgb(44, 44, 44)';
+  block.style.color = textColor;
+
+  const layoutWrapper = createTag('div', { class: "herosimple-container-wrapper" });
+  const contentContainer = createTag('div', { class: "hero-left-content" });
+  const imageContainer = createTag('div', { class: "hero-right-image" });
 
   block.setAttribute('daa-lh', 'hero');
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
@@ -22,12 +33,12 @@ export default async function decorate(block) {
     }
 
   });
-  
+
   const sourceElement = block.querySelector('source[type="image/webp"]');
   const srcsetValue = sourceElement ? sourceElement?.getAttribute('srcset') : null;
   const url = srcsetValue?.split(' ')[0];
   const pictureElement = block.querySelector('picture');
-  if(pictureElement){
+  if (pictureElement && variant === "fullWidth") {
     const parentDiv = pictureElement.parentElement;
     parentDiv.remove();
     Object.assign(block.style, {
@@ -37,4 +48,17 @@ export default async function decorate(block) {
       backgroundRepeat: 'no-repeat'
     });
   }
+
+  else if (pictureElement && variant === "halfWidth") {
+    const pictureWrapper = pictureElement.closest('div') || pictureElement;
+
+    imageContainer.appendChild(pictureWrapper);
+
+    Array.from(block.children).filter(div => !div.contains(pictureElement)).forEach(div => contentContainer.appendChild(div));
+
+    block.innerHTML = '';
+    layoutWrapper.append(contentContainer, imageContainer);
+    block.appendChild(layoutWrapper);
+  }
+
 }

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -620,7 +620,7 @@ main .heading6 h6>span {
 }
 
 .spectrum-Heading--sizeXXL {
-  color: rgb(44, 44, 44);
+  /* color: rgb(44, 44, 44); */
 }
 
 .spectrum-Heading--sizeXL {

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -620,7 +620,7 @@ main .heading6 h6>span {
 }
 
 .spectrum-Heading--sizeXXL {
-  /* color: rgb(44, 44, 44); */
+  color: rgb(44, 44, 44);
 }
 
 .spectrum-Heading--sizeXL {


### PR DESCRIPTION
## Description

Created the inline image for the Hero block with three variants (`default`, `fullWidth`, and `halfWidth`).  
Customized the text color in the Hero block using the `textColor` prop and added support for buttons.

## Issue

https://jira.corp.adobe.com/browse/DEVSITE-1716

## Test URLs

### Half Width Variant (Single Button)

- Previous: https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/test-hr-0  
- Updated: https://devsite-1716--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/test-hr-0

### Full Width Variant (Multiple Buttons)

- Previous: https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/test-hero  
- Updated: https://devsite-1716--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/test-hero

### Default Variant

- Previous: https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/test-file  
- Updated: https://devsite-1716--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/test-file

### Full Width Variant (Single Button)

- Previous: https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/list-block  
- Updated: https://devsite-1716--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/list-block

## Clarification

Comment 1 : https://github.com/AdobeDocs/adp-devsite/commit/cb8c293ba022ce167b9a6dcc37f9b61a8038b767#r159576681

https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/test-file

On the above page, you can see a difference in the heading and text color. When we comment out that line, both the heading and text appear in the same color.

https://devsite-1716--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/test-file

Comment 2 : https://github.com/AdobeDocs/adp-devsite/commit/cb8c293ba022ce167b9a6dcc37f9b61a8038b767#r159576268

Resolved
