### PR TITLE
Add functionality for RedoclyAPIBlock in Private Repos

### DIFF
--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -770,6 +770,10 @@ export function getResourceUrl(path) {
       // absolute path, use the pathPrefix and resolvedPath.
       finalPath = `${window.location.origin}${pathPrefix}${resolvedPath}`;
     }
+    if (!finalPath) {
+      console.error(`[getResourceUrl] Could not resolve path "${path}" for private org.`);
+      return path;
+    }
     if (!finalPath.startsWith(window.location.origin)) {
       console.error(`[getResourceUrl] Resolved URL "${finalPath}" does not match expected origin "${window.location.origin}". Input path: "${path}".`);
     }

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -720,6 +720,7 @@ export function getResourceUrl(path) {
 
   const blobPath = getMetadata('githubblobpath');
   const pathPrefix = getMetadata('pathprefix');
+  const isPrivateOrg = blobPath && blobPath.includes('AdobeDocsPrivate');
   const githubPath ='https://github.com';
   const blobStr = '/blob/';
   const srcPagesStr = '/src/pages/';
@@ -752,6 +753,27 @@ export function getResourceUrl(path) {
   if(!isValidRelativePath) {
     // eslint-disable-next-line no-console
     console.error(`Invalid relative path "${resolvedPath}" for "${blobPath}"`);
+  }
+
+  // Private repos serve files from Azure rather than raw.githubusercontent.com
+  if (isPrivateOrg) {
+    let finalPath;
+    if (path.startsWith(pathPrefix)) {
+      // if the path starts with the pathPrefix, use static folder.
+      const relativePath = path.replace(pathPrefix, '');
+      finalPath = `${window.location.origin}${pathPrefix}/static${relativePath}`;
+    } else if (pathPrefix && resolvedPath.startsWith(pathPrefix)) {
+      // if the resolvedPath starts with the pathPrefix, look in src/pages folder.
+      const relativePath = resolvedPath.replace(pathPrefix, '');
+      finalPath = `${window.location.origin}${pathPrefix}/${relativePath}`;
+    } else if (resolvedPath.startsWith('/')) {
+      // absolute path, use the pathPrefix and resolvedPath.
+      finalPath = `${window.location.origin}${pathPrefix}${resolvedPath}`;
+    }
+    if (!finalPath.startsWith(window.location.origin)) {
+      console.error(`[getResourceUrl] Resolved URL "${finalPath}" does not match expected origin "${window.location.origin}". Input path: "${path}".`);
+    }
+    return finalPath;
   }
 
   // build raw git URL


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/DEVSITE-2329

Worked locally but need to test on stage (so the first case doesn't work on stage yet):

- **/private-eds/api/index.md:** [uses a relative path ](https://github.com/AdobeDocsPrivate/adp-dev-docs-private/blob/1b501fe9dbddf659a6e5b0c7d9bc23a14cd5b07f/src/pages/api/index.md?plain=1#L1)
Live page on stage: https://developer-stage.adobe.com/private-eds/api/ 
Azure blob url: https://developer-stage.adobe.com/private-eds/support/community/petstore.json (you need to log in to see it)

- **/private-eds/api/1-4.md:** [uses absolute path to blob](https://github.com/AdobeDocsPrivate/adp-dev-docs-private/blob/de902130fd6374f5beff8c088ea2ecabc02df38f/src/pages/api/1-4.md?plain=1#L1)
Live page on stage: https://developer-stage.adobe.com/private-eds/api/1-4
Azure blob url: https://developer-stage.adobe.com/private-eds/static/petstore.json (you need to log in to see it)