### PR TITLE
adding accordionitem component

### DIFF
--- a/hlx_statics/blocks/accordionitem/accordionitem.css
+++ b/hlx_statics/blocks/accordionitem/accordionitem.css
@@ -18,6 +18,7 @@ main div.accordionitem-wrapper {
 
 main div.accordionitem-wrapper div.accordionitem {
     width: 100%;
+    border-bottom: 1px solid #d9d9d9;
 }
 
 main div.accordionitem-wrapper div.accordionitem .accordionitem-title {

--- a/hlx_statics/blocks/accordionitem/accordionitem.css
+++ b/hlx_statics/blocks/accordionitem/accordionitem.css
@@ -1,0 +1,114 @@
+main div.accordionitem-wrapper:has(.accordionitem.background-color-white) {
+    background-color: white;
+}
+
+main div.accordionitem-wrapper div.accordionitem .accordionitem-div {
+    display: flex !important;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 1280px !important;
+    margin: auto !important;
+}
+
+main div.accordionitem-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+main div.accordionitem-wrapper div.accordionitem {
+    width: 100%;
+}
+
+main div.accordionitem-wrapper div.accordionitem .accordionitem-title {
+    display: flex !important;
+    flex-direction: column;
+    justify-content: center;
+    text-align: left;
+    color: black;
+    width: 1280px !important;
+    margin: auto !important
+}
+
+main div.accordionitem-wrapper div.accordionitem .accordionitem-subtitle {
+    color: rgb(110, 110, 110);
+}
+
+main div.accordionitem-wrapper div.accordionitem .accordionitem-item {
+    border-color: #d9d9d9 !important;
+    border-bottom: 1px solid;
+    display: list-item;
+    list-style: none;
+    width: 100%;
+}
+
+main div.accordionitem-wrapper div.accordionitem .spectrum-Accordion-ChevronIcon {
+    padding: 6px!important;
+}
+
+main div.accordionitem-wrapper div.accordionitem h3 {
+    margin: 0;
+}
+
+main div.accordionitem-wrapper div.accordionitem .accordion-itemHeader {
+    box-sizing: border-box;
+    margin: 0;
+    text-align: left;
+    align-items: center;
+    width: 100%!important;
+    background-color: inherit;
+    border: 0;
+    cursor: pointer;
+    padding-left: 0!important;
+    display: flex;
+    justify-content: flex-start;
+    font-family: inherit;
+    font-size: 16px !important;
+    padding-left: 0 !important;
+    padding-right: 22px;
+    padding-bottom: 8px;
+    padding-top: 8px;
+    font-weight: 700 !important;
+}
+
+main div.accordionitem-wrapper div.accordionitem .accordion-itemHeader:hover {
+    background-color:  #e9eaeb;
+    color: #2C2C2C;
+}
+
+main div.accordionitem-wrapper div.accordionitem .accordion-itemContent {
+    font-size: 16px;
+    margin-top: 12px;
+    padding-left: 20px!important;
+    padding-bottom: 16px;
+    display: none;
+}
+
+main div.accordionitem-wrapper div.accordionitem .active {
+    background-color: transparent;
+}
+
+main div.accordionitem-wrapper div.accordionitem .spectrum-Icon {
+    block-size: 10px;
+}
+
+main div.accordionitem-wrapper div.accordionitem.large-font .accordion-itemHeader{
+    font-size: 20px !important;
+}
+
+@media screen and (max-width: 1280px) {
+    main div.accordionitem-wrapper div.accordionitem .accordion-div {
+        width: 98vw !important;
+    }
+
+    main div.accordionitem-wrapper div.accordionitem .accordion-title {
+        width: 98vw !important;
+    }
+}
+
+@media screen and (max-width: 480px) {
+    main div.accordionitem-wrapper div.accordionitem .spectrum-Icon {
+        block-size: 18px;
+    }
+}

--- a/hlx_statics/blocks/accordionitem/accordionitem.css
+++ b/hlx_statics/blocks/accordionitem/accordionitem.css
@@ -7,7 +7,6 @@ main div.accordionitem-wrapper div.accordionitem .accordionitem-div {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    width: 1280px !important;
     margin: auto !important;
 }
 
@@ -27,7 +26,6 @@ main div.accordionitem-wrapper div.accordionitem .accordionitem-title {
     justify-content: center;
     text-align: left;
     color: black;
-    width: 1280px !important;
     margin: auto !important
 }
 
@@ -72,6 +70,10 @@ main div.accordionitem-wrapper div.accordionitem .accordion-itemHeader {
     font-weight: 700 !important;
 }
 
+main div.accordionitem-wrapper div.accordionitem .accordion-itemHeader .accordion-toggle-icon{
+    padding-right: 25px;
+}
+
 main div.accordionitem-wrapper div.accordionitem .accordion-itemHeader:hover {
     background-color:  #e9eaeb;
     color: #2C2C2C;
@@ -83,6 +85,11 @@ main div.accordionitem-wrapper div.accordionitem .accordion-itemContent {
     padding-left: 20px!important;
     padding-bottom: 16px;
     display: none;
+    overflow-x: auto;
+}
+
+main div.accordionitem-wrapper div.accordionitem .accordion-itemContent {
+
 }
 
 main div.accordionitem-wrapper div.accordionitem .active {

--- a/hlx_statics/blocks/accordionitem/accordionitem.js
+++ b/hlx_statics/blocks/accordionitem/accordionitem.js
@@ -102,14 +102,12 @@ function getAccordionItem(heading) {
   return `
     <h3>
         <button class="accordion-itemHeader" type="button"> 
-            <span class="spectrum-Accordion-ChevronIcon">
-                <svg aria-hidden="true" role="img" style="display: block" class="spectrum-Icon spectrum-UIIcon-ChevronRight100">
-                    <path d="M4.5 13.25a1.094 1.094 0 01-.773-1.868L8.109 7 3.727 2.618A1.094 1.094 0 15.273 1.07l5.157 5.156a1.094 1.094 0 010 1.546L5.273 12.93a1.091 1.091 0 01-.773.321z" class="spectrum-UIIcon--large"></path>
-                    <path d="M3 9.95a.875.875 0 01-.615-1.498L5.88 5 2.385 1.547A.875.875 0 13.615.302L7.74 4.377a.876.876 0 010 1.246L3.615 9.698A.872.872 0 13 9.95z" class="spectrum-UIIcon--medium"></path>                
+            <span class="accordion-toggle-icon">
+                <svg class="expand-icon" style="display: block;" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M8 3V13M3 8H13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                 </svg>
-                <svg aria-hidden="true" role="img" style="display: none" class="spectrum-Icon spectrum-UIIcon-ChevronDown100">
-                    <path d="M4.5 13.25a1.094 1.094 0 01-.773-1.868L8.109 7 3.727 2.618A1.094 1.094 0 15.273 1.07l5.157 5.156a1.094 1.094 0 010 1.546L5.273 12.93a1.091 1.091 0 01-.773.321z" class="spectrum-UIIcon--large"></path>
-                    <path d="M3 9.95a.875.875 0 01-.615-1.498L5.88 5 2.385 1.547A .875.875 0 13.615.302L7.74 4.377a.876.876 0 010 1.246L3.615 9.698A.872.872 0 13 9.95z" class="spectrum-UIIcon--medium"></path>
+                <svg class="collapse-icon" style="display: none;" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M3 8H13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                 </svg>
             </span>
             ${heading}
@@ -148,15 +146,15 @@ export default async function decorate(block) {
         content?.forEach((item) => {
           item.style.display = 'block';
         });
-        heading.querySelector('.spectrum-UIIcon-ChevronRight100').style.display = 'none';
-        heading.querySelector('.spectrum-UIIcon-ChevronDown100').style.display = 'block';
+        heading.querySelector('.expand-icon').style.display = 'none';
+        heading.querySelector('.collapse-icon').style.display = 'block';
       }else{ //hide contents
         heading.classList.remove('active');
         content?.forEach((item) => {
           item.style.display = 'none';
         });
-        heading.querySelector('.spectrum-UIIcon-ChevronRight100').style.display = 'block';
-        heading.querySelector('.spectrum-UIIcon-ChevronDown100').style.display = 'none';
+        heading.querySelector('.expand-icon').style.display = 'block';
+        heading.querySelector('.collapse-icon').style.display = 'none';
       };
     });
   });

--- a/hlx_statics/blocks/accordionitem/accordionitem.js
+++ b/hlx_statics/blocks/accordionitem/accordionitem.js
@@ -1,0 +1,166 @@
+import {removeEmptyPTags, createTag} from '../../scripts/lib-adobeio.js';
+
+/**
+ * Decorates tables with Adobe Spectrum styling
+ * @param {Element} block The block element containing tables
+ */
+function decorateTables(block) {
+  const tables = block.querySelectorAll('table');
+
+  tables.forEach(table => {
+    // Apply main table classes
+    table.className = 'spectrum-Table spectrum-Table--sizeM';
+
+    // Handle thead
+    let thead = table.querySelector('thead');
+    if (thead) {
+      thead.className = 'spectrum-Table-head';
+
+      // Check if first row just contains "Table" and empty cells - remove it
+      const rows = thead.querySelectorAll('tr');
+      if (rows.length > 0) {
+        const firstRow = rows[0];
+        const cells = firstRow.querySelectorAll('th');
+        const hasOnlyTableHeader = cells.length > 0 &&
+          cells[0].textContent.trim() === 'Table' &&
+          Array.from(cells).slice(1).every(cell => !cell.textContent.trim());
+
+        if (hasOnlyTableHeader) {
+          firstRow.remove();
+        }
+      }
+
+      // Style remaining header rows and cells
+      thead.querySelectorAll('tr').forEach(tr => {
+        tr.className = 'spectrum-Table-row';
+        tr.querySelectorAll('th').forEach(th => {
+          th.className = 'spectrum-Table-headCell';
+        });
+      });
+    }
+
+    // Handle tbody
+    const tbody = table.querySelector('tbody');
+    if (tbody) {
+      tbody.className = 'spectrum-Table-body';
+      const bodyRows = tbody.querySelectorAll('tr');
+
+      // Check if first row should be moved to thead (contains header-like content)
+      if (!thead && bodyRows.length > 0) {
+        const firstRow = bodyRows[0];
+        const cells = firstRow.querySelectorAll('td');
+
+        // Create thead and move first row as header
+        thead = document.createElement('thead');
+        thead.className = 'spectrum-Table-head';
+
+        const headerRow = document.createElement('tr');
+        headerRow.className = 'spectrum-Table-row';
+
+        cells.forEach(td => {
+          const th = document.createElement('th');
+          th.className = 'spectrum-Table-headCell';
+          th.innerHTML = td.innerHTML;
+          headerRow.appendChild(th);
+        });
+
+        thead.appendChild(headerRow);
+        table.insertBefore(thead, tbody);
+        firstRow.remove();
+      }
+
+      // Style remaining body rows
+      tbody.querySelectorAll('tr').forEach(tr => {
+        tr.className = 'spectrum-Table-row';
+        tr.querySelectorAll('td').forEach(td => {
+          td.className = 'spectrum-Table-cell';
+
+          // Wrap content in div with proper class
+          const content = td.innerHTML;
+          const wrapper = document.createElement('div');
+          wrapper.innerHTML = content;
+
+          // Convert inline code classes
+          wrapper.querySelectorAll('code.inline-code').forEach(code => {
+            code.className = 'spectrum-Code';
+          });
+
+          td.innerHTML = '';
+          td.appendChild(wrapper);
+        });
+      });
+    }
+  });
+}
+
+/**
+ * Returns the HTML for an accordion item
+ * @param {*} heading The heading text of the accordion
+ * @returns The accordion item HTML
+ */
+function getAccordionItem(heading) {
+  return `
+    <h3>
+        <button class="accordion-itemHeader" type="button"> 
+            <span class="spectrum-Accordion-ChevronIcon">
+                <svg aria-hidden="true" role="img" style="display: block" class="spectrum-Icon spectrum-UIIcon-ChevronRight100">
+                    <path d="M4.5 13.25a1.094 1.094 0 01-.773-1.868L8.109 7 3.727 2.618A1.094 1.094 0 15.273 1.07l5.157 5.156a1.094 1.094 0 010 1.546L5.273 12.93a1.091 1.091 0 01-.773.321z" class="spectrum-UIIcon--large"></path>
+                    <path d="M3 9.95a.875.875 0 01-.615-1.498L5.88 5 2.385 1.547A.875.875 0 13.615.302L7.74 4.377a.876.876 0 010 1.246L3.615 9.698A.872.872 0 13 9.95z" class="spectrum-UIIcon--medium"></path>                
+                </svg>
+                <svg aria-hidden="true" role="img" style="display: none" class="spectrum-Icon spectrum-UIIcon-ChevronDown100">
+                    <path d="M4.5 13.25a1.094 1.094 0 01-.773-1.868L8.109 7 3.727 2.618A1.094 1.094 0 15.273 1.07l5.157 5.156a1.094 1.094 0 010 1.546L5.273 12.93a1.091 1.091 0 01-.773.321z" class="spectrum-UIIcon--large"></path>
+                    <path d="M3 9.95a.875.875 0 01-.615-1.498L5.88 5 2.385 1.547A .875.875 0 13.615.302L7.74 4.377a.876.876 0 010 1.246L3.615 9.698A.872.872 0 13 9.95z" class="spectrum-UIIcon--medium"></path>
+                </svg>
+            </span>
+            ${heading}
+        </button>
+    </h3>
+    `;
+}
+
+/**
+ * decorates the accordion
+ * @param {Element} block The accordion block element
+ */
+export default async function decorate(block) {
+  block.setAttribute('daa-lh', 'accordionitem');
+  removeEmptyPTags(block);
+
+  block.querySelectorAll('.accordionitem > div > div').forEach((item) => {
+      item.setAttribute("class", "accordion-item");
+      const heading = item.querySelector('h3, h4, h5, h6');
+      if (heading) {
+        const headingText = heading?.innerText;
+        item.innerHTML = getAccordionItem(headingText);
+        item.setAttribute("class", "accordion-itemHeader");
+      } else {
+        item.setAttribute("class", "accordion-itemContent");
+      }
+   });
+
+  const accordion_items = block.querySelectorAll(':scope > div');
+  accordion_items.forEach((item, i) => {
+    item.addEventListener("click", () => {
+      const heading = item.querySelector('.accordion-itemHeader');
+      const content = item.querySelectorAll('.accordion-itemContent');
+      if(!heading.classList.contains('active')){ //click on item - show content
+        heading.classList.add('active');
+        content?.forEach((item) => {
+          item.style.display = 'block';
+        });
+        heading.querySelector('.spectrum-UIIcon-ChevronRight100').style.display = 'none';
+        heading.querySelector('.spectrum-UIIcon-ChevronDown100').style.display = 'block';
+      }else{ //hide contents
+        heading.classList.remove('active');
+        content?.forEach((item) => {
+          item.style.display = 'none';
+        });
+        heading.querySelector('.spectrum-UIIcon-ChevronRight100').style.display = 'block';
+        heading.querySelector('.spectrum-UIIcon-ChevronDown100').style.display = 'none';
+      };
+    });
+  });
+
+  // Decorate tables with Spectrum styling
+  decorateTables(block);
+}


### PR DESCRIPTION
This adds a accordionitem component for devdocs pages.  

https://devsite-1901-devdocs-accordion--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/test-accordion

The way to create the accordion will be like this 

<AccordionItem slots="heading, table, text, code"/>

### 1. Start play Test 

| Number | Action | Elapsed Real-Time (from beginning) | Playhead Position | Client Request |
| --- | --- | --- | --- | --- |
| 1 | The auto-play function occurs, or play button is pressed, and the video starts loading | 0 | 0 | `/sessionStart?configId=<datastreamID>` |

This call signals the intention of the user to play a video. The player state is not yet `playing`, but is instead `starting`. This call returns a Session ID which is referenced in the following examples with `{SID}`. The `{SID}`, is returned to the client and is used to identify all subsequent tracking calls within the session.  This call also generates a reporting event that is pushed to AEP and/or Analytics, depending on datastream configuration. Mandatory parameters must be included.

```json
{
 "eventType": "media.sessionStart",
  "timestamp": "YYYY-MM-DDT02:00:00.000Z",
  "mediaCollection": {
    "playhead": 0,
    "sessionDetails": {
      "name": "VA API Sample Player",
      "friendlyName": "ClickMe",
      "length": 60,
      "contentType": "VOD",
      "playerName": "sample-html5-api-player",
      "channel": "sample-channel",
      "appVersion": "va-api-0.0.0"
    }
  }
}
```
