### PR TITLE
remove unnecessary width

### DIFF
--- a/hlx_statics/blocks/embed/embed.js
+++ b/hlx_statics/blocks/embed/embed.js
@@ -227,7 +227,6 @@ export default function decorate(block) {
   }
   else {
     link = block.querySelector('.embed > div > div').innerText;
-    block.style.maxWidth = "800px";
   }
 
   block.textContent = '';


### PR DESCRIPTION
Based on this comment from express team https://adobeio.slack.com/archives/GTSGK6807/p1767826268096069

Remove unnecessary width set for the embed content when it's not a link.

Before:
https://main--adp-devsite--adobedocs.aem.page/test/louisa/

After:
https://embed-width--adp-devsite--adobedocs.aem.page/test/louisa/
