### PR TITLE
feat: superhero default

### DIFF
--- a/hlx_statics/blocks/superhero/superhero.css
+++ b/hlx_statics/blocks/superhero/superhero.css
@@ -310,6 +310,7 @@ main div.superhero-wrapper div.superhero.half-width div.superhero-video-containe
 main div.superhero-wrapper:has(div.superhero.default) {
   width: 100%;
 }
+
 main div.superhero-wrapper div.superhero.default {
   height: 272px;
   overflow: hidden;

--- a/hlx_statics/blocks/superhero/superhero.css
+++ b/hlx_statics/blocks/superhero/superhero.css
@@ -307,16 +307,16 @@ main div.superhero-wrapper div.superhero.half-width div.superhero-video-containe
   }
 }
 
-main div.superhero-wrapper {
+main div.superhero-wrapper:has(div.superhero.default) {
   width: 100%;
 }
-main div.superhero-wrapper div.superhero {
+main div.superhero-wrapper div.superhero.default {
   height: 272px;
   overflow: hidden;
   position: relative;
 }
 
-main div.superhero-wrapper div.superhero > div {
+main div.superhero-wrapper div.superhero.default > div {
   margin: 0 auto;
   width: 100%;
   display: flex;
@@ -326,112 +326,112 @@ main div.superhero-wrapper div.superhero > div {
   height: 100%;
 }
 
-main div.superhero-wrapper div.superhero > div > div {
+main div.superhero-wrapper div.superhero.default > div > div {
   width: calc(5 * 100% / 12);
   font-size: 20px;
 }
 
-main div.superhero-wrapper div.superhero .hero-left-content {
+main div.superhero-wrapper div.superhero.default .hero-left-content {
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
-main div.superhero-wrapper div.superhero div.hero-left-content > div {
+main div.superhero-wrapper div.superhero.default div.hero-left-content > div {
   display: flex;
   gap: 30px;
   flex-direction: column;
 }
 
-main div.superhero-wrapper div.superhero div.hero-left-content,
-main div.superhero-wrapper div.superhero div.hero-right-image {
+main div.superhero-wrapper div.superhero.default div.hero-left-content,
+main div.superhero-wrapper div.superhero.default div.hero-right-image {
   width: 50%;
 }
 
-main div.superhero-wrapper div.superhero div.hero-right-image img {
+main div.superhero-wrapper div.superhero.default div.hero-right-image img {
   width: 600px;
 }
 
-main div.superhero-wrapper div.halfWidth {
+main div.superhero-wrapper div.superhero.default.halfWidth {
   height: unset;
 }
 
-main div.superhero-wrapper div.halfWidth > div.superhero-container-wrapper {
+main div.superhero-wrapper div.superhero.default.halfWidth > div.superhero-container-wrapper {
   flex-direction: row;
   gap: 30px;
 }
 
-main div.superhero-wrapper div.fullWidth > div {
+main div.superhero-wrapper div.superhero.default.fullWidth > div {
   align-items: center;
   text-align: center;
 }
 
-main div.superhero-wrapper div.fullWidth > div > div {
+main div.superhero-wrapper div.superhero.default.fullWidth > div > div {
   width: unset;
 }
 
-main div.superhero-wrapper div.button-container > p,
-main div.superhero-wrapper .all-button-container > p {
+main div.superhero-wrapper div.superhero.default div.button-container > p,
+main div.superhero-wrapper div.superhero.default .all-button-container > p {
   margin: 0;
 }
 
-main div.superhero-wrapper .all-button-container {
+main div.superhero-wrapper div.superhero.default .all-button-container {
   display: inline-flex;
   gap: 16px;
 }
 
-main div.superhero-wrapper .text-color-white {
+main div.superhero-wrapper div.superhero.default.text-color-white {
   color: rgb(255, 255, 255);
 }
 
-main div.superhero-wrapper .text-color-black {
+main div.superhero-wrapper div.superhero.default.text-color-black {
   color: rgb(0, 0, 0);
 }
 
-main div.superhero-wrapper .text-color-gray {
+main div.superhero-wrapper div.superhero.default.text-color-gray {
   color: rgb(110, 110, 110);
 }
 
-main div.superhero-wrapper .text-color-navy {
+main div.superhero-wrapper div.superhero.default.text-color-navy {
   color: rgb(15, 55, 95);
 }
 
 @media screen and (min-width: 320px) and (max-width: 767px) {
-  main div.superhero-wrapper div.superhero div.hero-right-image img {
+  main div.superhero-wrapper div.superhero.default div.hero-right-image img {
     width: 300px;
   }
 }
 
 @media screen and (max-width: 1280px) {
-  main div.superhero-wrapper div.superhero > div > div {
+  main div.superhero-wrapper div.superhero.default > div > div {
     width: 100%;
   }
 }
 
-main div.superhero-wrapper div.superhero h1 {
+main div.superhero-wrapper div.superhero.default h1 {
   color: rgb(255, 255, 255);
   margin-top: 0;
   font-size: 36px !important;
 }
 
 @media screen and (max-width: 1024px) {
-  main div.superhero-wrapper div.superhero {
+  main div.superhero-wrapper div.superhero.default {
     height: auto;
     padding: 50px 0px;
   }
-  main div.superhero-wrapper div.superhero > div {
+  main div.superhero-wrapper div.superhero.default > div {
     margin: auto;
   }
 }
 
 @media screen and (max-width: 768px) {
-  main div.superhero-wrapper div.superhero {
+  main div.superhero-wrapper div.superhero.default {
     height: auto;
     padding: 32px 0;
   }
 }
 
-main div.superhero-wrapper .superhero .superhero-button-container {
+main div.superhero-wrapper div.superhero.default .superhero-button-container {
   display: flex;
   margin-top: 24px;
   gap: 16px;

--- a/hlx_statics/blocks/superhero/superhero.css
+++ b/hlx_statics/blocks/superhero/superhero.css
@@ -331,45 +331,6 @@ main div.superhero-wrapper div.superhero.default > div > div {
   font-size: 20px;
 }
 
-main div.superhero-wrapper div.superhero.default .hero-left-content {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-main div.superhero-wrapper div.superhero.default div.hero-left-content > div {
-  display: flex;
-  gap: 30px;
-  flex-direction: column;
-}
-
-main div.superhero-wrapper div.superhero.default div.hero-left-content,
-main div.superhero-wrapper div.superhero.default div.hero-right-image {
-  width: 50%;
-}
-
-main div.superhero-wrapper div.superhero.default div.hero-right-image img {
-  width: 600px;
-}
-
-main div.superhero-wrapper div.superhero.default.halfWidth {
-  height: unset;
-}
-
-main div.superhero-wrapper div.superhero.default.halfWidth > div.superhero-container-wrapper {
-  flex-direction: row;
-  gap: 30px;
-}
-
-main div.superhero-wrapper div.superhero.default.fullWidth > div {
-  align-items: center;
-  text-align: center;
-}
-
-main div.superhero-wrapper div.superhero.default.fullWidth > div > div {
-  width: unset;
-}
-
 main div.superhero-wrapper div.superhero.default div.button-container > p,
 main div.superhero-wrapper div.superhero.default .all-button-container > p {
   margin: 0;
@@ -394,12 +355,6 @@ main div.superhero-wrapper div.superhero.default.text-color-gray {
 
 main div.superhero-wrapper div.superhero.default.text-color-navy {
   color: rgb(15, 55, 95);
-}
-
-@media screen and (min-width: 320px) and (max-width: 767px) {
-  main div.superhero-wrapper div.superhero.default div.hero-right-image img {
-    width: 300px;
-  }
 }
 
 @media screen and (max-width: 1280px) {

--- a/hlx_statics/blocks/superhero/superhero.css
+++ b/hlx_statics/blocks/superhero/superhero.css
@@ -307,16 +307,16 @@ main div.superhero-wrapper div.superhero.half-width div.superhero-video-containe
   }
 }
 
-main div.herosimple-wrapper {
+main div.superhero-wrapper {
   width: 100%;
 }
-main div.herosimple-wrapper div.herosimple {
+main div.superhero-wrapper div.superhero {
   height: 272px;
   overflow: hidden;
   position: relative;
 }
 
-main div.herosimple-wrapper div.herosimple > div {
+main div.superhero-wrapper div.superhero > div {
   margin: 0 auto;
   width: 100%;
   display: flex;
@@ -326,112 +326,112 @@ main div.herosimple-wrapper div.herosimple > div {
   height: 100%;
 }
 
-main div.herosimple-wrapper div.herosimple > div > div {
+main div.superhero-wrapper div.superhero > div > div {
   width: calc(5 * 100% / 12);
   font-size: 20px;
 }
 
-main div.herosimple-wrapper div.herosimple .hero-left-content {
+main div.superhero-wrapper div.superhero .hero-left-content {
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
-main div.herosimple-wrapper div.herosimple div.hero-left-content > div {
+main div.superhero-wrapper div.superhero div.hero-left-content > div {
   display: flex;
   gap: 30px;
   flex-direction: column;
 }
 
-main div.herosimple-wrapper div.herosimple div.hero-left-content,
-main div.herosimple-wrapper div.herosimple div.hero-right-image {
+main div.superhero-wrapper div.superhero div.hero-left-content,
+main div.superhero-wrapper div.superhero div.hero-right-image {
   width: 50%;
 }
 
-main div.herosimple-wrapper div.herosimple div.hero-right-image img {
+main div.superhero-wrapper div.superhero div.hero-right-image img {
   width: 600px;
 }
 
-main div.herosimple-wrapper div.halfWidth {
+main div.superhero-wrapper div.halfWidth {
   height: unset;
 }
 
-main div.herosimple-wrapper div.halfWidth > div.herosimple-container-wrapper {
+main div.superhero-wrapper div.halfWidth > div.superhero-container-wrapper {
   flex-direction: row;
   gap: 30px;
 }
 
-main div.herosimple-wrapper div.fullWidth > div {
+main div.superhero-wrapper div.fullWidth > div {
   align-items: center;
   text-align: center;
 }
 
-main div.herosimple-wrapper div.fullWidth > div > div {
+main div.superhero-wrapper div.fullWidth > div > div {
   width: unset;
 }
 
-main div.herosimple-wrapper div.button-container > p,
-main div.herosimple-wrapper .all-button-container > p {
+main div.superhero-wrapper div.button-container > p,
+main div.superhero-wrapper .all-button-container > p {
   margin: 0;
 }
 
-main div.herosimple-wrapper .all-button-container {
+main div.superhero-wrapper .all-button-container {
   display: inline-flex;
   gap: 16px;
 }
 
-main div.herosimple-wrapper .text-color-white {
+main div.superhero-wrapper .text-color-white {
   color: rgb(255, 255, 255);
 }
 
-main div.herosimple-wrapper .text-color-black {
+main div.superhero-wrapper .text-color-black {
   color: rgb(0, 0, 0);
 }
 
-main div.herosimple-wrapper .text-color-gray {
+main div.superhero-wrapper .text-color-gray {
   color: rgb(110, 110, 110);
 }
 
-main div.herosimple-wrapper .text-color-navy {
+main div.superhero-wrapper .text-color-navy {
   color: rgb(15, 55, 95);
 }
 
 @media screen and (min-width: 320px) and (max-width: 767px) {
-  main div.herosimple-wrapper div.herosimple div.hero-right-image img {
+  main div.superhero-wrapper div.superhero div.hero-right-image img {
     width: 300px;
   }
 }
 
 @media screen and (max-width: 1280px) {
-  main div.herosimple-wrapper div.herosimple > div > div {
+  main div.superhero-wrapper div.superhero > div > div {
     width: 100%;
   }
 }
 
-main div.herosimple-wrapper div.herosimple h1 {
+main div.superhero-wrapper div.superhero h1 {
   color: rgb(255, 255, 255);
   margin-top: 0;
   font-size: 36px !important;
 }
 
 @media screen and (max-width: 1024px) {
-  main div.herosimple-wrapper div.herosimple {
+  main div.superhero-wrapper div.superhero {
     height: auto;
     padding: 50px 0px;
   }
-  main div.herosimple-wrapper div.herosimple > div {
+  main div.superhero-wrapper div.superhero > div {
     margin: auto;
   }
 }
 
 @media screen and (max-width: 768px) {
-  main div.herosimple-wrapper div.herosimple {
+  main div.superhero-wrapper div.superhero {
     height: auto;
     padding: 32px 0;
   }
 }
 
-main div.herosimple-wrapper .herosimple .herosimple-button-container {
+main div.superhero-wrapper .superhero .superhero-button-container {
   display: flex;
   margin-top: 24px;
   gap: 16px;

--- a/hlx_statics/blocks/superhero/superhero.css
+++ b/hlx_statics/blocks/superhero/superhero.css
@@ -306,3 +306,134 @@ main div.superhero-wrapper div.superhero.half-width div.superhero-video-containe
     min-height: 0px;
   }
 }
+
+main div.herosimple-wrapper {
+  width: 100%;
+}
+main div.herosimple-wrapper div.herosimple {
+  height: 272px;
+  overflow: hidden;
+  position: relative;
+}
+
+main div.herosimple-wrapper div.herosimple > div {
+  margin: 0 auto;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  row-gap: 30px;
+  justify-content: center;
+  height: 100%;
+}
+
+main div.herosimple-wrapper div.herosimple > div > div {
+  width: calc(5 * 100% / 12);
+  font-size: 20px;
+}
+
+main div.herosimple-wrapper div.herosimple .hero-left-content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+main div.herosimple-wrapper div.herosimple div.hero-left-content > div {
+  display: flex;
+  gap: 30px;
+  flex-direction: column;
+}
+
+main div.herosimple-wrapper div.herosimple div.hero-left-content,
+main div.herosimple-wrapper div.herosimple div.hero-right-image {
+  width: 50%;
+}
+
+main div.herosimple-wrapper div.herosimple div.hero-right-image img {
+  width: 600px;
+}
+
+main div.herosimple-wrapper div.halfWidth {
+  height: unset;
+}
+
+main div.herosimple-wrapper div.halfWidth > div.herosimple-container-wrapper {
+  flex-direction: row;
+  gap: 30px;
+}
+
+main div.herosimple-wrapper div.fullWidth > div {
+  align-items: center;
+  text-align: center;
+}
+
+main div.herosimple-wrapper div.fullWidth > div > div {
+  width: unset;
+}
+
+main div.herosimple-wrapper div.button-container > p,
+main div.herosimple-wrapper .all-button-container > p {
+  margin: 0;
+}
+
+main div.herosimple-wrapper .all-button-container {
+  display: inline-flex;
+  gap: 16px;
+}
+
+main div.herosimple-wrapper .text-color-white {
+  color: rgb(255, 255, 255);
+}
+
+main div.herosimple-wrapper .text-color-black {
+  color: rgb(0, 0, 0);
+}
+
+main div.herosimple-wrapper .text-color-gray {
+  color: rgb(110, 110, 110);
+}
+
+main div.herosimple-wrapper .text-color-navy {
+  color: rgb(15, 55, 95);
+}
+
+@media screen and (min-width: 320px) and (max-width: 767px) {
+  main div.herosimple-wrapper div.herosimple div.hero-right-image img {
+    width: 300px;
+  }
+}
+
+@media screen and (max-width: 1280px) {
+  main div.herosimple-wrapper div.herosimple > div > div {
+    width: 100%;
+  }
+}
+
+main div.herosimple-wrapper div.herosimple h1 {
+  color: rgb(255, 255, 255);
+  margin-top: 0;
+  font-size: 36px !important;
+}
+
+@media screen and (max-width: 1024px) {
+  main div.herosimple-wrapper div.herosimple {
+    height: auto;
+    padding: 50px 0px;
+  }
+  main div.herosimple-wrapper div.herosimple > div {
+    margin: auto;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  main div.herosimple-wrapper div.herosimple {
+    height: auto;
+    padding: 32px 0;
+  }
+}
+
+main div.herosimple-wrapper .herosimple .herosimple-button-container {
+  display: flex;
+  margin-top: 24px;
+  gap: 16px;
+  margin-bottom: 10px;
+}

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -35,6 +35,7 @@ export default async function decorate(block) {
   } else if (hasAnyClass(block, [VARIANTS.halfWidth])) {
     decorateDevBizHalfWidth(block);
   } else {
+    block.classList.add(VARIANTS.default);
     decorateDevBizDefault(block);
   }
 }

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -72,7 +72,6 @@ async function decorateDevBizCentered(block) {
 }
 
 async function decorateDevBizHalfWidth(block) {
-  block.setAttribute('daa-lh', 'superhero');
   // Block decoration
   decorateLightOrDark(block, true);
   // H1 decoration
@@ -152,7 +151,6 @@ async function decorateDevBizDefault(block) {
 
   const allowedTextColors = { black: 'rgb(0, 0, 0)', white: 'rgb(255, 255, 255)', gray: 'rgb(110, 110, 110)', navy: 'rgb(15, 55, 95)' };
 
-  block.setAttribute('daa-lh', 'hero');
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     h.style.color = Object.keys(allowedTextColors).includes(textColor) && allowedTextColors[textColor];
     h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeXXL', 'spectrum-Heading');

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -150,11 +150,6 @@ async function decorateDevBizDefault(block) {
   const textColor = block.getAttribute('data-textcolor') || 'white';
   block.classList.add(`text-color-${textColor}`);
 
-  const layoutWrapper = createTag('div', { class: 'superhero-container-wrapper' });
-  const contentContainer = createTag('div', { class: 'hero-left-content' });
-  const imageContainer = createTag('div', { class: 'hero-right-image' });
-  const videoContainer = createTag('div', { class: 'hero-right-video' });
-
   const allowedTextColors = { black: 'rgb(0, 0, 0)', white: 'rgb(255, 255, 255)', gray: 'rgb(110, 110, 110)', navy: 'rgb(15, 55, 95)' };
 
   block.setAttribute('daa-lh', 'hero');
@@ -168,49 +163,16 @@ async function decorateDevBizDefault(block) {
   const url = srcsetValue?.split(' ')[0];
   const pictureElement = block.querySelector('picture');
 
-  const slots = block.getAttribute('data-slots').split(' ') || [];
-  const hasVideo = slots.includes('video');
-  const videoIndex = slots.indexOf('video');
+  const parentDiv = pictureElement?.parentElement;
 
-  const innerDiv = block.querySelector(':scope > div ');
-  const video = innerDiv.children[videoIndex];
+  if (parentDiv) parentDiv.remove();
 
-  if ((pictureElement && variant === 'fullWidth') || variant === 'default') {
-    const parentDiv = pictureElement?.parentElement;
-
-    if (parentDiv) parentDiv.remove();
-
-    Object.assign(block.style, {
-      backgroundImage: `url(${url})`,
-      backgroundSize: 'cover',
-      backgroundPosition: 'center',
-      backgroundRepeat: 'no-repeat',
-    });
-  } else if ((pictureElement || hasVideo) && variant === 'halfWidth') {
-    let mediaContainer = hasVideo ? videoContainer : imageContainer;
-    let videoLink = video && video.querySelector('a');
-    let excludeElement;
-
-    if (hasVideo) {
-      const videoTag = createTag('video');
-      videoTag.innerHTML = `<source src="${videoLink.href}" type="video/mp4" alt="${videoLink.textContent}">`;
-      mediaContainer.appendChild(videoTag);
-      innerDiv.children[videoIndex].remove();
-      excludeElement = videoTag;
-    } else {
-      const pictureWrapper = pictureElement.closest('div') || pictureElement;
-      mediaContainer.appendChild(pictureWrapper);
-      excludeElement = pictureElement;
-    }
-
-    Array.from(block.children)
-      .filter((div) => !div.contains(excludeElement))
-      .forEach((div) => contentContainer.appendChild(div));
-
-    block.innerHTML = '';
-    layoutWrapper.append(contentContainer, mediaContainer);
-    block.appendChild(layoutWrapper);
-  }
+  Object.assign(block.style, {
+    backgroundImage: `url(${url})`,
+    backgroundSize: 'cover',
+    backgroundPosition: 'center',
+    backgroundRepeat: 'no-repeat',
+  });
 
   if (block.getAttribute('data-slots').split(' ').includes('buttons')) {
     normalizeButtonContainer(block);

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -149,7 +149,7 @@ async function decorateDevBizDefault(block) {
   const textColor = block.getAttribute('data-textcolor') || 'white';
   block.classList.add(`text-color-${textColor}`);
 
-  const layoutWrapper = createTag('div', { class: 'herosimple-container-wrapper' });
+  const layoutWrapper = createTag('div', { class: 'superhero-container-wrapper' });
   const contentContainer = createTag('div', { class: 'hero-left-content' });
   const imageContainer = createTag('div', { class: 'hero-right-image' });
   const videoContainer = createTag('div', { class: 'hero-right-video' });

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -34,6 +34,8 @@ export default async function decorate(block) {
     decorateDevBizCentered(block);
   } else if (hasAnyClass(block, [VARIANTS.halfWidth])) {
     decorateDevBizHalfWidth(block);
+  } else {
+    decorateDevBizDefault(block);
   }
 }
 
@@ -136,6 +138,8 @@ async function decorateDevBizHalfWidth(block) {
     block.lastElementChild.replaceWith(videoContainer);
   }
 }
+
+async function decorateDevBizDefault(block) {}
 
 /**
  * restructures a DevDocs block to match DevBiz before the decorate function runs

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -139,7 +139,83 @@ async function decorateDevBizHalfWidth(block) {
   }
 }
 
-async function decorateDevBizDefault(block) {}
+async function decorateDevBizDefault(block) {
+  const background = block.getAttribute('data-background') || 'rgb(29, 125, 238)';
+  block.style.background = background;
+
+  const variant = block.getAttribute('data-variant') || 'default';
+  block.classList.add(variant);
+
+  const textColor = block.getAttribute('data-textcolor') || 'white';
+  block.classList.add(`text-color-${textColor}`);
+
+  const layoutWrapper = createTag('div', { class: 'herosimple-container-wrapper' });
+  const contentContainer = createTag('div', { class: 'hero-left-content' });
+  const imageContainer = createTag('div', { class: 'hero-right-image' });
+  const videoContainer = createTag('div', { class: 'hero-right-video' });
+
+  const allowedTextColors = { black: 'rgb(0, 0, 0)', white: 'rgb(255, 255, 255)', gray: 'rgb(110, 110, 110)', navy: 'rgb(15, 55, 95)' };
+
+  block.setAttribute('daa-lh', 'hero');
+  block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
+    h.style.color = Object.keys(allowedTextColors).includes(textColor) && allowedTextColors[textColor];
+    h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeXXL', 'spectrum-Heading');
+  });
+
+  const sourceElement = block.querySelector('source[type="image/webp"]');
+  const srcsetValue = sourceElement ? sourceElement?.getAttribute('srcset') : null;
+  const url = srcsetValue?.split(' ')[0];
+  const pictureElement = block.querySelector('picture');
+
+  const slots = block.getAttribute('data-slots').split(' ') || [];
+  const hasVideo = slots.includes('video');
+  const videoIndex = slots.indexOf('video');
+
+  const innerDiv = block.querySelector(':scope > div ');
+  const video = innerDiv.children[videoIndex];
+
+  if ((pictureElement && variant === 'fullWidth') || variant === 'default') {
+    const parentDiv = pictureElement?.parentElement;
+
+    if (parentDiv) parentDiv.remove();
+
+    Object.assign(block.style, {
+      backgroundImage: `url(${url})`,
+      backgroundSize: 'cover',
+      backgroundPosition: 'center',
+      backgroundRepeat: 'no-repeat',
+    });
+  } else if ((pictureElement || hasVideo) && variant === 'halfWidth') {
+    let mediaContainer = hasVideo ? videoContainer : imageContainer;
+    let videoLink = video && video.querySelector('a');
+    let excludeElement;
+
+    if (hasVideo) {
+      const videoTag = createTag('video');
+      videoTag.innerHTML = `<source src="${videoLink.href}" type="video/mp4" alt="${videoLink.textContent}">`;
+      mediaContainer.appendChild(videoTag);
+      innerDiv.children[videoIndex].remove();
+      excludeElement = videoTag;
+    } else {
+      const pictureWrapper = pictureElement.closest('div') || pictureElement;
+      mediaContainer.appendChild(pictureWrapper);
+      excludeElement = pictureElement;
+    }
+
+    Array.from(block.children)
+      .filter((div) => !div.contains(excludeElement))
+      .forEach((div) => contentContainer.appendChild(div));
+
+    block.innerHTML = '';
+    layoutWrapper.append(contentContainer, mediaContainer);
+    block.appendChild(layoutWrapper);
+  }
+
+  if (block.getAttribute('data-slots').split(' ').includes('buttons')) {
+    normalizeButtonContainer(block);
+    decorateButtons(block);
+  }
+}
 
 /**
  * restructures a DevDocs block to match DevBiz before the decorate function runs
@@ -288,4 +364,22 @@ function rearrangeLinks(block) {
     heroButtonContainer.append(p);
   });
   leftDiv.append(heroButtonContainer);
+}
+
+function normalizeButtonContainer(block) {
+  const anchorElement = Array.from(block.querySelectorAll('a'));
+  if (anchorElement.length > 0) {
+    anchorElement.forEach((anchor, i) => {
+      const p = createTag('p');
+      const node = i === 0 ? createTag('strong') : p;
+      node.appendChild(anchor.cloneNode(true));
+      p.appendChild(node === p ? node.firstChild : node);
+      anchor.replaceWith(p);
+    });
+
+    const lastGroup = block.lastElementChild?.lastElementChild;
+    if (lastGroup && [...lastGroup.children].every((child) => child.tagName === 'P')) {
+      lastGroup.classList.add('all-button-container');
+    }
+  }
 }

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -230,6 +230,7 @@ main.dev-docs.no-onthispage .main-resources-wrapper {
 }
 
 main.dev-docs .herosimple > div,
+main .superhero.default > div,
 main.dev-docs:has(.herosimple, .superhero) .sub-parent,
 main.dev-docs:not(:has(.herosimple)):not(:has(.superhero)) > .grid-main-area,
 main.dev-docs .footer-wrapper .footer-links-container-inner {
@@ -238,6 +239,7 @@ main.dev-docs .footer-wrapper .footer-links-container-inner {
 }
 
 main.dev-docs .herosimple > div,
+main .superhero.default > div,
 main.dev-docs:has(.herosimple, .superhero) .sub-parent,
 main.dev-docs:not(:has(.herosimple)):not(:has(.superhero)) .grid-main-area,
 main.dev-docs .footer-wrapper {
@@ -246,12 +248,15 @@ main.dev-docs .footer-wrapper {
 }
 
 main.dev-docs .herosimple > div,
+main .superhero.default > div,
 main.dev-docs:has(.herosimple, .superhero) .sub-parent,
 main.dev-docs:has(.herosimple, .superhero) .footer-wrapper {
   max-width: 1000px;
 }
 
 main.dev-docs:not(.no-layout).no-sidenav .herosimple > div,
+main.dev-docs:not(.no-layout).no-sidenav .superhero.default > div,
+main.dev-biz .superhero.default > div,
 main.dev-docs:not(.no-layout):has(.herosimple, .superhero).no-sidenav .sub-parent,
 main.dev-docs:not(.no-layout):has(.herosimple, .superhero).no-sidenav .footer-wrapper,
 main.dev-docs:not(.no-layout):not(:has(.herosimple)):not(:has(.superhero)) .grid-main-area,


### PR DESCRIPTION
## Description
Add `default` variant to `Superhero` block

## Ticket
https://jira.corp.adobe.com/browse/DEVSITE-1756

## Test
Both DevBiz and DevDocs `Superhero` `default` use the same style as `HeroSimple` `default`:
- (existing) DevDocs HeroSimple default: https://superhero-default--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/old/herosimple-default
- (new) DevDocs Superhero default: https://superhero-default--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/superhero/new/herosimple-default
- (new) DevBiz Superhero default: https://superhero-default--adp-devsite--adobedocs.aem.page/test/melissa/superhero/new/superhero-default?nocache=1757630127977

## Other tests
 - DevDocs with 2 buttons, cyan background, and black text:
   - <img width="1728" height="870" alt="Screenshot 2025-10-02 at 11 11 36 AM" src="https://github.com/user-attachments/assets/1cb8b7c2-b8a5-427e-bdbc-7602800c4fa2" />

 - DevBiz with 2 buttons and gray text:
   - <img width="1728" height="1080" alt="Screenshot 2025-10-02 at 11 08 08 AM" src="https://github.com/user-attachments/assets/417ef21d-cd45-46df-9b8a-95d95d8bb056" />


