### PR TITLE
refactor: standardize superhero variant names

### DIFF
--- a/hlx_statics/blocks/superhero/superhero.css
+++ b/hlx_statics/blocks/superhero/superhero.css
@@ -1,5 +1,6 @@
 main div.superhero-wrapper:has(div.superhero.centered),
-main div.superhero-wrapper:has(div.superhero.centeredxl) {
+main div.superhero-wrapper:has(div.superhero.centered-xl),
+main div.superhero-wrapper:has(div.superhero.centeredXL) {
   background: rgb(255, 255, 255);
   background-position: center;
   background-size: cover;
@@ -12,14 +13,16 @@ main div.superhero-wrapper div.superhero.centered {
   height: 350px;
 }
 
-main div.superhero-wrapper div.superhero.centeredxl {
+main div.superhero-wrapper div.superhero.centered-xl,
+main div.superhero-wrapper div.superhero.centeredXL {
   position: relative;
   width: 100%;
   height: 624px;
 }
 
 main div.superhero-wrapper div.superhero.centered .superhero-content,
-main div.superhero-wrapper div.superhero.centeredxl .superhero-content {
+main div.superhero-wrapper div.superhero.centered-xl .superhero-content,
+main div.superhero-wrapper div.superhero.centeredXL .superhero-content {
   position: absolute;
   display: flex;
   flex-direction: column;
@@ -31,7 +34,8 @@ main div.superhero-wrapper div.superhero.centeredxl .superhero-content {
   width: 100%;
 }
 
-main div.superhero-wrapper div.superhero.centeredxl img {
+main div.superhero-wrapper div.superhero.centered-xl img,
+main div.superhero-wrapper div.superhero.centeredXL img {
   width: 100%;
   height: 624px;
   object-fit: cover;
@@ -44,14 +48,16 @@ main div.superhero-wrapper div.superhero.centered img {
 }
 
 main div.superhero-wrapper div.superhero.centered :is(h1, h2, h3, h4, h5, h6),
-main div.superhero-wrapper div.superhero.centeredxl :is(h1, h2, h3, h4, h5, h6) {
+main div.superhero-wrapper div.superhero.centered-xl :is(h1, h2, h3, h4, h5, h6),
+main div.superhero-wrapper div.superhero.centeredXL :is(h1, h2, h3, h4, h5, h6) {
   text-align: center;
   margin-top: 0;
   margin-bottom: 16px;
 }
 
 main div.superhero-wrapper div.superhero.centered p.spectrum-Body--sizeL,
-main div.superhero-wrapper div.superhero.centeredxl p.spectrum-Body--sizeL {
+main div.superhero-wrapper div.superhero.centered-xl p.spectrum-Body--sizeL,
+main div.superhero-wrapper div.superhero.centeredXL p.spectrum-Body--sizeL {
   margin-top: 0 !important;
   font-size: 18px;
   /* color: rgb(34, 34, 34) !important; */
@@ -59,7 +65,8 @@ main div.superhero-wrapper div.superhero.centeredxl p.spectrum-Body--sizeL {
 }
 
 main div.superhero-wrapper div.superhero.centered .superhero-button-container,
-main div.superhero-wrapper div.superhero.centeredxl .superhero-button-container {
+main div.superhero-wrapper div.superhero.centered-xl .superhero-button-container,
+main div.superhero-wrapper div.superhero.centeredXL .superhero-button-container {
   display: flex;
   flex-wrap: wrap;
   display: inline-flex;
@@ -70,18 +77,21 @@ main div.superhero-wrapper div.superhero.centeredxl .superhero-button-container 
 
 @media screen and (min-width: 768px) and (max-width: 1024px) {
   main div.superhero-wrapper div.superhero.centered .superhero-content,
-  main div.superhero-wrapper div.superhero.centeredxl .superhero-content {
+  main div.superhero-wrapper div.superhero.centered-xl .superhero-content,
+  main div.superhero-wrapper div.superhero.centeredXL .superhero-content {
     padding: 0 32px;
   }
 
   main div.superhero-wrapper div.superhero.centered img,
-  main div.superhero-wrapper div.superhero.centeredxl img {
+  main div.superhero-wrapper div.superhero.centered-xl img,
+  main div.superhero-wrapper div.superhero.centeredXL img {
     width: 100%;
     height: 350px;
     object-fit: cover;
   }
 
-  main div.superhero-wrapper .centeredxl img {
+  main div.superhero-wrapper .centered-xl img,
+  main div.superhero-wrapper .centeredXL img {
     width: 100%;
     height: 350px;
     object-fit: cover;
@@ -90,38 +100,43 @@ main div.superhero-wrapper div.superhero.centeredxl .superhero-button-container 
 
 @media screen and (min-width: 320px) and (max-width: 767px) {
   main div.superhero-wrapper div.superhero.centered,
-  main div.superhero-wrapper div.superhero.centeredxl {
+  main div.superhero-wrapper div.superhero.centered-xl,
+  main div.superhero-wrapper div.superhero.centeredXL {
     position: relative;
     width: 100%;
     height: 75vh !important;
   }
 
-  main div.superhero-wrapper div.superhero.centeredxl {
+  main div.superhero-wrapper div.superhero.centered-xl,
+  main div.superhero-wrapper div.superhero.centeredXL {
     position: relative;
     width: 100%;
     height: 100vh !important;
   }
 
   main div.superhero-wrapper div.superhero.centered img,
-  main div.superhero-wrapper div.superhero.centeredxl img {
+  main div.superhero-wrapper div.superhero.centered-xl img,
+  main div.superhero-wrapper div.superhero.centeredXL img {
     overflow-clip-margin: content-box;
     overflow: clip;
     height: 75vh !important;
   }
 
-  main div.superhero-wrapper div.superhero.centeredxl img {
+  main div.superhero-wrapper div.superhero.centered-xl img,
+  main div.superhero-wrapper div.superhero.centeredXL img {
     overflow-clip-margin: content-box;
     overflow: clip;
     height: 100vh !important;
   }
 
   main div.superhero-wrapper div.superhero.centered .superhero-content,
-  main div.superhero-wrapper div.superhero.centeredxl .superhero-content {
+  main div.superhero-wrapper div.superhero.centered-xl .superhero-content,
+  main div.superhero-wrapper div.superhero.centeredXL .superhero-content {
     padding: 0 32px;
   }
 }
 
-main div.superhero-wrapper div.superhero.halfwidth {
+main div.superhero-wrapper div.superhero.half-width {
   background: rgb(255, 255, 255);
   height: 500px;
   width: 100%;
@@ -130,29 +145,29 @@ main div.superhero-wrapper div.superhero.halfwidth {
   justify-content: center;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth.full-width-background img {
+main div.superhero-wrapper div.superhero.half-width.full-width-background img {
   width: 100% !important;
   height: 350px !important;
   object-fit: cover !important;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth p.spectrum-Body--sizeL {
+main div.superhero-wrapper div.superhero.half-width p.spectrum-Body--sizeL {
   margin-top: 0 !important;
   color: rgb(80, 80, 80) !important;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth.font-white h1,
-main div.superhero-wrapper div.superhero.halfwidth.font-white h2,
-main div.superhero-wrapper div.superhero.halfwidth.font-white h3,
-main div.superhero-wrapper div.superhero.halfwidth.font-white p {
+main div.superhero-wrapper div.superhero.half-width.font-white h1,
+main div.superhero-wrapper div.superhero.half-width.font-white h2,
+main div.superhero-wrapper div.superhero.half-width.font-white h3,
+main div.superhero-wrapper div.superhero.half-width.font-white p {
   color: white !important;
 }
 
-main div.superhero-wrapper:has(div.superhero.halfwidth) {
+main div.superhero-wrapper:has(div.superhero.half-width) {
   padding: 0;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth > div:first-child {
+main div.superhero-wrapper div.superhero.half-width > div:first-child {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -162,11 +177,11 @@ main div.superhero-wrapper div.superhero.halfwidth > div:first-child {
   margin-right: 32px;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth div:nth-child(2) {
+main div.superhero-wrapper div.superhero.half-width div:nth-child(2) {
   flex: 1;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth div:nth-child(2) > div {
+main div.superhero-wrapper div.superhero.half-width div:nth-child(2) > div {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -174,7 +189,7 @@ main div.superhero-wrapper div.superhero.halfwidth div:nth-child(2) > div {
   margin-top: 0;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth div:nth-child(2) > div img {
+main div.superhero-wrapper div.superhero.half-width div:nth-child(2) > div img {
   width: 100% !important;
   height: 100% !important;
   object-fit: cover !important;
@@ -182,42 +197,42 @@ main div.superhero-wrapper div.superhero.halfwidth div:nth-child(2) > div img {
   min-height: 500px !important;
 }
 
-main div.superhero-wrapper:has(.halfwidth.full-width-background) div:nth-child(2) > div img {
+main div.superhero-wrapper:has(.half-width.full-width-background) div:nth-child(2) > div img {
   display: none;
 }
 
-main div.superhero-wrapper:has(.halfwidth.full-width-background) div:nth-child(3) {
+main div.superhero-wrapper:has(.half-width.full-width-background) div:nth-child(3) {
   display: flex;
   align-items: center;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth .icon-container {
+main div.superhero-wrapper div.superhero.half-width .icon-container {
   height: 48px;
   width: 48px;
   margin-top: 0 !important;
   margin-bottom: 24px !important;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth span.icon {
+main div.superhero-wrapper div.superhero.half-width span.icon {
   display: none;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth .icon {
+main div.superhero-wrapper div.superhero.half-width .icon {
   height: 100%;
   object-fit: contain;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth h3,
-main div.superhero-wrapper div.superhero.halfwidth h1 {
+main div.superhero-wrapper div.superhero.half-width h3,
+main div.superhero-wrapper div.superhero.half-width h1 {
   margin-top: 0;
   margin-bottom: 16px;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth h1 + p.last-of-type {
+main div.superhero-wrapper div.superhero.half-width h1 + p.last-of-type {
   margin-bottom: 0 !important;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth .superhero-button-container {
+main div.superhero-wrapper div.superhero.half-width .superhero-button-container {
   display: flex;
   flex-wrap: wrap;
   margin-top: 24px;
@@ -225,72 +240,72 @@ main div.superhero-wrapper div.superhero.halfwidth .superhero-button-container {
   margin-bottom: 10px;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth h3 {
+main div.superhero-wrapper div.superhero.half-width h3 {
   margin-top: 0;
   margin-bottom: 16px;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth h1 + p.last-of-type {
+main div.superhero-wrapper div.superhero.half-width h1 + p.last-of-type {
   margin-bottom: 0 !important;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth.font-color-white a {
+main div.superhero-wrapper div.superhero.half-width.font-color-white a {
   text-decoration: underline;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth.font-color-white h1,
-main div.superhero-wrapper div.superhero.halfwidth.font-color-white a,
-main div.superhero-wrapper div.superhero.halfwidth.font-color-white p {
+main div.superhero-wrapper div.superhero.half-width.font-color-white h1,
+main div.superhero-wrapper div.superhero.half-width.font-color-white a,
+main div.superhero-wrapper div.superhero.half-width.font-color-white p {
   color: white !important;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth.font-color-black {
+main div.superhero-wrapper div.superhero.half-width.font-color-black {
   color: black;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth.over-gradient p.button-container:not(strong) a:not(.spectrum-Button--accent) {
+main div.superhero-wrapper div.superhero.half-width.over-gradient p.button-container:not(strong) a:not(.spectrum-Button--accent) {
   border-color: white;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth.over-gradient p.button-container:not(strong) a:not(.spectrum-Button--accent) > span {
+main div.superhero-wrapper div.superhero.half-width.over-gradient p.button-container:not(strong) a:not(.spectrum-Button--accent) > span {
   color: white;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth.over-gradient p.button-container a {
+main div.superhero-wrapper div.superhero.half-width.over-gradient p.button-container a {
   font-size: 16px;
 }
 
-main div.superhero-wrapper div.superhero.halfwidth div.superhero-video-container {
+main div.superhero-wrapper div.superhero.half-width div.superhero-video-container {
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
 @media screen and (max-width: 768px) {
-  main div.superhero-wrapper div.superhero.halfwidth {
+  main div.superhero-wrapper div.superhero.half-width {
     padding: 32px;
     overflow: hidden;
   }
 
-  main div.superhero-wrapper div.superhero.halfwidth > div:first-child {
+  main div.superhero-wrapper div.superhero.half-width > div:first-child {
     margin-left: 64px;
     margin-right: 32px;
     width: 100%;
     margin: 0;
   }
 
-  main div.superhero-wrapper div.superhero.halfwidth div:nth-child(2) {
+  main div.superhero-wrapper div.superhero.half-width div:nth-child(2) {
     display: none;
   }
-  main div.superhero-wrapper div.superhero.halfwidth .spectrum-Heading--sizeXXL {
+  main div.superhero-wrapper div.superhero.half-width .spectrum-Heading--sizeXXL {
     font-size: 36px;
   }
 
-  main div.superhero-wrapper div.superhero.halfwidth picture {
+  main div.superhero-wrapper div.superhero.half-width picture {
     display: none;
   }
 
-  main div.superhero-wrapper div.superhero.halfwidth div:nth-child(2) > div div {
+  main div.superhero-wrapper div.superhero.half-width div:nth-child(2) > div div {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -298,15 +313,14 @@ main div.superhero-wrapper div.superhero.halfwidth div.superhero-video-container
     margin-top: 0;
   }
 
-  main div.superhero-wrapper div.superhero.halfwidth div:nth-child(2) > div img {
+  main div.superhero-wrapper div.superhero.half-width div:nth-child(2) > div img {
     width: 100% !important;
     min-width: 320px !important;
   }
 }
 
 @media screen and (max-width: 425px) {
-  main div.superhero-wrapper div.superhero.halfwidth div:nth-child(2) > div img {
+  main div.superhero-wrapper div.superhero.half-width div:nth-child(2) > div img {
     min-height: 0px;
   }
 }
-

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -1,13 +1,7 @@
 import { removeEmptyPTags, decorateButtons, createTag } from '../../scripts/lib-adobeio.js';
 import { decorateLightOrDark } from '../../scripts/lib-helix.js';
 
-const VARIANTS = {
-  default: 'default',
-  centered: 'centered',
-  centeredxl: 'centeredxl',
-  halfwidth: 'halfwidth'
-};
-const CENTERED_VARIANTS = [VARIANTS.centered, VARIANTS.centeredxl];
+const DEFAULT_VARIANT = 'default';
 const DEFAULT_BACKGROUND_COLOR = 'rgb(29, 125, 238)';
 const DEFAULT_TEXT_COLOR = 'white';
 const ALLOWED_TEXT_COLORS = ['black', DEFAULT_TEXT_COLOR, 'gray', 'navy'];
@@ -23,13 +17,13 @@ export default async function decorate(block) {
   const isDevBiz = main.classList.contains('dev-biz');
   const isDevDocs = main.classList.contains('dev-docs');
 
-  if (isDevBiz && hasAnyClass(block, CENTERED_VARIANTS)) {
+  if (isDevBiz && hasAnyClass(block, ['centered', 'centered-xl'])) {
     decorateDevBizCentered(block);
-  } else if (isDevDocs && hasAnyVariant(block, CENTERED_VARIANTS)) {
+  } else if (isDevDocs && hasAnyVariant(block, ['centered', 'centeredXL'])) {
     restructureAsDevBizCentered(block);
     decorateDevBizCentered(block);
     applyDataAttributeStyles(block);
-  } else if (isDevBiz && hasAnyClass(block, [VARIANTS.halfwidth])) {
+  } else if (isDevBiz && hasAnyClass(block, ['half-width'])) {
     decorateDevBizHalfWidth(block);
   }
 }
@@ -39,7 +33,7 @@ function hasAnyClass(block, classes) {
 }
 
 function hasAnyVariant(block, variants) {
-  const variant = block.getAttribute('data-variant') || VARIANTS.default;
+  const variant = block.getAttribute('data-variant') || DEFAULT_VARIANT;
   return variants.some((v) => v === variant);
 }
 
@@ -144,20 +138,20 @@ function restructureAsDevBizCentered(block) {
   const imageContent = slotElements.image?.querySelector('picture > img');
 
   const newChildren = [];
-  
+
   const contentDiv = createTag('div');
   const contentInnerDiv = createTag('div');
-  
+
   if (headingContent) {
     contentInnerDiv.appendChild(headingContent);
   }
-  
+
   if (textContent) {
     const p = createTag('p');
     p.textContent = textContent.textContent;
     contentInnerDiv.appendChild(p);
   }
-  
+
   if (buttonsContent) {
     buttonsContent.forEach((button, index) => {
       const p = createTag('p', { class: 'button-container' });
@@ -171,31 +165,34 @@ function restructureAsDevBizCentered(block) {
       contentInnerDiv.appendChild(p);
     });
   }
-  
+
   contentDiv.appendChild(contentInnerDiv);
   newChildren.push(contentDiv);
-  
+
   const imageDiv = createTag('div');
   const imageInnerDiv = createTag('div');
-  
+
   if (imageContent) {
     const picture = createTag('picture');
     picture.appendChild(imageContent);
     imageInnerDiv.appendChild(picture);
   }
-  
+
   imageDiv.appendChild(imageInnerDiv);
   newChildren.push(imageDiv);
-  
+
   block.replaceChildren(...newChildren);
 }
 
 function applyDataAttributeStyles(block) {
+  const variant = block.getAttribute('data-variant') || DEFAULT_VARIANT;
+  block.classList.add(variant);
+
   const background = block.getAttribute('data-background') || DEFAULT_BACKGROUND_COLOR;
   block.style.background = background;
 
   const textColor = block.getAttribute('data-textcolor') || DEFAULT_TEXT_COLOR;
-  if(ALLOWED_TEXT_COLORS.includes(textColor)) {
+  if (ALLOWED_TEXT_COLORS.includes(textColor)) {
     block.querySelectorAll('h1, h2, h3, h4, h5, h6, p').forEach((el) => {
       el.style.color = textColor;
     });
@@ -215,5 +212,3 @@ function rearrangeLinks(block) {
   });
   leftDiv.append(heroButtonContainer);
 }
-
-


### PR DESCRIPTION
## Description
Rename Superhero variants to
- kebab-case for DevBiz
- camelCase for DevDocs

## Context
- Use camelCase in DevDocs because while Gatsby uses both camelCase and lowercase, camelCase is easier to read and doesn't get marked as spelling error in IDEs.
- Use kebab-case in DevBiz because it is already using kebab-case for other classNames and block names. This way, the Google doc won't look odd with mixed cases.
- We can keep the variant names separate for DevBiz and DevDocs because the overlap is only large for our team and not widespread across the site (https://adobeio.slack.com/archives/C06M1C7UBV3/p1758569490379679?thread_ts=1758568335.783539&cid=C06M1C7UBV3).

## Ticket 
https://jira.corp.adobe.com/browse/DEVSITE-1756

## Test
Verified these render the same after standardizing variant names:

| Workflow | Variant | Source | Page |
| -- | -- | -- | -- |
| DevBiz | centered | https://docs.google.com/document/d/1r70ZJKXHzhzVrG-sPwUrwxb-0vFDdgjzyMCLs9_2IqE/edit?tab=t.0#heading=h.kfcfoa8idwsy | https://rename-superhero-variants--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/sitehero-default?nocache=1757448691014 |
| DevDocs | centered | https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/superhero/new/superhero-centered.md?plain=1 | https://rename-superhero-variants--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/superhero-centered |
| DevBiz | centered-xl | https://docs.google.com/document/d/11WdFTcVNHNXWKC0b3iXUN16numvA6vmWxLsjw92vZds/edit?tab=t.0 | https://rename-superhero-variants--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/sitehero-xl?nocache=1757450847855 |
| DevDocs | centeredXL | https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/superhero/new/superhero-centeredxl.md?plain=1 | https://rename-superhero-variants--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/superhero-centeredxl |
| DevBiz | half-width | https://docs.google.com/document/d/1B4Rjhkhlk3Hc7ce6mRtT1KYr0qCmby8ut3S_bxG2Aoo/edit?tab=t.0 | https://rename-superhero-variants--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/hero-default?nocache=1757690545196 |
| DevBiz | half-width with video | https://docs.google.com/document/d/17965XTRbTug-LSZBpratisUCcveqV9lvizYcchgMpyY/edit?tab=t.0 | https://rename-superhero-variants--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/hero-full-width-background?nocache=1758576037884 |


