### PR TITLE
Fix : unify inline-code font size

### DIFF
--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -325,7 +325,7 @@ main .inline-code {
   line-height: 1.5rem;
 }
 
-main .default-content-wrapper .header-content a .inline-code , .default-content-wrapper .header-content .inline-code , div.heading3-wrapper .inline-code , div.table-wrapper .table .inline-code {
+main .default-content-wrapper .header-content a .inline-code , .default-content-wrapper .header-content .inline-code , div.block .inline-code {
   font-size: 16px;
 }
 


### PR DESCRIPTION

**Fix :** Apply consistent font size to inline-code elements across headings and tables.

**For heading2 :**

Previous :  https://stage--adp-devsite-stage--adobedocs.aem.page/express/embed-sdk/docs/guides/concepts/appconfig 

Updated :  https://fix-inline-code--adp-devsite-stage--adobedocs.aem.page/express/embed-sdk/docs/guides/concepts/appconfig


**For heading1 :**

Previous :  https://stage--adp-devsite-stage--adobedocs.aem.page/express/embed-sdk/docs/v4/sdk/src/cc-everywhere-base/classes/cc-everywhere-base

Updated :  https://fix-inline-code--adp-devsite-stage--adobedocs.aem.page/express/embed-sdk/docs/v4/sdk/src/cc-everywhere-base/classes/cc-everywhere-base


**For heading5 and table inline-code :**

Previous :  https://stage--adp-devsite-stage--adobedocs.aem.page/express/add-ons/docs/references/addonsdk/addonsdk-app

Updated :  https://fix-inline-code--adp-devsite-stage--adobedocs.aem.page/express/add-ons/docs/references/addonsdk/addonsdk-app