### PR TITLE
fix: onthispage right margin

### DIFF
--- a/hlx_statics/blocks/onthispage/onthispage.css
+++ b/hlx_statics/blocks/onthispage/onthispage.css
@@ -3,7 +3,6 @@ main .onthispage-wrapper {
   top: 128px;
   bottom: 0;
   left: 0;
-  width: 224px;
   margin: 128px 32px 0 32px;
   height: calc(100vh - 128px);
   overflow: auto;


### PR DESCRIPTION
## Description
Fix `onthispage` right margin

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1800

## Before
https://stage--adp-devsite-stage--adobedocs.aem.page/app-builder/docs/resources/blog-articles

<img width="1386" alt="Screenshot 2025-07-04 at 8 06 37 AM" src="https://github.com/user-attachments/assets/a9721e19-a922-4d42-b2d7-ec34276b9b4b" />

## After
https://devsite-1800--adp-devsite-stage--adobedocs.aem.page/app-builder/docs/resources/blog-articles



<img width="1380" alt="Screenshot 2025-07-04 at 8 06 50 AM" src="https://github.com/user-attachments/assets/ccd7bb25-4048-48e7-9400-881c2a3d6b62" />
