### PR TITLE
Devsite 1910- fix image not to be stretch 100%

### DIFF
--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -1186,8 +1186,7 @@ main .action-buttons div{
 }
 
 main .default-content-wrapper img{
-  width: 100%;
-  height: 100%;
+  max-width:100%
 }
 
 main li h3{

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -1186,7 +1186,9 @@ main .action-buttons div{
 }
 
 main .default-content-wrapper img{
-  max-width:100%
+  max-width: 100%;
+  display: block;
+  margin: 1rem 0;
 }
 
 main li h3{


### PR DESCRIPTION
Update how the image do not stretch all the way across a page. 

Previously: 
https://developer-stage.adobe.com/acrobat-sign/developer-guide/overview/releasenotes/

With Fix:
https://devsite-1910-image--adp-devsite-stage--adobedocs.aem.page/acrobat-sign/developer-guide/overview/releasenotes/