### PR TITLE
added playground url for the stage

### DIFF
--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -650,9 +650,10 @@ export function isLocalHostEnvironment(host) {
  * @param {*} host The host
  * @returns True if the current URL is a stage environment, false otherwise
  */
-export function isStageEnvironment(host) {
+export function isStageEnvironment(host, includeAemHosts = false) {
   return host.indexOf('stage.adobe.io') >= 0
-    || host.indexOf('developer-stage') >= 0;
+    || host.indexOf('developer-stage') >= 0
+    || (includeAemHosts && host.indexOf('.page') >= 0 && host.indexOf('--adp-devsite-stage--') >= 0);
 }
 
 /**
@@ -660,8 +661,9 @@ export function isStageEnvironment(host) {
  * @param {*} host The host
  * @returns True if the current URL is a dev environment, false otherwise
  */
-export function isDevEnvironment(host) {
-  return host.indexOf('developer-dev') >= 0;
+export function isDevEnvironment(host, includeAemHosts = false) {
+  return host.indexOf('developer-dev') >= 0
+    || (includeAemHosts && host.indexOf('.page') >= 0 && host.indexOf('--adp-devsite--') < 0);
 }
 
 /**
@@ -669,8 +671,9 @@ export function isDevEnvironment(host) {
  * @param {*} host The host
  * @returns True if the current URL is a prod environment, false otherwise
  */
-export function isProdEnvironment(host) {
-  return host.indexOf('developer.adobe.com') >= 0;
+export function isProdEnvironment(host, includeAemHosts = false) {
+  return host.indexOf('developer.adobe.com') >= 0
+    || (includeAemHosts && host.indexOf('.live') >= 0);
 }
 
 /**

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -663,7 +663,7 @@ export function isStageEnvironment(host, includeAemHosts = false) {
  */
 export function isDevEnvironment(host, includeAemHosts = false) {
   return host.indexOf('developer-dev') >= 0
-    || (includeAemHosts && host.indexOf('.page') >= 0 && host.indexOf('--adp-devsite--') < 0);
+    || (includeAemHosts && host.indexOf('.page') >= 0 && host.indexOf('--adp-devsite--') >= 0);
 }
 
 /**

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -850,7 +850,7 @@ function loadPrism(document) {
               const playgroundMode = pre?.getAttribute('data-playground-mode');
 
               const playgroundExecutionMode = pre?.getAttribute('data-playground-execution-mode');
-              const playgroundURL = isStageEnvironment(window.location.host)
+              const playgroundURL = isStageEnvironment(window.location.host) || isHlxPath(window.location.host)
                 ? (pre?.getAttribute('data-playground-url-stage') || pre?.getAttribute('data-playground-url'))
                 : pre?.getAttribute('data-playground-url');
               if (!sessionId || !playgroundMode || !playgroundExecutionMode || !playgroundURL) return null;

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -850,7 +850,7 @@ function loadPrism(document) {
               const playgroundMode = pre?.getAttribute('data-playground-mode');
 
               const playgroundExecutionMode = pre?.getAttribute('data-playground-execution-mode');
-              const playgroundURL = isStageEnvironment(window.location.host) || isHlxPath(window.location.host)
+              const playgroundURL = isStageEnvironment(window.location.host) || isLocalHostEnvironment(window.location.host)
                 ? (pre?.getAttribute('data-playground-url-stage') || pre?.getAttribute('data-playground-url'))
                 : pre?.getAttribute('data-playground-url');
               if (!sessionId || !playgroundMode || !playgroundExecutionMode || !playgroundURL) return null;

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -848,8 +848,11 @@ function loadPrism(document) {
               const pre = env.element.closest('pre');
               const sessionId = pre?.getAttribute('data-playground-session-id');
               const playgroundMode = pre?.getAttribute('data-playground-mode');
+
               const playgroundExecutionMode = pre?.getAttribute('data-playground-execution-mode');
-              const playgroundURL = pre?.getAttribute('data-playground-url');
+              const playgroundURL = isStageEnvironment(window.location.host)
+                ? (pre?.getAttribute('data-playground-url-stage') || pre?.getAttribute('data-playground-url'))
+                : pre?.getAttribute('data-playground-url');
               if (!sessionId || !playgroundMode || !playgroundExecutionMode || !playgroundURL) return null;
               const btn = createTag('button', { class: 'try-code-button' });
               btn.textContent = 'Try in playground';

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -850,7 +850,7 @@ function loadPrism(document) {
               const playgroundMode = pre?.getAttribute('data-playground-mode');
 
               const playgroundExecutionMode = pre?.getAttribute('data-playground-execution-mode');
-              const playgroundURL = isStageEnvironment(window.location.host) || isLocalHostEnvironment(window.location.host)
+              const playgroundURL = isStageEnvironment(window.location.host, true) || isLocalHostEnvironment(window.location.host)
                 ? (pre?.getAttribute('data-playground-url-stage') || pre?.getAttribute('data-playground-url'))
                 : pre?.getAttribute('data-playground-url');
               if (!sessionId || !playgroundMode || !playgroundExecutionMode || !playgroundURL) return null;


### PR DESCRIPTION
## Description

I’ve added separate stage and production URLs for the playground. Previously, stage, local, and production were all using the production URL. Now I’ve updated it so that the URLs are handled differently.

If the environment is stage or local, it will render the stage URL. Otherwise, it will render the production URL.

I’ve fixed the issue with this change.

## Ticket

https://jira.corp.adobe.com/browse/DEVSITE-2244

## Test URL

Previous: https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/code-playground-button
Updated : https://playground-stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/code-playground-button