### PR TITLE
fix : site wide banner covers top nav drop down menu

### DIFF
--- a/hlx_statics/blocks/header/header.css
+++ b/hlx_statics/blocks/header/header.css
@@ -172,7 +172,7 @@ header.global-nav-header {
   border-bottom: 1px solid #eaeaea;
   text-decoration: none;
   background-color: #fff;
-  z-index: 1001;
+  z-index: 1000000;
   padding-left: 32px;
   padding-right: 32px;
   width: 100%;


### PR DESCRIPTION
## Description 

Site wide banner covers top nav drop down menu

## Issue 

https://jira.corp.adobe.com/browse/DEVSITE-1851

## Test URL

Previous : https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/support/contribute/
Update : https://top-nav-cover-issue--adp-devsite-stage--adobedocs.aem.page/github-actions-test/support/contribute/
