### PR TITLE
fix : herosimple gap issue

### DIFF
--- a/hlx_statics/blocks/herosimple/herosimple.css
+++ b/hlx_statics/blocks/herosimple/herosimple.css
@@ -49,6 +49,7 @@ main div.herosimple-wrapper div.halfWidth {
 
 main div.herosimple-wrapper div.halfWidth>div.herosimple-container-wrapper {
   flex-direction: row;
+  gap:30px;
 }
 
 main div.herosimple-wrapper div.fullWidth>div {


### PR DESCRIPTION
## Description

Fix the HeroSimple block gap issue in the devdocs

## Test URL

Previous : https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/hero/current/herosimple-halfwidth
Update : https://fix-hero-gap-issue--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/hero/current/herosimple-halfwidth