### PR TITLE
fix : cta = devbiz overgradiant

### DIFF
--- a/hlx_statics/blocks/announcement/announcement.css
+++ b/hlx_statics/blocks/announcement/announcement.css
@@ -107,6 +107,14 @@ main div.announcement-wrapper .announcement.secondary-border-white .spectrum-But
   border-color: white !important;
 }
 
+main div.announcement-wrapper p.button-container.over-gradiant a {
+  font-size: 16px;
+}
+
+main div.announcement-wrapper p.button-container.over-gradiant a:hover {
+  background: rgb(213,213,213);
+}
+
 @media screen and (max-width: 1024px) {
   main .announcement-wrapper>.block>div {
     margin: 0 !important;

--- a/hlx_statics/blocks/announcement/announcement.js
+++ b/hlx_statics/blocks/announcement/announcement.js
@@ -84,7 +84,12 @@ export default async function decorate(block) {
       block.classList.add("background-color-gray");
     }
   }
-  decorateButtons(block);
+  if( block.querySelectorAll('.button-container')?.length > 0){
+    block.querySelectorAll('.button-container').forEach((btn)=>btn.classList.add('over-gradiant'))
+  }
+  const isOverGradient = block.classList.contains('over-gradient');
+  const color = isOverGradient ? 'white' : undefined;
+  decorateButtons(block, color, color);
   removeEmptyPTags(block);
   rearrangeLinks(block);
   setBackgroundImage(block);


### PR DESCRIPTION
## Description

DevBiz CTA buttons
Tim Suggest : For the Embed SDK outline button, again I think we can add a block option like "over-gradient" so the second button can be applied with the white text and outline. 

## Issue

https://jira.corp.adobe.com/browse/DEVSITE-1785

## Test URL 

Previous : https://main--adp-devsite--adobedocs.aem.page/test/baskar/image-text-block
Updated : https://fix-cta-overgradiant--adp-devsite--adobedocs.aem.page/test/baskar/image-text-block

