### PR TITLE
adding dark gray to cards block

### DIFF
--- a/hlx_statics/blocks/cards/cards.css
+++ b/hlx_statics/blocks/cards/cards.css
@@ -10,6 +10,16 @@ main div.cards-wrapper:has(.cards.background-color-white) {
   background-color: white !important;
 }
 
+main div.cards-wrapper:has(.cards.background-color-dark-gray),
+main div.cards.background-color-dark-gray {
+  background-color: #323232;
+}
+
+main div.cards-wrapper div.cards.background-color-dark-gray .card-heading,
+main div.cards-wrapper div.cards.background-color-dark-gray p {
+  color: white;
+}
+
 main div.cards-wrapper div.cards {
   width: 100%;
   max-width: 1280px;

--- a/hlx_statics/blocks/cards/cards.js
+++ b/hlx_statics/blocks/cards/cards.js
@@ -31,7 +31,7 @@ export default async function decorate(block) {
     decorateLightOrDark(block);
 
     card.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((header) => {
-      header.classList.add('spectrum-Heading', 'spectrum-Heading--sizeM');
+      header.classList.add('spectrum-Heading', 'spectrum-Heading--sizeM', 'card-heading');
     });
 
     card.querySelectorAll('p').forEach((p) => {


### PR DESCRIPTION
In replace of the text block in the devdocs, we are using cards instead and also need to add the background color support to the cards component. 

Previous: 
https://main--adp-devsite--adobedocs.aem.page/test/louisa/commerce

Fix:
https://devsite-1875-cards-color--adp-devsite--adobedocs.aem.page/test/louisa/commerce
