### PR TITLE
docs: update AEM install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 This is the Adobe I/O Helix repo. It contains all the scripts, styles and other helixy bits to power the adobe.io website. 
 
 ## Installation
-1. Install hlx as a global command. You need Node 10.13 or newer. `$ npm install -g @adobe/helix-cli`
-3. Run `$ hlx up`
+1. Install hlx as a global command. You need Node 10.13 or newer. `$ npm install -g @adobe/aem-cli`
+3. Run `$ aem up`
 4. Navigate to http://localhost:3000/
 
 ## Building styles


### PR DESCRIPTION
## Description
Update AEM install instructions

## Context
We should be using the `@adobe/aem-cli` as the server. `@adobe/helix-cli` is old now. (https://adobeio.slack.com/archives/C03AVNFAA8Y/p1758662589077779?thread_ts=1758659930.585559&cid=C03AVNFAA8Y)