### PR TITLE
update how to load the title

### DIFF
--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -841,6 +841,8 @@ function loadTitle() {
       let titleFromH1 = null;
 
       for (const h1 of h1Elements) {
+        // Skip H1 inside the nav profile dropdown popover
+        if (h1.closest('#nav-profile-dropdown-popover')) continue;
         // Check if this H1 contains an image
         const hasImage = h1.querySelector('img');
         if (!hasImage) {


### PR DESCRIPTION
Currently the title is having a race condition or if it find the popover from the "nav-profile-dropdown-popover", it'll pick up the h1 title which becomes the user's name to replace the title in the browser. 

We must move this code into stage before we can test it. 
