### PR TITLE
decode any brackets

### DIFF
--- a/hlx_statics/blocks/table/table.js
+++ b/hlx_statics/blocks/table/table.js
@@ -51,14 +51,12 @@ export default async function decorate(block) {
     [...child.children].forEach((col) => {
       const rowIndex = hasHeader ? i : i + 1;
       const cell = isHeader ? buildCellHead(rowIndex) : buildCell(rowIndex);
-      // Replace HTML entities for <br/> tags
-      const cellContent = col.innerHTML.replace(/&lt;br\/&gt;/g, '<br/>');
-      cell.innerHTML = cellContent;
+      cell.innerHTML = col.innerHTML;
       row.append(cell);
     });
   });
 
   block.innerHTML = '';
   block.append(table);
-  
+
 }

--- a/hlx_statics/scripts/lib-helix.js
+++ b/hlx_statics/scripts/lib-helix.js
@@ -392,6 +392,7 @@ export function decorateBlock(block) {
   }
 }
 
+
 /**
  * Extracts the config from a block.
  * @param {Element} block The block element
@@ -506,6 +507,7 @@ export function updateSectionsStatus(main) {
  * @param {Element} main The container element
  */
 export function decorateBlocks(main) {
+  main.innerHTML = main.innerHTML.replace(/&lt;/g, '<').replace(/&gt;/g, '>');
   main
     .querySelectorAll('div.section > div > div')
     .forEach((block) => decorateBlock(block));
@@ -843,21 +845,21 @@ window.copyMarkdownContent = async function(btn, event) {
   if (event) {
     event.preventDefault();
   }
-  
+
   const baseUrl = btn.dataset.githubUrl;
   const rawUrl = baseUrl.replace('github.com', 'raw.githubusercontent.com').replace('/blob/', '/');
   const label = btn.querySelector('.copy-markdown-button-label');
   const originalText = label.textContent;
-  
+
   try {
     const response = await fetch(rawUrl);
     if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
     await navigator.clipboard.writeText(await response.text());
     label.textContent = 'Copied!';
     btn.classList.add('copied');
-    setTimeout(() => { 
-      label.textContent = originalText; 
-      btn.classList.remove('copied'); 
+    setTimeout(() => {
+      label.textContent = originalText;
+      btn.classList.remove('copied');
     }, 3000);
     console.log('Markdown copied to clipboard!');
   } catch (error) {


### PR DESCRIPTION
This is a workaround for our brackets is to encode it in MD files and then decode it will render properly on the page.

Before: 
https://main--adp-devsite-stage--adobedocs.aem.page/commerce/contributor/guides/code-contributions/
The comment is showing up on the page
<img width="1405" height="356" alt="Screenshot 2025-09-25 at 1 29 44 PM" src="https://github.com/user-attachments/assets/e6460b5b-ec0c-47e7-90e8-2494dbcba725" />

After:
https://decode-anchor--adp-devsite-stage--adobedocs.aem.page/commerce/contributor/guides/code-contributions/ 
Comment only renders as comments on the page. 
<img width="1830" height="674" alt="Screenshot 2025-09-25 at 1 29 14 PM" src="https://github.com/user-attachments/assets/16e440fc-ecab-47db-a11d-193af281c13f" />
