### PR TITLE
Devsite 1939 sidenav

### DIFF
--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -538,7 +538,7 @@ function activeSubNav(actTab) {
       const link = li.querySelector(':scope > a');
       if (link) {
         const linkPath = new URL(link.href, window.location.origin).pathname;
-        if (linkPath.startsWith(pagePath)) {
+        if (linkPath.startsWith(pagePath) && getMetadata("template") === "documentation") {
           showSidenav = true;
         }
         if (!linkPath.startsWith(topNavPath)) {
@@ -549,10 +549,7 @@ function activeSubNav(actTab) {
       }
     });
   }
-  // If this is the landing page of the devdoc site, no side nav should be shown. 
-  if (getMetadata("template") !== "documentation"){
-    showSidenav = false;
-  }
+  
   if (!showSidenav) {
     document.querySelector("main").classList.add("no-sidenav");
   }


### PR DESCRIPTION
This will prevent the sidenav to show up for any landing path of the devdoc pages. 
It will also include sidenav when the sidenav path prefix iis part of the parent page
https://devsite-1939-sidenav--adp-devsite-stage--adobedocs.aem.page/commerce/contributor/