### PR TITLE
update load title

### DIFF
--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -486,7 +486,7 @@ function loadDelayed() {
 }
 
 function loadTitle() {
-  document.title = window.location.href;
+  document.title =  document.title ? document.title : window.location.href;
 }
 
 function loadPrism(document) {

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -486,7 +486,9 @@ function loadDelayed() {
 }
 
 function loadTitle() {
-  document.title =  document.title ? document.title : window.location.href;
+  if (!document.title || document.title === '') {
+    document.title = window.location.href;
+  }
 }
 
 function loadPrism(document) {


### PR DESCRIPTION
The connector is now returning title if it exists. This update will make sure the document.title is reflected.   
https://devsite-1733-update-title-name--adp-devsite--adobedocs.aem.page/developer-distribution/creative-cloud/docs/guides/branding-guidelines