### PR TITLE
fix : video has extra black height above and below

### DIFF
--- a/hlx_statics/blocks/iframe/iframe.css
+++ b/hlx_statics/blocks/iframe/iframe.css
@@ -87,3 +87,8 @@ main div.iframe-wrapper .iframe-custom-width{
   align-items: center;
   justify-content: center;
 }
+
+main div.iframe-wrapper iframe.iframe-container:not(.youtube-iframe) {
+  height: auto !important;
+  aspect-ratio: 16 / 9;
+}

--- a/hlx_statics/blocks/iframe/iframe.css
+++ b/hlx_statics/blocks/iframe/iframe.css
@@ -88,7 +88,9 @@ main div.iframe-wrapper .iframe-custom-width{
   justify-content: center;
 }
 
-main div.iframe-wrapper iframe.iframe-container:not(.youtube-iframe) {
+/* 16:9 only for iframe blocks authored with the aspect-video variant;
+   skip when data-height is set (.iframe-has-explicit-height) or YouTube (.youtube-iframe). */
+main div.iframe-wrapper iframe.iframe-container.aspect-video:not(.youtube-iframe):not(.iframe-has-explicit-height) {
   height: auto !important;
   aspect-ratio: 16 / 9;
 }

--- a/hlx_statics/blocks/iframe/iframe.js
+++ b/hlx_statics/blocks/iframe/iframe.js
@@ -183,10 +183,10 @@ export default async function decorate(block) {
   }
 
   if (width) {
-    iframe.style.width = width;
+    iframe.style.setProperty('width', width, 'important');
   }
   if (height) {
-    iframe.style.height = height;
+    iframe.style.setProperty('height', height, 'important');
   }
 
   penpalScript.onload = () => {

--- a/hlx_statics/blocks/iframe/iframe.js
+++ b/hlx_statics/blocks/iframe/iframe.js
@@ -186,7 +186,9 @@ export default async function decorate(block) {
     iframe.style.setProperty('width', width, 'important');
   }
   if (height) {
+    iframe.classList.add('iframe-has-explicit-height');
     iframe.style.setProperty('height', height, 'important');
+    iframe.classList.add('iframe-has-explicit-height');
   }
 
   penpalScript.onload = () => {


### PR DESCRIPTION
## Description

Video has extra black height above and below
https://developer-stage.adobe.com/express/add-ons/docs/guides/build/advanced-topics/frameworks-libraries-bundling#typescript-definitions

## Jira

https://jira.corp.adobe.com/browse/DEVSITE-2303

## Test URL

Previous: https://developer-stage.adobe.com/express/add-ons/docs/guides/build/advanced-topics/frameworks-libraries-bundling#typescript-definitions
Update : https://iframe-blank-issue--adp-devsite-stage--adobedocs.aem.page/express/add-ons/docs/guides/build/advanced-topics/frameworks-libraries-bundling#typescript-definitions

## Screenshot

Previous : 
<img width="1919" height="990" alt="image" src="https://github.com/user-attachments/assets/34231cdf-c11c-4d4f-a0a0-193b00eba7fc" />

Update : 
<img width="1919" height="989" alt="image" src="https://github.com/user-attachments/assets/a83f9da7-6b1c-4ba5-aeb2-d93743ffd70a" />
