### PR TITLE
adding the topnav dropdown scrollable

### DIFF
--- a/hlx_statics/blocks/header/header.css
+++ b/hlx_statics/blocks/header/header.css
@@ -324,6 +324,8 @@ header.global-nav-header > ul#navigation-links > li > button.is-open .spectrum-P
   header.global-nav-header div.nav-dropdown-popover {
     margin-top: -6px;
     margin-left: -1px;
+    max-height: 75vh;
+    overflow-y: auto;
   }
 
   header .nav-mobile-distribute-button {


### PR DESCRIPTION
The dropdown menu is not scrollable. Now the fix is to have the scrollable and only to the viewport of 75 percent.
before:
https://developer-stage.adobe.com/experience-platform-apis/
after:
https://devsite-2287-topnav--adp-devsite-stage--adobedocs.aem.page/experience-platform-apis/