### PR TITLE
refactor: rename text-color modifier

### DIFF
--- a/hlx_statics/blocks/superhero/superhero.css
+++ b/hlx_statics/blocks/superhero/superhero.css
@@ -156,13 +156,6 @@ main div.superhero-wrapper div.superhero.half-width p.spectrum-Body--sizeL {
   color: rgb(80, 80, 80) !important;
 }
 
-main div.superhero-wrapper div.superhero.half-width.font-white h1,
-main div.superhero-wrapper div.superhero.half-width.font-white h2,
-main div.superhero-wrapper div.superhero.half-width.font-white h3,
-main div.superhero-wrapper div.superhero.half-width.font-white p {
-  color: white !important;
-}
-
 main div.superhero-wrapper:has(div.superhero.half-width) {
   padding: 0;
 }


### PR DESCRIPTION
## Description 
Rename text color modifiers in `Superhero` for consistency

 ## Context 
- HeroSimple uses `text-color-white`: https://github.com/AdobeDocs/adp-devsite/blob/eb342aa9251ddebd93e9d917c5ab407cb2f2e1c6/hlx_statics/blocks/herosimple/herosimple.css#L74-L88
- Hero uses
  - `font-white`: https://github.com/AdobeDocs/adp-devsite/blob/eb342aa9251ddebd93e9d917c5ab407cb2f2e1c6/hlx_statics/blocks/hero/hero.css#L21-L26
  - `font-color-white`: https://github.com/AdobeDocs/adp-devsite/blob/eb342aa9251ddebd93e9d917c5ab407cb2f2e1c6/hlx_statics/blocks/hero/hero.css#L114-L126
 - Since we're consolidating these into Superhero, we should standardize the naming conventions
 - `text-color` is better than `font-color` because it's more accurate (i.e. sets the color of the text content, whereas font typically refers to typeface, size, weight, etc.)

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1756

## Test
Verified page renders the same after renaming text color modifier from `font-color-...` to `text-color-...`
| Text color | Source | Page |
| -- | -- | -- |
| white | https://docs.google.com/document/d/1tSUO4RRtR8apjw5QdncUwEDoo6yNbziqQn5VEQJ0cY4/edit?tab=t.0 | https://rename-text-color-attribute--adp-devsite--adobedocs.aem.page/test/melissa/superhero/test/text-color-white?nocache=1758650245924|
| black | https://docs.google.com/document/d/1-Jjk_EAPJEEVyhlc9ffGfAeogb5hd87NOeZh15-NB7c/edit?tab=t.0 | https://rename-text-color-attribute--adp-devsite--adobedocs.aem.page/test/melissa/superhero/test/text-color-black?nocache=1758650346024 |