### PR TITLE
feat: devdocs superhero centered and centeredxl

### DIFF
--- a/hlx_statics/blocks/breadcrumbs/breadcrumbs.js
+++ b/hlx_statics/blocks/breadcrumbs/breadcrumbs.js
@@ -80,7 +80,7 @@ async function buildBreadcrumbs() {
 }
 
 export default async function decorate(block) {
-  const hasHero = Boolean(document.querySelector('.herosimple-container') || document.querySelector('.hero-container'));
+  const hasHero = Boolean(document.querySelector('.hero, .site-hero, .herosimple'));
   const showBreadcrumbsConfig = getMetadata('hidebreadcrumbnav') !== 'true';
   const showBreadcrumbs = !hasHero && showBreadcrumbsConfig;
   if(showBreadcrumbs) {

--- a/hlx_statics/blocks/breadcrumbs/breadcrumbs.js
+++ b/hlx_statics/blocks/breadcrumbs/breadcrumbs.js
@@ -80,7 +80,7 @@ async function buildBreadcrumbs() {
 }
 
 export default async function decorate(block) {
-  const hasHero = Boolean(document.querySelector('.hero, .site-hero, .herosimple'));
+  const hasHero = Boolean(document.querySelector('.hero, .site-hero, .herosimple, .superhero'));
   const showBreadcrumbsConfig = getMetadata('hidebreadcrumbnav') !== 'true';
   const showBreadcrumbs = !hasHero && showBreadcrumbsConfig;
   if(showBreadcrumbs) {

--- a/hlx_statics/blocks/superhero/superhero.css
+++ b/hlx_statics/blocks/superhero/superhero.css
@@ -43,8 +43,8 @@ main div.superhero-wrapper div.superhero.centered img {
   object-fit: cover;
 }
 
-main div.superhero-wrapper div.superhero.centered h1,
-main div.superhero-wrapper div.superhero.centeredxl h1 {
+main div.superhero-wrapper div.superhero.centered :is(h1, h2, h3, h4, h5, h6),
+main div.superhero-wrapper div.superhero.centeredxl :is(h1, h2, h3, h4, h5, h6) {
   text-align: center;
   margin-top: 0;
   margin-bottom: 16px;

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -37,8 +37,6 @@ async function decorateDevBizCentered(block) {
   });
 
   block.querySelectorAll('p').forEach((p) => {
-    const hasLinks = p.querySelectorAll('a, button');
-    // don't attach to icon container or if p tag contains links
     if (!p.classList.contains('icon-container')) {
       p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
       p.style.color = 'white';

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -1,5 +1,7 @@
 import { removeEmptyPTags, decorateButtons, createTag } from '../../scripts/lib-adobeio.js';
 
+const CENTERED_VARIANTS = ['centered', 'centeredxl'];
+
 /**
  * decorates the superhero
  * @param {Element} block The superhero block element
@@ -11,9 +13,13 @@ export default async function decorate(block) {
   const isDevBiz = main.classList.contains('dev-biz');
   const isDevDocs = main.classList.contains('dev-docs');
 
-  if (isDevBiz && ['centered', 'centeredxl'].some((variant) => block.classList.contains(variant))) {
+  if (isDevBiz && hasAnyClass(block, CENTERED_VARIANTS)) {
     decorateDevBizCentered(block);
   }
+}
+
+function hasAnyClass(block, classes) {
+  return classes.some((c) => block.classList.contains(c));
 }
 
 async function decorateDevBizCentered(block) {

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -7,7 +7,11 @@ import { removeEmptyPTags, decorateButtons, createTag } from '../../scripts/lib-
 export default async function decorate(block) {
   block.setAttribute('daa-lh', 'superhero');
 
-  if (['centered', 'centeredxl'].some((variant) => block.classList.contains(variant))) {
+  const main = document.querySelector('main');
+  const isDevBiz = main.classList.contains('dev-biz');
+  const isDevDocs = main.classList.contains('dev-docs');
+
+  if (isDevBiz && ['centered', 'centeredxl'].some((variant) => block.classList.contains(variant))) {
     removeEmptyPTags(block);
     decorateButtons(block);
 

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -43,7 +43,7 @@ async function decorateDevBizCentered(block) {
   block.classList.add('spectrum--dark');
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeXXL');
-    h.style.color = 'white';
+    h.style.color = DEFAULT_TEXT_COLOR;
     h.parentElement.classList.add('superhero-content');
     h.parentElement.append(button_div);
   });
@@ -51,7 +51,7 @@ async function decorateDevBizCentered(block) {
   block.querySelectorAll('p').forEach((p) => {
     if (!p.classList.contains('icon-container')) {
       p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
-      p.style.color = 'white';
+      p.style.color = DEFAULT_TEXT_COLOR;
     }
     if (p.classList.contains('button-container')) {
       button_div.append(p);

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -12,29 +12,33 @@ export default async function decorate(block) {
   const isDevDocs = main.classList.contains('dev-docs');
 
   if (isDevBiz && ['centered', 'centeredxl'].some((variant) => block.classList.contains(variant))) {
-    removeEmptyPTags(block);
-    decorateButtons(block);
-
-    const button_div = createTag('div', { class: 'hero-button-container' });
-
-    block.classList.add('spectrum--dark');
-    block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
-      h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeXXL');
-      h.style.color = 'white';
-      h.parentElement.classList.add('superhero-content');
-      h.parentElement.append(button_div);
-    });
-
-    block.querySelectorAll('p').forEach((p) => {
-      const hasLinks = p.querySelectorAll('a, button');
-      // don't attach to icon container or if p tag contains links
-      if (!p.classList.contains('icon-container')) {
-        p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
-        p.style.color = 'white';
-      }
-      if (p.classList.contains('button-container')) {
-        button_div.append(p);
-      }
-    });
+    decorateDevBizCentered(block);
   }
+}
+
+async function decorateDevBizCentered(block) {
+  removeEmptyPTags(block);
+  decorateButtons(block);
+
+  const button_div = createTag('div', { class: 'hero-button-container' });
+
+  block.classList.add('spectrum--dark');
+  block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
+    h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeXXL');
+    h.style.color = 'white';
+    h.parentElement.classList.add('superhero-content');
+    h.parentElement.append(button_div);
+  });
+
+  block.querySelectorAll('p').forEach((p) => {
+    const hasLinks = p.querySelectorAll('a, button');
+    // don't attach to icon container or if p tag contains links
+    if (!p.classList.contains('icon-container')) {
+      p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
+      p.style.color = 'white';
+    }
+    if (p.classList.contains('button-container')) {
+      button_div.append(p);
+    }
+  });
 }

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -1,6 +1,9 @@
 import { removeEmptyPTags, decorateButtons, createTag } from '../../scripts/lib-adobeio.js';
 
 const CENTERED_VARIANTS = ['centered', 'centeredxl'];
+const DEFAULT_BACKGROUND_COLOR = 'rgb(29, 125, 238)';
+const DEFAULT_TEXT_COLOR = 'white';
+const ALLOWED_TEXT_COLORS = ['black', DEFAULT_TEXT_COLOR, 'gray', 'navy'];
 
 /**
  * decorates the superhero
@@ -15,11 +18,20 @@ export default async function decorate(block) {
 
   if (isDevBiz && hasAnyClass(block, CENTERED_VARIANTS)) {
     decorateDevBizCentered(block);
+  } else if (isDevDocs && hasAnyVariant(block, CENTERED_VARIANTS)) {
+    restructureAsDevBizCentered(block);
+    decorateDevBizCentered(block);
+    applyDataAttributeStyles(block);
   }
 }
 
 function hasAnyClass(block, classes) {
   return classes.some((c) => block.classList.contains(c));
+}
+
+function hasAnyVariant(block, variants) {
+  const variant = block.getAttribute('data-variant') || 'default';
+  return variants.some((v) => v === variant);
 }
 
 async function decorateDevBizCentered(block) {
@@ -46,3 +58,80 @@ async function decorateDevBizCentered(block) {
     }
   });
 }
+
+/**
+ * restructures a devdocs block to match devbiz before the decorate function runs
+ */
+function restructureAsDevBizCentered(block) {
+  const slotNames = block
+    ?.getAttribute('data-slots')
+    ?.split(',')
+    .map((slot) => slot.trim());
+
+  const children = Array.from(block.children[0].children);
+  const slotElements = Object.fromEntries(slotNames.map((slotName, index) => [slotName, children[index]]));
+
+  const headingContent = slotElements.heading?.querySelector('h1, h2, h3, h4, h5, h6');
+  const textContent = slotElements.text?.firstChild;
+  const buttonsContent = slotElements.buttons?.querySelectorAll('ul > li > a');
+  const imageContent = slotElements.image?.querySelector('picture > img');
+
+  const newChildren = [];
+  
+  const contentDiv = createTag('div');
+  const contentInnerDiv = createTag('div');
+  
+  if (headingContent) {
+    contentInnerDiv.appendChild(headingContent);
+  }
+  
+  if (textContent) {
+    const p = createTag('p');
+    p.textContent = textContent.textContent;
+    contentInnerDiv.appendChild(p);
+  }
+  
+  if (buttonsContent) {
+    buttonsContent.forEach((button, index) => {
+      const p = createTag('p', { class: 'button-container' });
+      if (index === 0) {
+        const strong = createTag('strong');
+        strong.appendChild(button);
+        p.appendChild(strong);
+      } else {
+        p.appendChild(button);
+      }
+      contentInnerDiv.appendChild(p);
+    });
+  }
+  
+  contentDiv.appendChild(contentInnerDiv);
+  newChildren.push(contentDiv);
+  
+  const imageDiv = createTag('div');
+  const imageInnerDiv = createTag('div');
+  
+  if (imageContent) {
+    const picture = createTag('picture');
+    picture.appendChild(imageContent);
+    imageInnerDiv.appendChild(picture);
+  }
+  
+  imageDiv.appendChild(imageInnerDiv);
+  newChildren.push(imageDiv);
+  
+  block.replaceChildren(...newChildren);
+}
+
+function applyDataAttributeStyles(block) {
+  const background = block.getAttribute('data-background') || DEFAULT_BACKGROUND_COLOR;
+  block.style.background = background;
+
+  const textColor = block.getAttribute('data-textcolor') || DEFAULT_TEXT_COLOR;
+  if(ALLOWED_TEXT_COLORS.includes(textColor)) {
+    block.querySelectorAll('h1, h2, h3, h4, h5, h6, p').forEach((el) => {
+      el.style.color = textColor;
+    });
+  }
+}
+

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -323,17 +323,22 @@ export function buildGrid(main) {
  * @param {*} main The grid container
  */
 export function buildGridAreaMain(main) {
-  const herosimpleWrapper = main.querySelector('.herosimple-wrapper');
   const gridAreaMain = main.querySelector('.grid-main-area');
   const subParent = createTag("div", { class: "sub-parent" });
-  if (herosimpleWrapper) {
+  
+  const heroWrapperClasses = ['herosimple-wrapper', 'superhero-wrapper'];
+  const selector = '.' + heroWrapperClasses.join(', .');
+  const heroWrapper = main.querySelector(selector);
+  const heroWrapperClass = heroWrapperClasses.find(c => heroWrapper?.classList.contains(c));
+  
+  if (heroWrapper) {
     const children = Array.from(gridAreaMain.children);
     children.forEach((child) => {
-      if (!child.classList.contains("herosimple-wrapper")) {
+      if (!child.classList.contains(heroWrapperClass)) {
         subParent.appendChild(child);
       }
     });
-    gridAreaMain.insertBefore(subParent, herosimpleWrapper.nextSibling);
+    gridAreaMain.insertBefore(subParent, heroWrapper.nextSibling);
   } else {
     gridAreaMain.appendChild(subParent);
   }

--- a/hlx_statics/scripts/lib-helix.js
+++ b/hlx_statics/scripts/lib-helix.js
@@ -798,7 +798,7 @@ export function githubActionsBlock(doc) {
   if (!baseUrl) return;
   const githubEditUrl = baseUrl.replace('blob', 'edit');
   const githubIssueUrl = baseUrl.replace('blob', 'issues/new?title=Issue%20in%20');
-  const hasHero = Boolean(document.querySelector('.hero, .site-hero, .herosimple'));
+  const hasHero = Boolean(document.querySelector('.hero, .site-hero, .herosimple, .superhero'));
   if (!hasHero) {
     const newContent = doc.createElement('div');
     newContent.classList.add('section', 'github-actions-wrapper');

--- a/hlx_statics/scripts/lib-helix.js
+++ b/hlx_statics/scripts/lib-helix.js
@@ -798,7 +798,8 @@ export function githubActionsBlock(doc) {
   if (!baseUrl) return;
   const githubEditUrl = baseUrl.replace('blob', 'edit');
   const githubIssueUrl = baseUrl.replace('blob', 'issues/new?title=Issue%20in%20');
-  if (!doc.querySelector('.herosimple-container') && !doc.querySelector('.hero-container')) {
+  const hasHero = Boolean(document.querySelector('.hero, .site-hero, .herosimple'));
+  if (!hasHero) {
     const newContent = doc.createElement('div');
     newContent.classList.add('section', 'github-actions-wrapper');
     newContent.innerHTML = `

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -626,7 +626,7 @@ async function loadLazy(doc) {
     footer.style.gridArea = 'footer';
     main.append(footer);
 
-    const hasHero = Boolean(document.querySelector('.hero, .herosimple'));
+    const hasHero = Boolean(document.querySelector('.herosimple'));
     const hasResources = Boolean(document.querySelector('.resources-wrapper'));
     const hasHeading = main.querySelectorAll('h2:not(.side-nav h2):not(footer h2), h3:not(.side-nav h3):not(footer h3)').length !== 0;
     if (!hasHero && hasHeading) {

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -213,7 +213,7 @@ function optimizeImageUrl(url) {
  *  </picture>
  */
 function optimizeHeroPictures() {
-  const heroes = ['hero', 'herosimple', 'site-hero'];
+  const heroes = ['hero', 'herosimple', 'site-hero', 'superhero'];
   const selector = heroes.map(hero => `div.${hero} picture`).join(', ');
   const pictures = document.querySelectorAll(selector);
   pictures.forEach(picture => {
@@ -626,7 +626,7 @@ async function loadLazy(doc) {
     footer.style.gridArea = 'footer';
     main.append(footer);
 
-    const hasHero = Boolean(document.querySelector('.herosimple'));
+    const hasHero = Boolean(document.querySelector('.herosimple, .superhero'));
     const hasResources = Boolean(document.querySelector('.resources-wrapper'));
     const hasHeading = main.querySelectorAll('h2:not(.side-nav h2):not(footer h2), h3:not(.side-nav h3):not(footer h3)').length !== 0;
     if (!hasHero && hasHeading) {

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -230,32 +230,32 @@ main.dev-docs.no-onthispage .main-resources-wrapper {
 }
 
 main.dev-docs .herosimple > div,
-main.dev-docs:has(.herosimple) .sub-parent,
-main.dev-docs:not(:has(.herosimple)) > .grid-main-area,
+main.dev-docs:has(.herosimple, .superhero) .sub-parent,
+main.dev-docs:not(:has(.herosimple)):not(:has(.superhero)) > .grid-main-area,
 main.dev-docs .footer-wrapper .footer-links-container-inner {
   padding-left: 32px;
   padding-right: 32px;
 }
 
 main.dev-docs .herosimple > div,
-main.dev-docs:has(.herosimple) .sub-parent,
-main.dev-docs:not(:has(.herosimple)) .grid-main-area,
+main.dev-docs:has(.herosimple, .superhero) .sub-parent,
+main.dev-docs:not(:has(.herosimple)):not(:has(.superhero)) .grid-main-area,
 main.dev-docs .footer-wrapper {
   margin: 0 auto;
   width: 100%;
 }
 
 main.dev-docs .herosimple > div,
-main.dev-docs:has(.herosimple) .sub-parent,
-main.dev-docs:has(.herosimple) .footer-wrapper {
+main.dev-docs:has(.herosimple, .superhero) .sub-parent,
+main.dev-docs:has(.herosimple, .superhero) .footer-wrapper {
   max-width: 1000px;
 }
 
 main.dev-docs:not(.no-layout).no-sidenav .herosimple > div,
-main.dev-docs:not(.no-layout):has(.herosimple).no-sidenav .sub-parent,
-main.dev-docs:not(.no-layout):has(.herosimple).no-sidenav .footer-wrapper,
-main.dev-docs:not(.no-layout):not(:has(.herosimple)) .grid-main-area,
-main.dev-docs:not(.no-layout):not(:has(.herosimple)) .footer-wrapper {
+main.dev-docs:not(.no-layout):has(.herosimple, .superhero).no-sidenav .sub-parent,
+main.dev-docs:not(.no-layout):has(.herosimple, .superhero).no-sidenav .footer-wrapper,
+main.dev-docs:not(.no-layout):not(:has(.herosimple)):not(:has(.superhero)) .grid-main-area,
+main.dev-docs:not(.no-layout):not(:has(.herosimple)):not(:has(.superhero)) .footer-wrapper {
   max-width: 1280px;
 }
 


### PR DESCRIPTION
## Description
Add `centered` and `centeredxl` variants to DevDocs `Superhero` 

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1756

## Test
DevDocs uses [Gatsby-compatible markdown](https://github.com/adobe/aio-theme?tab=readme-ov-file#hero-block) (source) and DevBiz styling (page):

| | DevDocs Superhero (centered) | DevBiz Superhero (centered) |
| --- | --- | --- |
| Source | https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/superhero/new/superhero-centered.md?plain=1 | https://docs.google.com/document/d/1r70ZJKXHzhzVrG-sPwUrwxb-0vFDdgjzyMCLs9_2IqE/edit?tab=t.0#heading=h.kfcfoa8idwsy |
| Page | https://devdocs-superhero-centered--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/superhero-centered | https://devdocs-superhero-centered--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/sitehero-default?nocache=1757448691014 |

| | DevDocs Superhero (centeredxl) | DevBiz Superhero (centeredxl) |
| --- | --- | --- |
| Source | https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/superhero/new/superhero-centeredxl.md?plain=1 | https://docs.google.com/document/d/11WdFTcVNHNXWKC0b3iXUN16numvA6vmWxLsjw92vZds/edit?tab=t.0 |
| Page | https://devdocs-superhero-centered--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/superhero-centeredxl | https://devdocs-superhero-centered--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/sitehero-xl?nocache=1757450847855 |

Various combos of DevDocs data-attributes:
- `centered`, default `background`, default `textcolor`, two buttons:
  - <img width="1728" height="819" alt="Screenshot 2025-09-17 at 8 51 51 PM" src="https://github.com/user-attachments/assets/3c052aef-9ec4-4df7-a733-27ad5df065db" />
- `centered`, `background="navy"`, invalid `textcolor="yellow"`,  no text, one button:
  - <img width="1728" height="777" alt="Screenshot 2025-09-17 at 9 29 35 PM" src="https://github.com/user-attachments/assets/4e947e60-a592-4711-ae93-3ae649210705" />
- `centeredxl`, background image, `textcolor="black"`, no text, no buttons:
  - <img width="1728" height="1019" alt="Screenshot 2025-09-17 at 9 34 17 PM" src="https://github.com/user-attachments/assets/b4de8dde-112d-436f-aed3-7bae220f6645" />

Existing hero blocks remain unchanged between `devdocs-superhero-centered` and `stage`:
- HeroSimple: https://devdocs-superhero-centered--adp-devsite-stage--adobedocs.aem.page/cloud-storage/
- Hero: https://devdocs-superhero-centered--adp-devsite-stage--adobedocs.aem.page/commerce-xd-kits/
- Site Hero: https://devdocs-superhero-centered--adp-devsite-stage--adobedocs.aem.page/firefly-services/audio-video-beta/
