### PR TITLE
feat: devdocs superhero halfwidth

### DIFF
--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -185,16 +185,16 @@ function restructureAsDevBiz(block) {
   }
 
   const mediaDiv = createTag('div');
-  const mediaInnerDiv = createTag('div');
 
   if (imageContent) {
+    const mediaInnerDiv = createTag('div');
     const picture = createTag('picture');
     picture.appendChild(imageContent);
     mediaInnerDiv.appendChild(picture);
+    mediaDiv.appendChild(mediaInnerDiv);
   }
 
-  if (mediaInnerDiv.children.length > 0) {
-    mediaDiv.appendChild(mediaInnerDiv);
+  if (mediaDiv.children.length > 0) {
     newChildren.push(mediaDiv);
   }
 

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -179,8 +179,10 @@ function restructureAsDevBiz(block) {
     });
   }
 
-  contentDiv.appendChild(contentInnerDiv);
-  newChildren.push(contentDiv);
+  if (contentInnerDiv.children.length > 0) {
+    contentDiv.appendChild(contentInnerDiv);
+    newChildren.push(contentDiv);
+  }
 
   const imageDiv = createTag('div');
   const imageInnerDiv = createTag('div');
@@ -191,8 +193,10 @@ function restructureAsDevBiz(block) {
     imageInnerDiv.appendChild(picture);
   }
 
-  imageDiv.appendChild(imageInnerDiv);
-  newChildren.push(imageDiv);
+  if (imageInnerDiv.children.length > 0) {
+    imageDiv.appendChild(imageInnerDiv);
+    newChildren.push(imageDiv);
+  }
 
   block.replaceChildren(...newChildren);
 }

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -15,9 +15,6 @@ const TEXT_COLORS = {
   navy: 'navy',
 };
 
-const DEFAULT_BACKGROUND_COLOR = 'rgb(29, 125, 238)';
-const DEFAULT_TEXT_COLOR = TEXT_COLORS.white;
-
 /**
  * decorates the superhero
  * @param {Element} block The superhero block element
@@ -45,6 +42,8 @@ function hasAnyClass(block, classes) {
 }
 
 async function decorateDevBizCentered(block) {
+  const defaultTextColor = TEXT_COLORS.white;
+
   removeEmptyPTags(block);
   decorateButtons(block);
 
@@ -53,7 +52,7 @@ async function decorateDevBizCentered(block) {
   block.classList.add('spectrum--dark');
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeXXL');
-    h.style.color = DEFAULT_TEXT_COLOR;
+    h.style.color = defaultTextColor;
     h.parentElement.classList.add('superhero-content');
     h.parentElement.append(button_div);
   });
@@ -61,7 +60,7 @@ async function decorateDevBizCentered(block) {
   block.querySelectorAll('p').forEach((p) => {
     if (!p.classList.contains('icon-container')) {
       p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
-      p.style.color = DEFAULT_TEXT_COLOR;
+      p.style.color = defaultTextColor;
     }
     if (p.classList.contains('button-container')) {
       button_div.append(p);
@@ -134,7 +133,17 @@ function restructureAsDevBiz(block) {
   const camelCaseVariant = block.getAttribute('data-variant') || VARIANTS.default;
   if (camelCaseVariant in VARIANTS) {
     const kebabCaseVariant = VARIANTS[camelCaseVariant];
+    block.setAttribute('data-variant', kebabCaseVariant);
     block.classList.add(kebabCaseVariant);
+  }
+
+  const textColor = block.getAttribute('data-textcolor');
+  if (textColor) {
+    block.classList.add(`text-color-${textColor}`);
+  }
+
+  if (block.getAttribute('data-overgradient')) {
+    block.classList.add('over-gradient');
   }
 
   const slotNames = block
@@ -142,18 +151,33 @@ function restructureAsDevBiz(block) {
     ?.split(',')
     .map((slot) => slot.trim());
 
+  if (slotNames.includes('fullWidthBackground')) {
+    block.classList.add('full-width-background');
+  }
+
+  if (slotNames.includes('video')) {
+    block.classList.add('video');
+  }
+
   const children = Array.from(block.children[0].children);
   const slotElements = Object.fromEntries(slotNames.map((slotName, index) => [slotName, children[index]]));
 
+  const iconContent = slotElements.icon?.firstElementChild;
   const headingContent = slotElements.heading?.querySelector('h1, h2, h3, h4, h5, h6');
   const textContent = slotElements.text;
   const buttonsContent = slotElements.buttons?.querySelectorAll('ul > li > a');
+  const backgroundContent = slotElements.fullWidthBackground?.querySelector('picture > img');
   const imageContent = slotElements.image?.querySelector('picture > img');
+  const videoContent = slotElements.video;
 
   const newChildren = [];
 
   const contentDiv = createTag('div');
   const contentInnerDiv = createTag('div');
+
+  if (iconContent) {
+    contentInnerDiv.appendChild(iconContent);
+  }
 
   if (headingContent) {
     contentInnerDiv.appendChild(headingContent);
@@ -184,6 +208,20 @@ function restructureAsDevBiz(block) {
     newChildren.push(contentDiv);
   }
 
+  const backgroundDiv = createTag('div');
+  const backgroundInnerDiv = createTag('div');
+
+  if (backgroundContent) {
+    const picture = createTag('picture');
+    picture.appendChild(backgroundContent);
+    backgroundInnerDiv.appendChild(picture);
+  }
+
+  if (backgroundInnerDiv.children.length > 0) {
+    backgroundDiv.appendChild(backgroundInnerDiv);
+    newChildren.push(backgroundDiv);
+  }
+
   const mediaDiv = createTag('div');
 
   if (imageContent) {
@@ -194,6 +232,10 @@ function restructureAsDevBiz(block) {
     mediaDiv.appendChild(mediaInnerDiv);
   }
 
+  if (videoContent) {
+    mediaDiv.appendChild(videoContent);
+  }
+
   if (mediaDiv.children.length > 0) {
     newChildren.push(mediaDiv);
   }
@@ -202,10 +244,14 @@ function restructureAsDevBiz(block) {
 }
 
 function applyDataAttributeStyles(block) {
-  const background = block.getAttribute('data-background') || DEFAULT_BACKGROUND_COLOR;
+  const variant = block.getAttribute('data-variant') || VARIANTS.default;
+
+  const defaultBackgroundColor = variant === VARIANTS.halfWidth ? 'rgb(255, 255, 255)' : 'rgb(29, 125, 238)';
+  const background = block.getAttribute('data-background') || defaultBackgroundColor;
   block.style.background = background;
 
-  const textColor = block.getAttribute('data-textcolor') || DEFAULT_TEXT_COLOR;
+  const defaultTextColor = variant === VARIANTS.halfWidth ? TEXT_COLORS.black : TEXT_COLORS.white;
+  const textColor = block.getAttribute('data-textcolor') || defaultTextColor;
   if (Object.keys(TEXT_COLORS).includes(textColor)) {
     block.querySelectorAll('h1, h2, h3, h4, h5, h6, p').forEach((el) => {
       el.style.color = textColor;

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -7,9 +7,16 @@ const VARIANTS = {
   centeredXL: 'centered-xl',
   halfWidth: 'half-width',
 };
+
+const TEXT_COLORS = {
+  black: 'black',
+  white: 'white',
+  gray: 'gray',
+  navy: 'navy',
+};
+
 const DEFAULT_BACKGROUND_COLOR = 'rgb(29, 125, 238)';
-const DEFAULT_TEXT_COLOR = 'white';
-const ALLOWED_TEXT_COLORS = ['black', DEFAULT_TEXT_COLOR, 'gray', 'navy'];
+const DEFAULT_TEXT_COLOR = TEXT_COLORS.white;
 
 /**
  * decorates the superhero
@@ -195,7 +202,7 @@ function applyDataAttributeStyles(block) {
   block.style.background = background;
 
   const textColor = block.getAttribute('data-textcolor') || DEFAULT_TEXT_COLOR;
-  if (ALLOWED_TEXT_COLORS.includes(textColor)) {
+  if (Object.keys(TEXT_COLORS).includes(textColor)) {
     block.querySelectorAll('h1, h2, h3, h4, h5, h6, p').forEach((el) => {
       el.style.color = textColor;
     });

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -184,18 +184,18 @@ function restructureAsDevBiz(block) {
     newChildren.push(contentDiv);
   }
 
-  const imageDiv = createTag('div');
-  const imageInnerDiv = createTag('div');
+  const mediaDiv = createTag('div');
+  const mediaInnerDiv = createTag('div');
 
   if (imageContent) {
     const picture = createTag('picture');
     picture.appendChild(imageContent);
-    imageInnerDiv.appendChild(picture);
+    mediaInnerDiv.appendChild(picture);
   }
 
-  if (imageInnerDiv.children.length > 0) {
-    imageDiv.appendChild(imageInnerDiv);
-    newChildren.push(imageDiv);
+  if (mediaInnerDiv.children.length > 0) {
+    mediaDiv.appendChild(mediaInnerDiv);
+    newChildren.push(mediaDiv);
   }
 
   block.replaceChildren(...newChildren);

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -7,7 +7,6 @@ const VARIANTS = {
   centeredXL: 'centered-xl',
   halfWidth: 'half-width',
 };
-const CENTERED_VARIANTS = [VARIANTS.centered, VARIANTS.centeredXL];
 const DEFAULT_BACKGROUND_COLOR = 'rgb(29, 125, 238)';
 const DEFAULT_TEXT_COLOR = 'white';
 const ALLOWED_TEXT_COLORS = ['black', DEFAULT_TEXT_COLOR, 'gray', 'navy'];
@@ -20,31 +19,22 @@ export default async function decorate(block) {
   block.setAttribute('daa-lh', 'superhero');
 
   const main = document.querySelector('main');
-  const isDevBiz = main.classList.contains('dev-biz');
   const isDevDocs = main.classList.contains('dev-docs');
 
   if (isDevDocs) {
-    renameAsDevBiz(block);
+    restructureAsDevBiz(block);
+    applyDataAttributeStyles(block);
   }
 
-  if (isDevBiz && hasAnyClass(block, CENTERED_VARIANTS)) {
+  if (hasAnyClass(block, [VARIANTS.centered, VARIANTS.centeredXL])) {
     decorateDevBizCentered(block);
-  } else if (isDevDocs && hasAnyVariant(block, CENTERED_VARIANTS)) {
-    restructureAsDevBizCentered(block);
-    decorateDevBizCentered(block);
-    applyDataAttributeStyles(block);
-  } else if (isDevBiz && hasAnyClass(block, [VARIANTS.halfWidth])) {
+  } else if (hasAnyClass(block, [VARIANTS.halfWidth])) {
     decorateDevBizHalfWidth(block);
   }
 }
 
 function hasAnyClass(block, classes) {
   return classes.some((c) => block.classList.contains(c));
-}
-
-function hasAnyVariant(block, variants) {
-  const variant = block.getAttribute('data-variant') || VARIANTS.default;
-  return variants.some((v) => v === variant);
 }
 
 async function decorateDevBizCentered(block) {
@@ -131,20 +121,15 @@ async function decorateDevBizHalfWidth(block) {
 }
 
 /**
- * renames attributes of a DevDocs block from camelCase to kebab-case to match DevBiz before the decorate function runs
- */
-function renameAsDevBiz(block) {
-  const variant = block.getAttribute('data-variant') || VARIANTS.default;
-  // VARIANTS has camelCase keys and kebab-case values
-  if (variant in VARIANTS) {
-    block.setAttribute('data-variant', VARIANTS[variant]);
-  }
-}
-
-/**
  * restructures a DevDocs block to match DevBiz before the decorate function runs
  */
-function restructureAsDevBizCentered(block) {
+function restructureAsDevBiz(block) {
+  const camelCaseVariant = block.getAttribute('data-variant') || VARIANTS.default;
+  if (camelCaseVariant in VARIANTS) {
+    const kebabCaseVariant = VARIANTS[camelCaseVariant];
+    block.classList.add(kebabCaseVariant);
+  }
+
   const slotNames = block
     ?.getAttribute('data-slots')
     ?.split(',')
@@ -206,9 +191,6 @@ function restructureAsDevBizCentered(block) {
 }
 
 function applyDataAttributeStyles(block) {
-  const variant = block.getAttribute('data-variant') || DEFAULT_VARIANT;
-  block.classList.add(variant);
-
   const background = block.getAttribute('data-background') || DEFAULT_BACKGROUND_COLOR;
   block.style.background = background;
 

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -146,7 +146,7 @@ function restructureAsDevBiz(block) {
   const slotElements = Object.fromEntries(slotNames.map((slotName, index) => [slotName, children[index]]));
 
   const headingContent = slotElements.heading?.querySelector('h1, h2, h3, h4, h5, h6');
-  const textContent = slotElements.text?.firstChild;
+  const textContent = slotElements.text;
   const buttonsContent = slotElements.buttons?.querySelectorAll('ul > li > a');
   const imageContent = slotElements.image?.querySelector('picture > img');
 
@@ -161,7 +161,7 @@ function restructureAsDevBiz(block) {
 
   if (textContent) {
     const p = createTag('p');
-    p.textContent = textContent.textContent;
+    p.innerHTML = textContent.innerHTML;
     contentInnerDiv.appendChild(p);
   }
 


### PR DESCRIPTION
## Description
Add DevDocs `half-width` to `Superhero`

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1756

## Test
DevDocs uses [Gatsby-compatible markdown](https://github.com/adobe/aio-theme?tab=readme-ov-file#hero-block) and DevBiz styling.

- Original half-width (originally from Gatsby):

| | DevDocs | DevBiz |
| --- | --- | --- |
| Source | https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/superhero/new/hero-default.md?plain=1 | https://docs.google.com/document/d/1B4Rjhkhlk3Hc7ce6mRtT1KYr0qCmby8ut3S_bxG2Aoo/edit?tab=t.0 |
| Page | https://devdocs-superhero-halfwidth--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/hero-default | https://devdocs-superhero-halfwidth--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/hero-default?nocache=1757690545196 |

- Padded half-width with image (originally from DevBiz):

| | DevDocs | DevBiz |
| --- | --- | --- |
| Source | https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/superhero/new/hero-default-image.md?plain=1 | https://docs.google.com/document/d/1rN-2vB7flE_LZNs6iRVEiF2v4yp6rZi8xG51PrWmqK4/edit?tab=t.0 |
| Page | https://devdocs-superhero-halfwidth--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/hero-default-image | https://devdocs-superhero-halfwidth--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/hero-full-width-background-and-image?nocache=1758854037176 |

- Padded half-width with video (originally from DevBiz):

| | DevDocs | DevBiz |
| --- | --- | --- |
| Source | https://github.com/AdobeDocs/adp-devsite-github-actions-test/blob/main/src/pages/test/superhero/new/hero-default-video.md?plain=1 | https://docs.google.com/document/d/1x_0-TfhhizvdYLTv3eLTeQAextYyQRXvwiNvzvDOeys/edit?tab=t.0 |
| Page | https://devdocs-superhero-halfwidth--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/hero-default-video | https://devdocs-superhero-halfwidth--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/hero-full-width-background-and-video?nocache=1758853480107 |


## Other tests
This PR refactored `Superhero` a bit, so ensured the existing variants remain unchanged:
- centered
  - DevBiz: https://devdocs-superhero-halfwidth--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/sitehero-default?nocache=1757448691014
  - DevDocs: https://devdocs-superhero-halfwidth--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/herosimple-fullwidth
- centered-xl
  - DevBiz: https://devdocs-superhero-halfwidth--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/sitehero-xl?nocache=1757450847855
  - DevDocs: https://devdocs-superhero-halfwidth--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/superhero-centeredxl

