### PR TITLE
fix: discoverblock overflow

### DIFF
--- a/hlx_statics/blocks/discoverblock/discoverblock.css
+++ b/hlx_statics/blocks/discoverblock/discoverblock.css
@@ -39,4 +39,5 @@ main div.discoverblock-wrapper .discover-child-container{
     display: flex;
     flex-direction: column;
     gap: 10px;
+    max-width: 100%;
 }


### PR DESCRIPTION
## Description
Fix `discoverblock` overflow

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1751

## Before
https://stage--adp-devsite-stage--adobedocs.aem.page/app-builder/docs/resources/blog-articles

<img width="524" alt="Screenshot 2025-07-04 at 7 04 20 AM" src="https://github.com/user-attachments/assets/2411f218-eb0a-4d44-a8fc-e1b53861caa3" />

## After
https://devsite-1751--adp-devsite-stage--adobedocs.aem.page/app-builder/docs/resources/blog-articles
<img width="519" alt="Screenshot 2025-07-04 at 7 07 41 AM" src="https://github.com/user-attachments/assets/e2398f33-beae-41f4-83db-d1fcc4db7945" />

