### PR TITLE
Devsite 2305 dropdown width and selector 

### DIFF
--- a/hlx_statics/blocks/header/header.css
+++ b/hlx_statics/blocks/header/header.css
@@ -350,6 +350,31 @@ header.global-nav-header ul.nav-sub-menu {
   max-width: max-content;
 }
 
+header.global-nav-header .nav-sub-menu .spectrum-Menu-item {
+  position: relative;
+  padding-left: 28px !important;
+}
+
+header.global-nav-header .nav-sub-menu .spectrum-Menu-item.is-selected a {
+  margin-left: 0px;
+}
+
+header.global-nav-header .nav-sub-menu .spectrum-Menu-item a:hover {
+  background-color: rgba(0, 0, 0, .001);
+}
+
+header.global-nav-header .nav-sub-menu .spectrum-Menu-item.is-selected .spectrum-Menu-checkmark {
+  position: absolute;
+  left: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: block;
+  width: 18px !important;
+  height: 18px !important;
+  color: var(--spectrum-global-color-blue-500, #1473e6);
+  fill: currentColor;
+}
+
 header.global-nav-header li .nav-dropdown-item{
   display: flex;
   flex-direction: column;

--- a/hlx_statics/blocks/header/header.css
+++ b/hlx_statics/blocks/header/header.css
@@ -347,12 +347,12 @@ header.global-nav-header > ul#navigation-links > li {
 }
 
 header.global-nav-header ul.nav-sub-menu {
-  max-width: max-content;
+  width: max-content;
 }
 
 header.global-nav-header .nav-sub-menu .spectrum-Menu-item {
   position: relative;
-  padding-left: 28px !important;
+  padding-left: 24px !important;
 }
 
 header.global-nav-header .nav-sub-menu .spectrum-Menu-item.is-selected a {
@@ -365,7 +365,7 @@ header.global-nav-header .nav-sub-menu .spectrum-Menu-item a:hover {
 
 header.global-nav-header .nav-sub-menu .spectrum-Menu-item.is-selected .spectrum-Menu-checkmark {
   position: absolute;
-  left: 4px;
+  left: 0px;
   top: 50%;
   transform: translateY(-50%);
   display: block;
@@ -375,14 +375,20 @@ header.global-nav-header .nav-sub-menu .spectrum-Menu-item.is-selected .spectrum
   fill: currentColor;
 }
 
-header.global-nav-header li .nav-dropdown-item{
+header.global-nav-header li .nav-dropdown-item {
   display: flex;
   flex-direction: column;
 }
 
+header.global-nav-header li .nav-dropdown-item .nav-dropdown-name {
+  white-space: nowrap;
+}
+
 header.global-nav-header li .nav-dropdown-item .nav-dropdown-description {
   font-size: 12px;
+  max-width: 200px;
   text-wrap: initial;
+
 }
 
 header.global-nav-header a.nav-dropdown-links {

--- a/hlx_statics/blocks/header/header.css
+++ b/hlx_statics/blocks/header/header.css
@@ -325,6 +325,7 @@ header.global-nav-header > ul#navigation-links > li > button.is-open .spectrum-P
     margin-top: -6px;
     margin-left: -1px;
     max-height: 75vh;
+    overflow-x: hidden;
     overflow-y: auto;
   }
 
@@ -346,7 +347,7 @@ header.global-nav-header > ul#navigation-links > li {
 }
 
 header.global-nav-header ul.nav-sub-menu {
-  max-width: 230px;
+  max-width: max-content;
 }
 
 header.global-nav-header li .nav-dropdown-item{

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -555,6 +555,14 @@ function activateTab(tabItem, isMainPage) {
   if (tabItem.closest('.nav-dropdown-popover')){
     // if the item is within a dropdown, it needs to find the parent item to be underlined.
     underlineItem = tabItem.closest('.nav-dropdown-popover');
+    const menuItem = tabItem.closest('.spectrum-Menu-item');
+    if (menuItem) {
+      menuItem.classList.add('is-selected');
+      const checkmark = `<svg role="img" class="spectrum-Icon spectrum-UIIcon-Checkmark100 spectrum-Menu-checkmark" aria-hidden="true">
+        <path d="M3.5 9.5a.999.999 0 01-.774-.368l-2.45-3a1 1 0 111.548-1.264l1.657 2.028 4.68-6.01A1 1 0 019.74 2.114l-5.45 7a1 1 0 01-.777.386z" class="spectrum-UIIcon--medium"></path>
+      </svg>`;
+      menuItem.insertAdjacentHTML('afterbegin', checkmark);
+    }
   }
   underlineItem.parentElement.classList.add("activeTab");
 }


### PR DESCRIPTION
fixing https://jira.corp.adobe.com/browse/DEVSITE-2305 and https://jira.corp.adobe.com/browse/DEVSITE-2295

Before width after conversion is having a scroll bar horizontally and does not have a selector.
<img width="779" height="451" alt="Screenshot 2026-03-25 at 4 52 15 PM" src="https://github.com/user-attachments/assets/3f6c74c6-71da-415c-bb25-fdb41328268b" />

After:
https://devsite-2305-dropdown-width--adp-devsite--adobedocs.aem.page/uix/docs/services/aem-experience-hub/
and for the conversion where the menu is very long
<img width="833" height="340" alt="Screenshot 2026-03-25 at 4 53 00 PM" src="https://github.com/user-attachments/assets/101d5696-dc8f-47cd-bb3c-dff67fe6096e" />

 
