### PR TITLE
refactor: handling of devdocs superhero names

### DIFF
--- a/hlx_statics/blocks/superhero/superhero.css
+++ b/hlx_statics/blocks/superhero/superhero.css
@@ -1,6 +1,5 @@
 main div.superhero-wrapper:has(div.superhero.centered),
-main div.superhero-wrapper:has(div.superhero.centered-xl),
-main div.superhero-wrapper:has(div.superhero.centeredXL) {
+main div.superhero-wrapper:has(div.superhero.centered-xl) {
   background: rgb(255, 255, 255);
   background-position: center;
   background-size: cover;
@@ -13,16 +12,14 @@ main div.superhero-wrapper div.superhero.centered {
   height: 350px;
 }
 
-main div.superhero-wrapper div.superhero.centered-xl,
-main div.superhero-wrapper div.superhero.centeredXL {
+main div.superhero-wrapper div.superhero.centered-xl {
   position: relative;
   width: 100%;
   height: 624px;
 }
 
 main div.superhero-wrapper div.superhero.centered .superhero-content,
-main div.superhero-wrapper div.superhero.centered-xl .superhero-content,
-main div.superhero-wrapper div.superhero.centeredXL .superhero-content {
+main div.superhero-wrapper div.superhero.centered-xl .superhero-content {
   position: absolute;
   display: flex;
   flex-direction: column;
@@ -34,8 +31,7 @@ main div.superhero-wrapper div.superhero.centeredXL .superhero-content {
   width: 100%;
 }
 
-main div.superhero-wrapper div.superhero.centered-xl img,
-main div.superhero-wrapper div.superhero.centeredXL img {
+main div.superhero-wrapper div.superhero.centered-xl img {
   width: 100%;
   height: 624px;
   object-fit: cover;
@@ -48,16 +44,14 @@ main div.superhero-wrapper div.superhero.centered img {
 }
 
 main div.superhero-wrapper div.superhero.centered :is(h1, h2, h3, h4, h5, h6),
-main div.superhero-wrapper div.superhero.centered-xl :is(h1, h2, h3, h4, h5, h6),
-main div.superhero-wrapper div.superhero.centeredXL :is(h1, h2, h3, h4, h5, h6) {
+main div.superhero-wrapper div.superhero.centered-xl :is(h1, h2, h3, h4, h5, h6) {
   text-align: center;
   margin-top: 0;
   margin-bottom: 16px;
 }
 
 main div.superhero-wrapper div.superhero.centered p.spectrum-Body--sizeL,
-main div.superhero-wrapper div.superhero.centered-xl p.spectrum-Body--sizeL,
-main div.superhero-wrapper div.superhero.centeredXL p.spectrum-Body--sizeL {
+main div.superhero-wrapper div.superhero.centered-xl p.spectrum-Body--sizeL {
   margin-top: 0 !important;
   font-size: 18px;
   /* color: rgb(34, 34, 34) !important; */
@@ -65,8 +59,7 @@ main div.superhero-wrapper div.superhero.centeredXL p.spectrum-Body--sizeL {
 }
 
 main div.superhero-wrapper div.superhero.centered .superhero-button-container,
-main div.superhero-wrapper div.superhero.centered-xl .superhero-button-container,
-main div.superhero-wrapper div.superhero.centeredXL .superhero-button-container {
+main div.superhero-wrapper div.superhero.centered-xl .superhero-button-container {
   display: flex;
   flex-wrap: wrap;
   display: inline-flex;
@@ -77,21 +70,18 @@ main div.superhero-wrapper div.superhero.centeredXL .superhero-button-container 
 
 @media screen and (min-width: 768px) and (max-width: 1024px) {
   main div.superhero-wrapper div.superhero.centered .superhero-content,
-  main div.superhero-wrapper div.superhero.centered-xl .superhero-content,
-  main div.superhero-wrapper div.superhero.centeredXL .superhero-content {
+  main div.superhero-wrapper div.superhero.centered-xl .superhero-content {
     padding: 0 32px;
   }
 
   main div.superhero-wrapper div.superhero.centered img,
-  main div.superhero-wrapper div.superhero.centered-xl img,
-  main div.superhero-wrapper div.superhero.centeredXL img {
+  main div.superhero-wrapper div.superhero.centered-xl img {
     width: 100%;
     height: 350px;
     object-fit: cover;
   }
 
-  main div.superhero-wrapper .centered-xl img,
-  main div.superhero-wrapper .centeredXL img {
+  main div.superhero-wrapper .centered-xl img {
     width: 100%;
     height: 350px;
     object-fit: cover;
@@ -100,38 +90,33 @@ main div.superhero-wrapper div.superhero.centeredXL .superhero-button-container 
 
 @media screen and (min-width: 320px) and (max-width: 767px) {
   main div.superhero-wrapper div.superhero.centered,
-  main div.superhero-wrapper div.superhero.centered-xl,
-  main div.superhero-wrapper div.superhero.centeredXL {
+  main div.superhero-wrapper div.superhero.centered-xl {
     position: relative;
     width: 100%;
     height: 75vh !important;
   }
 
-  main div.superhero-wrapper div.superhero.centered-xl,
-  main div.superhero-wrapper div.superhero.centeredXL {
+  main div.superhero-wrapper div.superhero.centered-xl {
     position: relative;
     width: 100%;
     height: 100vh !important;
   }
 
   main div.superhero-wrapper div.superhero.centered img,
-  main div.superhero-wrapper div.superhero.centered-xl img,
-  main div.superhero-wrapper div.superhero.centeredXL img {
+  main div.superhero-wrapper div.superhero.centered-xl img {
     overflow-clip-margin: content-box;
     overflow: clip;
     height: 75vh !important;
   }
 
-  main div.superhero-wrapper div.superhero.centered-xl img,
-  main div.superhero-wrapper div.superhero.centeredXL img {
+  main div.superhero-wrapper div.superhero.centered-xl img {
     overflow-clip-margin: content-box;
     overflow: clip;
     height: 100vh !important;
   }
 
   main div.superhero-wrapper div.superhero.centered .superhero-content,
-  main div.superhero-wrapper div.superhero.centered-xl .superhero-content,
-  main div.superhero-wrapper div.superhero.centeredXL .superhero-content {
+  main div.superhero-wrapper div.superhero.centered-xl .superhero-content {
     padding: 0 32px;
   }
 }

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -1,7 +1,13 @@
 import { removeEmptyPTags, decorateButtons, createTag } from '../../scripts/lib-adobeio.js';
 import { decorateLightOrDark } from '../../scripts/lib-helix.js';
 
-const DEFAULT_VARIANT = 'default';
+const VARIANTS = {
+  default: 'default',
+  centered: 'centered',
+  centeredXL: 'centered-xl',
+  halfWidth: 'half-width',
+};
+const CENTERED_VARIANTS = [VARIANTS.centered, VARIANTS.centeredXL];
 const DEFAULT_BACKGROUND_COLOR = 'rgb(29, 125, 238)';
 const DEFAULT_TEXT_COLOR = 'white';
 const ALLOWED_TEXT_COLORS = ['black', DEFAULT_TEXT_COLOR, 'gray', 'navy'];
@@ -17,13 +23,17 @@ export default async function decorate(block) {
   const isDevBiz = main.classList.contains('dev-biz');
   const isDevDocs = main.classList.contains('dev-docs');
 
-  if (isDevBiz && hasAnyClass(block, ['centered', 'centered-xl'])) {
+  if (isDevDocs) {
+    renameAsDevBiz(block);
+  }
+
+  if (isDevBiz && hasAnyClass(block, CENTERED_VARIANTS)) {
     decorateDevBizCentered(block);
-  } else if (isDevDocs && hasAnyVariant(block, ['centered', 'centeredXL'])) {
+  } else if (isDevDocs && hasAnyVariant(block, CENTERED_VARIANTS)) {
     restructureAsDevBizCentered(block);
     decorateDevBizCentered(block);
     applyDataAttributeStyles(block);
-  } else if (isDevBiz && hasAnyClass(block, ['half-width'])) {
+  } else if (isDevBiz && hasAnyClass(block, [VARIANTS.halfWidth])) {
     decorateDevBizHalfWidth(block);
   }
 }
@@ -33,7 +43,7 @@ function hasAnyClass(block, classes) {
 }
 
 function hasAnyVariant(block, variants) {
-  const variant = block.getAttribute('data-variant') || DEFAULT_VARIANT;
+  const variant = block.getAttribute('data-variant') || VARIANTS.default;
   return variants.some((v) => v === variant);
 }
 
@@ -121,7 +131,18 @@ async function decorateDevBizHalfWidth(block) {
 }
 
 /**
- * restructures a devdocs block to match devbiz before the decorate function runs
+ * renames attributes of a DevDocs block from camelCase to kebab-case to match DevBiz before the decorate function runs
+ */
+function renameAsDevBiz(block) {
+  const variant = block.getAttribute('data-variant') || VARIANTS.default;
+  // VARIANTS has camelCase keys and kebab-case values
+  if (variant in VARIANTS) {
+    block.setAttribute('data-variant', VARIANTS[variant]);
+  }
+}
+
+/**
+ * restructures a DevDocs block to match DevBiz before the decorate function runs
  */
 function restructureAsDevBizCentered(block) {
   const slotNames = block


### PR DESCRIPTION
## Description
Refactor handling of DevDocs names in https://github.com/AdobeDocs/adp-devsite/pull/312.

The previous approach is harder to read and maintain because it requires pairs of CSS selectors with kebab-case for DevBiz and camelCase for DevDocs. 

The current approach dynamically renames DevDoc's camelCase to match DevBiz's kebab-case so it can reuse DevBiz's CSS.

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1756

## Test
Verified these pages render the same without changing the Google doc / markdown file
| Workflow | Variant | Source | Page |
| -- | -- | -- | -- |
| DevBiz | centered | https://docs.google.com/document/d/1r70ZJKXHzhzVrG-sPwUrwxb-0vFDdgjzyMCLs9_2IqE/edit?tab=t.0#heading=h.kfcfoa8idwsy | https://refactor-superhero-name-handling--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/sitehero-default?nocache=1757448691014 |
| DevDocs | centered | https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/superhero/new/superhero-centered.md?plain=1 | https://refactor-superhero-name-handling--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/superhero-centered |
| DevBiz | centered-xl | https://docs.google.com/document/d/11WdFTcVNHNXWKC0b3iXUN16numvA6vmWxLsjw92vZds/edit?tab=t.0 | https://refactor-superhero-name-handling--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/sitehero-xl?nocache=1757450847855 |
| DevDocs | centeredXL | https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/superhero/new/superhero-centeredxl.md?plain=1 | https://refactor-superhero-name-handling--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/superhero-centeredxl |
| DevBiz | half-width | https://docs.google.com/document/d/1B4Rjhkhlk3Hc7ce6mRtT1KYr0qCmby8ut3S_bxG2Aoo/edit?tab=t.0 | https://refactor-superhero-name-handling--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/hero-default?nocache=1757690545196 |
| DevBiz | half-width with video | https://docs.google.com/document/d/17965XTRbTug-LSZBpratisUCcveqV9lvizYcchgMpyY/edit?tab=t.0 | https://refactor-superhero-name-handling--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/hero-full-width-background?nocache=1758576037884 |
