### PR TITLE
Fixed top offsite

### DIFF
--- a/hlx_statics/blocks/site-wide-banner/site-wide-banner.js
+++ b/hlx_statics/blocks/site-wide-banner/site-wide-banner.js
@@ -1,6 +1,7 @@
 import {
   createTag,
   decorateButtons,
+  setFixedTopOffset,
 } from "../../scripts/lib-adobeio.js";
 import {
   fetchSiteWideBanner,
@@ -51,6 +52,7 @@ export default async function decorate(block) {
 
   if (banner && Object.keys(banner).length !== 0) {
     siteParent.style.display = null;
+    setFixedTopOffset();
 
     const { text, icon, buttonLink, button, isClose, bgColor = "notice" } = banner;
     const padding = `${siteParent.getBoundingClientRect().height + (isMobile ? 180 : 16)}px`;
@@ -90,6 +92,7 @@ export default async function decorate(block) {
       block.classList.add("closable");
       closeBtn.addEventListener("click", () => {
         siteParent.style.display = "none";
+        setFixedTopOffset();
         paddingTargets.forEach(el => el && (el.style.paddingTop = "0px"));
         if (isMobile) {
           const sibling = siteParent.nextElementSibling;

--- a/hlx_statics/components/heading.js
+++ b/hlx_statics/components/heading.js
@@ -10,7 +10,7 @@ function Anchor({ id }) {
   div.setAttribute('aria-hidden', 'true');
   div.setAttribute('id', id);
   div.style.setProperty('position', 'relative');
-  div.style.setProperty('top', 'calc(-1 * var(--spectrum-global-dimension-size-800)');
+  div.style.setProperty('top', 'calc(-1 * var(--fixed-top-offset, 64px))');
   return div;
 }
 

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -1034,6 +1034,22 @@ export function decorateAnchorLink(header) {
   // });
 }
 
+export function setFixedTopOffset() {
+  let maxBottom = 0;
+  document.querySelectorAll('body > header, main > *').forEach((el) => {
+    const style = window.getComputedStyle(el);
+    if (style.position === 'fixed' && style.display !== 'none') {
+      const rect = el.getBoundingClientRect();
+      if (rect.height > 0) {
+        maxBottom = Math.max(maxBottom, rect.bottom);
+      }
+    }
+  });
+  const offset = maxBottom || 64;
+  document.documentElement.style.setProperty('--fixed-top-offset', `${offset}px`);
+  return offset;
+}
+
 /**
  * Scrolls element into view with adjustment for lazy-loaded decorations.
  * @param {Element} element The element to scroll to

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -60,6 +60,7 @@ import {
   imsGetProfileSuccess,
   imsGetProfileError,
   scrollWithLayoutAdjustment,
+  setFixedTopOffset,
   whenFirstVisible
 } from './lib-adobeio.js';
 
@@ -788,6 +789,7 @@ async function loadLazy(doc) {
   sampleRUM.observe(main.querySelectorAll('div[data-block-name]'));
   sampleRUM.observe(main.querySelectorAll('picture > img'));
 
+  setFixedTopOffset();
   scrollToHash(doc);
 
   if (window.location.hostname.endsWith('aem.page') || window.location.hostname === ('localhost')) {

--- a/hlx_statics/styles/styles.css
+++ b/hlx_statics/styles/styles.css
@@ -34,7 +34,7 @@ body.appear {
 }
 
 html {
-  scroll-padding-top: 60px;
+  scroll-padding-top: 0;
 }
 
 @font-face {


### PR DESCRIPTION
Two scroll-offset mechanisms were double-counting:                                     
  1. scroll-padding-top: 60px on html — shifts scroll position for all anchor navigation
  2. A hidden anchor <div> inserted before each heading with position: relative; top:    
  -64px — the actual scroll target (appears first in DOM for the same id)             
                                                                                         
  Together, scrollIntoView() placed the hidden div 60px from the top, then the h3     
  appeared 64px further down (124px total) — barely clearing the header alone, and hidden
   behind the header + banner combined.  

Fix:                                                                             
  Replace both mechanisms with a single dynamic CSS variable --fixed-top-offset:         
   
  - scroll-padding-top set to 0 — the hidden div is the sole offset mechanism            
  - Hidden div uses var(--fixed-top-offset, 64px) instead of the hardcoded Spectrum token
  - New setFixedTopOffset() function computes the variable by reading the actual rendered
   bottom of all position: fixed elements (header + banner when present)                 
  - setFixedTopOffset() is called on page load, when the site-wide banner appears, and   
  when it is dismissed  