### PR TITLE
fix: DevBiz footer max-width

### DIFF
--- a/hlx_statics/blocks/footer/footer.css
+++ b/hlx_statics/blocks/footer/footer.css
@@ -21,7 +21,8 @@ footer>div {
   margin: 0 auto;
 }
 
-main:not(.no-layout) footer>div {
+main.dev-docs:not(.no-layout) footer>div,
+main.dev-biz ~ footer>div {
   max-width: 1280px;
 }
 

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -278,14 +278,16 @@ async function loadEager(doc) {
     await waitForLCP(LCP_BLOCKS);
   }
 
+  const mainContainer = document.querySelector('main');
   if (IS_DEV_DOCS) {
     // check if this page is from dev docs, then change the main container to white background.
-    const mainContainer = document.querySelector('main');
     mainContainer.classList.add('dev-docs', 'white-background');
 
     buildGrid(main);
     buildSideNav(main);
     buildBreadcrumbs(main);
+  } else {
+    mainContainer.classList.add('dev-biz');
   }
 
   buildSiteWideBanner(main);


### PR DESCRIPTION
## Description
Cap DevBiz footer width to 1280px

## Context
This was a regression introduced in https://github.com/AdobeDocs/adp-devsite/pull/299 because in DevDocs `footer` is a child of `main`, but in DevBiz `footer` is a sibling of `main`.


## Before
https://stage--adp-devsite--adobedocs.aem.page/developers-live/
<img width="1728" height="1041" alt="before" src="https://github.com/user-attachments/assets/bf205407-bd39-445d-8a1d-727d152fcd04" />

## After
https://devbiz-footer-max-width--adp-devsite--adobedocs.aem.page/developers-live/
<img width="1728" height="1041" alt="after" src="https://github.com/user-attachments/assets/dca39275-4e42-42d6-be1a-9609a4626835" />
