### PR TITLE
no new tab for local dev

### DIFF
--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -45,7 +45,7 @@ export function checkExternalLink(main) {
     if (url) {
       const [_, queryString] = url.split('?');
       const searchParams = new URLSearchParams(queryString);
-      const internalDomains = ['developer.adobe.com', 'developer-stage.adobe.com', 'developer-dev.adobe.com', 'hlx.page', 'hlx.live', 'aem.page', 'aem.live'];
+      const internalDomains = ['developer.adobe.com', 'developer-stage.adobe.com', 'developer-dev.adobe.com', 'hlx.page', 'hlx.live', 'aem.page', 'aem.live', 'localhost', '127.0.0.1'];
       const isExternal = !internalDomains.some(domain => url.includes(domain)) || searchParams.has('aio_external');
       if (isExternal) {
         a.target = '_blank';


### PR DESCRIPTION
JIRA: [DEVSITE-2220](https://jira.corp.adobe.com/browse/DEVSITE-2220)
When the repo is running on local dev, every click on tab nav will open a new tab. Added local host and local IP to the no tab list