### PR TITLE
feat: full width RedoclyAPIBlock

### DIFF
--- a/hlx_statics/blocks/footer/footer.css
+++ b/hlx_statics/blocks/footer/footer.css
@@ -18,8 +18,11 @@ footer {
 
 footer>div {
   box-sizing: border-box;
-  max-width: 1280px;
   margin: 0 auto;
+}
+
+main:not(.no-layout) footer>div {
+  max-width: 1280px;
 }
 
 footer>div ul {

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -298,6 +298,10 @@ export function buildGrid(main) {
     gridAreaMain.style.gridArea = 'main';
     gridAreaMain.classList.add('grid-main-area');
   }
+  
+  if(getMetadata('layout') === 'none' && gridAreaMain?.classList.contains('redoclyapiblock-container')){
+    main?.classList.add('no-layout');
+  }
 
   const sideNav = document.querySelector('.side-nav');
   if (sideNav) sideNav.style.gridArea = 'sidenav';

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -251,11 +251,11 @@ main.dev-docs:has(.herosimple) .footer-wrapper {
   max-width: 1000px;
 }
 
-main.dev-docs.no-sidenav .herosimple > div,
-main.dev-docs:has(.herosimple).no-sidenav .sub-parent,
-main.dev-docs:has(.herosimple).no-sidenav .footer-wrapper,
-main.dev-docs:not(:has(.herosimple)) .grid-main-area,
-main.dev-docs:not(:has(.herosimple)) .footer-wrapper {
+main.dev-docs:not(.no-layout).no-sidenav .herosimple > div,
+main.dev-docs:not(.no-layout):has(.herosimple).no-sidenav .sub-parent,
+main.dev-docs:not(.no-layout):has(.herosimple).no-sidenav .footer-wrapper,
+main.dev-docs:not(.no-layout):not(:has(.herosimple)) .grid-main-area,
+main.dev-docs:not(.no-layout):not(:has(.herosimple)) .footer-wrapper {
   max-width: 1280px;
 }
 


### PR DESCRIPTION
## Description
Set RedoclyAPIBlock to full width when frontmatter has `layout: none` in EDS, similar to [Gatsby](https://github.com/adobe/aio-theme?tab=readme-ov-file#full-width-page)

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1725

## Tests
- with `layout: none`
  - page: https://devsite-17250-redocly-full-width--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/redocly-api-block-no-layout
  - markdown: https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/redocly-api-block-no-layout.md?plain=1#L2
- without `layout: none`
  - page: https://devsite-17250-redocly-full-width--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/redocly-api-block-default
  - markdown: https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/redocly-api-block-default.md?plain=1#L1

## Screenshots
- with `layout: none`
  - <img width="1728" height="1039" alt="Screenshot 2025-09-02 at 4 26 13 PM" src="https://github.com/user-attachments/assets/07fb29ba-2224-46f6-9d45-d61b27757adb" />
  - <img width="1728" height="1038" alt="Screenshot 2025-09-02 at 4 26 26 PM" src="https://github.com/user-attachments/assets/d163ee24-9467-4090-8390-b810625afc55" />

- without `layout: none`
  - <img width="1728" height="1039" alt="Screenshot 2025-09-02 at 4 25 13 PM" src="https://github.com/user-attachments/assets/f99f22a5-94eb-433a-8104-f633d8c8db6c" />
  - <img width="1728" height="1040" alt="Screenshot 2025-09-02 at 4 25 22 PM" src="https://github.com/user-attachments/assets/5eff9380-569a-4638-b1e5-114d41b1a353" />

