### PR TITLE
fix issue with safari

### DIFF
--- a/hlx_statics/blocks/site-wide-banner/site-wide-banner.js
+++ b/hlx_statics/blocks/site-wide-banner/site-wide-banner.js
@@ -14,8 +14,8 @@ export default async function decorate(block) {
   // default setting this to none and then show it once it loads
   siteParent.style.display = 'none';
 
-  const mainArea = document.querySelector('[style*="grid-area: main"]');
-  const sidenavArea = document.querySelector('[style*="grid-area: sidenav"]');
+  const mainArea = document.querySelector('.grid-main-area');
+  const sidenavArea = document.querySelector('.side-nav-container');
   const productName = getMetadata('product');
   const isMobile = window.innerWidth < 1025;
   const paddingTargets = IS_DEV_DOCS ? [mainArea, sidenavArea] : [siteParent.nextElementSibling?.nextElementSibling];

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -294,7 +294,10 @@ export function buildGrid(main) {
   mainContainer.style.display = 'grid';
 
   const gridAreaMain = main.querySelector('.section');
-  if (gridAreaMain) gridAreaMain.style.gridArea = 'main';
+  if (gridAreaMain) {
+    gridAreaMain.style.gridArea = 'main';
+    gridAreaMain.classList.add('grid-main-area');
+  }
 
   const sideNav = document.querySelector('.side-nav');
   if (sideNav) sideNav.style.gridArea = 'sidenav';
@@ -317,7 +320,7 @@ export function buildGrid(main) {
  */
 export function buildGridAreaMain(main) {
   const herosimpleWrapper = main.querySelector('.herosimple-wrapper');
-  const gridAreaMain = main.querySelector('main > div[style*="grid-area: main"]');
+  const gridAreaMain = main.querySelector('.grid-main-area');
   const subParent = createTag("div", { class: "sub-parent" });
   if (herosimpleWrapper) {
     const children = Array.from(gridAreaMain.children);
@@ -399,7 +402,7 @@ export function buildResources(main) {
  */
 export function buildNextPrev(main) {
   let nextPrevWrapper = createTag('div', { class: 'next-prev-wrapper block', 'data-block-name': 'next-prev' });
-  const gridAreaMain = main.querySelector('div[style*="grid-area: main"]');
+  const gridAreaMain = main.querySelector('.grid-main-area');
   gridAreaMain.appendChild(nextPrevWrapper)
 }
 

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -231,7 +231,7 @@ main.dev-docs.no-onthispage .main-resources-wrapper {
 
 main.dev-docs .herosimple > div,
 main.dev-docs:has(.herosimple) .sub-parent,
-main.dev-docs:not(:has(.herosimple)) > div[style*="grid-area: main"],
+main.dev-docs:not(:has(.herosimple)) > .grid-main-area,
 main.dev-docs .footer-wrapper .footer-links-container-inner {
   padding-left: 32px;
   padding-right: 32px;
@@ -239,7 +239,7 @@ main.dev-docs .footer-wrapper .footer-links-container-inner {
 
 main.dev-docs .herosimple > div,
 main.dev-docs:has(.herosimple) .sub-parent,
-main.dev-docs:not(:has(.herosimple)) > div[style*="grid-area: main"],
+main.dev-docs:not(:has(.herosimple)) .grid-main-area,
 main.dev-docs .footer-wrapper {
   margin: 0 auto;
   width: 100%;
@@ -254,7 +254,7 @@ main.dev-docs:has(.herosimple) .footer-wrapper {
 main.dev-docs.no-sidenav .herosimple > div,
 main.dev-docs:has(.herosimple).no-sidenav .sub-parent,
 main.dev-docs:has(.herosimple).no-sidenav .footer-wrapper,
-main.dev-docs:not(:has(.herosimple)) > div[style*="grid-area: main"],
+main.dev-docs:not(:has(.herosimple)) .grid-main-area,
 main.dev-docs:not(:has(.herosimple)) .footer-wrapper {
   max-width: 1280px;
 }
@@ -1237,5 +1237,5 @@ main .no-breadcrumbs {
 }
 
 main .action-buttons.copy-markdown-button{
-  cursor:pointer; 
+  cursor:pointer;
 }


### PR DESCRIPTION
previously in safari: 
https://developer-stage.adobe.com/developer-distribution/adobe-connect/ 
<img width="1522" height="1014" alt="Screenshot 2025-08-08 at 3 07 06 PM" src="https://github.com/user-attachments/assets/f958962d-3447-4228-8f4d-c7b942efac0e" />

After the fix in safari:

<img width="1646" height="999" alt="Screenshot 2025-08-08 at 3 09 38 PM" src="https://github.com/user-attachments/assets/49f6cd8c-07f6-40e6-882c-cec645760a94" />

Fix is mainly to take out any style: grid-area being called in the code as it's reading differently in safari. 
Grid-area in safari is called grid-row-start, grid-row-end.. 
