### PR TITLE
feat: remove gatsby-style half-width variant from superhero

### DIFF
--- a/hlx_statics/blocks/superhero/superhero.css
+++ b/hlx_statics/blocks/superhero/superhero.css
@@ -121,8 +121,12 @@ main div.superhero-wrapper div.superhero.centered-xl .superhero-button-container
   }
 }
 
+main div.superhero-wrapper:has(div.superhero.half-width),
 main div.superhero-wrapper div.superhero.half-width {
   background: rgb(255, 255, 255);
+}
+
+main div.superhero-wrapper div.superhero.half-width {
   height: 500px;
   width: 100%;
   overflow: hidden;
@@ -130,7 +134,7 @@ main div.superhero-wrapper div.superhero.half-width {
   justify-content: center;
 }
 
-main div.superhero-wrapper div.superhero.half-width.full-width-background img {
+main div.superhero-wrapper div.superhero.half-width img {
   width: 100% !important;
   height: 350px !important;
   object-fit: cover !important;
@@ -175,11 +179,11 @@ main div.superhero-wrapper div.superhero.half-width div:nth-child(2) > div img {
   min-height: 500px !important;
 }
 
-main div.superhero-wrapper:has(.half-width.full-width-background) div:nth-child(2) > div img {
+main div.superhero-wrapper:has(.half-width) div:nth-child(2) > div img {
   display: none;
 }
 
-main div.superhero-wrapper:has(.half-width.full-width-background) div:nth-child(3) {
+main div.superhero-wrapper:has(.half-width) div:nth-child(3) {
   display: flex;
   align-items: center;
 }

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -111,11 +111,22 @@ async function decorateDevBizHalfWidth(block) {
     heroWrapper.querySelectorAll('.superhero-container > div > div').forEach((herowrapper) => {
       Object.assign(herowrapper.style, {
         backgroundColor: 'transparent',
-        width: '75%',
-        margin: 'auto',
       });
     });
+  } else {
+    // insert a placeholder div (where the background image would be), because it is styled as the space between the text and the image/video.
+    const emptyDiv = createTag('div');
+    const emptyInnerDiv = createTag('div');
+    emptyDiv.appendChild(emptyInnerDiv);
+    block.insertBefore(emptyDiv, block.lastElementChild);
   }
+
+  heroWrapper.querySelectorAll('.superhero-container > div > div').forEach((herowrapper) => {
+    Object.assign(herowrapper.style, {
+      width: '75%',
+      margin: 'auto',
+    });
+  });
 
   const videoURL = block.lastElementChild.querySelector('a');
   if (videoURL && block.classList.contains('video')) {
@@ -249,6 +260,8 @@ function applyDataAttributeStyles(block) {
   const defaultBackgroundColor = variant === VARIANTS.halfWidth ? 'rgb(255, 255, 255)' : 'rgb(29, 125, 238)';
   const background = block.getAttribute('data-background') || defaultBackgroundColor;
   block.style.background = background;
+  const wrapper = block.parentElement;
+  wrapper.style.background = background;
 
   const defaultTextColor = variant === VARIANTS.halfWidth ? TEXT_COLORS.black : TEXT_COLORS.white;
   const textColor = block.getAttribute('data-textcolor') || defaultTextColor;


### PR DESCRIPTION
## Description
Replace SuperHero `half-width` variant from Gatsby-style to Express-style.

## Context
Currently, we have two types of `half-width` variants for Hero:
1. Gatsby-style: non-padded, carried over from [aio-theme](https://github.com/adobe/aio-theme?tab=readme-ov-file#hero-block)

<img width="1728" height="1040" alt="Screenshot 2025-09-26 at 6 05 57 PM" src="https://github.com/user-attachments/assets/b6880897-0af8-4718-9cb5-b0333a091408" />

2. Express-style: padded, designed by Express team

<img width="1728" height="1040" alt="Screenshot 2025-09-26 at 6 06 06 PM" src="https://github.com/user-attachments/assets/76931595-9698-4e46-bccb-d5b4a082846e" />




Pat noted the styles are similar enough to go with the Express team's style for SuperHero. We're discontinuing the Gatsby-style variant since the Express team has been very specific about their design requirements, and Pat believes most teams won't mind this small change.

## Test
These pages rendered Gatsby-style on `stage`, but now render Express-style on `remove-gatsby-style-half-width`:
- DevBiz half-width:  https://remove-gatsby-style-half-width--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/hero-default?nocache=1757690545196
- DevDocs half-width: https://remove-gatsby-style-half-width--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/hero-default

These pages were already Express-style, and remain unchanged between `stage` and `remove-gatsby-style-half-width`:
- DevBiz half-width with full-width-background and image: https://remove-gatsby-style-half-width--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/hero-full-width-background-and-image?nocache=1758854037176
- DevDocs half-width with full-width-background and image: https://remove-gatsby-style-half-width--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/hero-default-image
- DevBiz half-width with full-width-background and video: https://remove-gatsby-style-half-width--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/hero-full-width-background-and-video?nocache=1758853480107
- DevDocs half-width with full-width-background and video: https://remove-gatsby-style-half-width--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/hero-default-video

Background is configurable on DevDocs via the `background` attribute:
<img width="1728" height="1022" alt="Screenshot 2025-09-26 at 9 58 04 PM" src="https://github.com/user-attachments/assets/a5c1e65e-9c36-4a68-941c-4a0f95f9ae3a" />
