### PR TITLE
fix: localdev and images

### DIFF
--- a/hlx_statics/scripts/lib-helix.js
+++ b/hlx_statics/scripts/lib-helix.js
@@ -604,7 +604,7 @@ export async function loadBlocks(main) {
 export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 400px)', width: '2000' }, { width: '750' }]) {
   const url = new URL(src, window.location.href);
   const picture = document.createElement('picture');
-  const { pathname } = url;
+  const { origin, pathname } = url;
   const ext = pathname.substring(pathname.lastIndexOf('.') + 1);
 
   // webp
@@ -612,7 +612,7 @@ export function createOptimizedPicture(src, alt = '', eager = false, breakpoints
     const source = document.createElement('source');
     if (br.media) source.setAttribute('media', br.media);
     source.setAttribute('type', 'image/webp');
-    source.setAttribute('srcset', `${pathname}?width=${br.width}&format=webply&optimize=medium`);
+    source.setAttribute('srcset', `${origin}${pathname}?width=${br.width}&format=webply&optimize=medium`);
     picture.appendChild(source);
   });
 
@@ -621,14 +621,14 @@ export function createOptimizedPicture(src, alt = '', eager = false, breakpoints
     if (i < breakpoints.length - 1) {
       const source = document.createElement('source');
       if (br.media) source.setAttribute('media', br.media);
-      source.setAttribute('srcset', `${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
+      source.setAttribute('srcset', `${origin}${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
       picture.appendChild(source);
     } else {
       const img = document.createElement('img');
       img.setAttribute('loading', eager ? 'eager' : 'lazy');
       img.setAttribute('alt', alt);
       picture.appendChild(img);
-      img.setAttribute('src', `${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
+      img.setAttribute('src', `${origin}${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
     }
   });
 

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -36,6 +36,7 @@ import {
   decorateNestedCodes,
   isHlxPath,
   decorateProfile,
+  isLocalHostEnvironment,
   isStageEnvironment,
   isProdEnvironment,
   addExtraScript,
@@ -622,7 +623,30 @@ function loadPrism(document) {
   codeBlocks.forEach((block) => observer.observe(block));
 }
 
+function fixLocalDev(document){
+  if(isLocalHostEnvironment(window.location.host)){
+    // replace all images with eds div structure
+    document.querySelectorAll('img').forEach((img) => {
+      if(img.src.includes('raw.githubusercontent.com')) {
+        const lastDotIndex = img.src.lastIndexOf('.');
+        let imageExtension = '';
+        if (lastDotIndex !== -1) {
+          imageExtension= img.src.substring(lastDotIndex + 1);
+        }
+
+        let picture = createTag('picture');
+        let source = createTag('source', { type: `image/${imageExtension}`, srcset: `${img.src}?width=2000&amp;format=png&amp;optimize=medium`, media: `media="(min-width: 600px)`});
+        let image = createTag('img', { alt: img.alt, src: img.src});
+
+        picture.appendChild(source);
+        picture.appendChild(image);
+        img.replaceWith(picture);
+      }
+    });
+  }
+}
 async function loadPage() {
+  fixLocalDev(document);
   await loadEager(document);
   await loadLazy(document);
   loadPrism(document);


### PR DESCRIPTION
This fixes images when working in local dev mode. The issue is that when in local dev, the html images are just plain img's in a simple div structure eg `<div> <img /> </div>`. However, when a site is deployed in eds, the html structure of images have a `<picture> <source / ><img /></picture`. 

