### PR TITLE
refactored caching

### DIFF
--- a/dev.mjs
+++ b/dev.mjs
@@ -152,6 +152,14 @@ app.use(async (req, res) => {
 
   res.status(resp.status);
 
+  // Doc responses from the runtime connector lack Cache-Control, causing
+  // browsers to apply heuristic caching (RFC 7234) and silently serve stale
+  // content. Setting no-cache ensures the browser always revalidates via
+  // If-Modified-Since / If-None-Match while still caching for 304 efficiency.
+  if (source === 'docs' && !headers.has('cache-control')) {
+    headers.set('cache-control', 'no-cache');
+  }
+
   // Set headers properly for Express
   headers.forEach((value, key) => {
     res.set(key, value);

--- a/hlx_statics/blocks/fragment/fragment.js
+++ b/hlx_statics/blocks/fragment/fragment.js
@@ -85,7 +85,7 @@ import {
               if (!resp.ok) return;
 
               const currentLm = resp.headers.get('last-modified');
-              const storedLm = sssionStorage.getItem(fragmentLmKey);
+              const storedLm = sessionStorage.getItem(fragmentLmKey);
               const storedHtml = sessionStorage.getItem(fragmentHash);
 
               if (currentLm && storedLm === currentLm && storedHtml) {

--- a/hlx_statics/blocks/fragment/fragment.js
+++ b/hlx_statics/blocks/fragment/fragment.js
@@ -15,6 +15,12 @@ import {
   import {
     isLocalHostEnvironment
   } from '../../scripts/lib-adobeio.js';
+
+  // Dedup concurrent config validation fetches within the same page load.
+  // Multiple callers (top-nav, buttons, side-nav) all loadFragment the same
+  // config URL — this ensures only ONE network request is made.
+  const configValidationCache = new Map();
+
   /**
    * Loads a fragment.
    * @param {string} path The path to the fragment
@@ -62,30 +68,77 @@ import {
 
       const hashCode = (s) => s.split('').reduce((a, b) => (((a << 5) - a) + b.charCodeAt(0)) | 0, 0);
       const fragmentHash = `${hashCode(fetchPathUrl)}`;
+      const fragmentLmKey = `${fragmentHash}_lm`;
       let main;
 
-    if (sessionStorage.getItem(fragmentHash)) {
-      main = document.createElement('main');
-      main.innerHTML = sessionStorage.getItem(fragmentHash);
-    } else {
-      const resp = await fetch(fetchPathUrl);
-      if (resp.ok) {
-        const htmlText = await resp.text();
-        main = document.createElement('main');
-        if (isLocalHostForDocs ) {
-          const parser = new DOMParser();
-          const doc = parser.parseFromString(htmlText, 'text/html');
-          const mainContent = doc.querySelector('main');
-          if (mainContent) {
-            main.innerHTML = mainContent.innerHTML;
-          }
-        } else {
-          main.innerHTML = htmlText;
+      const isConfig = lastPrefix === 'config';
+      const cachedHtml = sessionStorage.getItem(fragmentHash);
+
+      if (isConfig) {
+        // Config validation: one fetch per page load, shared across all callers.
+        // Uses If-Modified-Since revalidation (cache: 'no-cache') so the browser
+        // leverages its HTTP cache for 304 responses while always checking freshness.
+        if (!configValidationCache.has(fragmentHash)) {
+          configValidationCache.set(fragmentHash, (async () => {
+            try {
+              const resp = await fetch(fetchPathUrl, { cache: 'no-cache' });
+              if (!resp.ok) return;
+
+              const currentLm = resp.headers.get('last-modified');
+              const storedLm = sssionStorage.getItem(fragmentLmKey);
+              const storedHtml = sessionStorage.getItem(fragmentHash);
+
+              if (currentLm && storedLm === currentLm && storedHtml) {
+                console.log(`[fragment] config valid (last-modified: ${currentLm})`);
+                return;
+              }
+
+              console.log(`[fragment] config ${storedHtml ? 'stale' : 'miss'} (${storedLm} → ${currentLm})`);
+              const htmlText = await resp.text();
+              const temp = document.createElement('main');
+              if (isLocalHostForDocs) {
+                const parser = new DOMParser();
+                const doc = parser.parseFromString(htmlText, 'text/html');
+                const mainContent = doc.querySelector('main');
+                if (mainContent) temp.innerHTML = mainContent.innerHTML;
+              } else {
+                temp.innerHTML = htmlText;
+              }
+              sessionStorage.setItem(fragmentHash, temp.innerHTML);
+              if (currentLm) sessionStorage.setItem(fragmentLmKey, currentLm);
+            } catch (e) {
+              console.warn('[fragment] config validation failed', e);
+            }
+          })());
         }
 
-        sessionStorage.setItem(fragmentHash, main.innerHTML);
+        await configValidationCache.get(fragmentHash);
+        const content = sessionStorage.getItem(fragmentHash);
+        if (content) {
+          main = document.createElement('main');
+          main.innerHTML = content;
+        }
+      } else if (cachedHtml) {
+        main = document.createElement('main');
+        main.innerHTML = cachedHtml;
+      } else {
+        const resp = await fetch(fetchPathUrl);
+        if (resp.ok) {
+          const htmlText = await resp.text();
+          main = document.createElement('main');
+          if (isLocalHostForDocs) {
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(htmlText, 'text/html');
+            const mainContent = doc.querySelector('main');
+            if (mainContent) {
+              main.innerHTML = mainContent.innerHTML;
+            }
+          } else {
+            main.innerHTML = htmlText;
+          }
+          sessionStorage.setItem(fragmentHash, main.innerHTML);
+        }
       }
-    }
 
     // Always run initialization for both cached and fresh fragments
     if (main) {


### PR DESCRIPTION
## Summary

Completes the `last-modified` cache invalidation chain for `config.md` (companion to 
aemsites/devsite-runtime-connector#85 and AdobeDocs/adp-devsite-utils#70).

The two upstream PRs correctly set and forward the `Last-Modified` header through the 
server chain (content server → runtime connector → dev.mjs → browser), but the 
client-side `fragment.js` never consumed it — `sessionStorage` cached config HTML using 
only the URL hash as key, with no invalidation mechanism at all.

## Before

1. `loadFragment` caches config HTML in `sessionStorage` keyed by `hashCode(url)`.
2. On cache hit, the cached HTML is returned **immediately with zero network requests**.
3. `sessionStorage` persists across page refreshes within the same tab.
4. **Result**: Editing `config.md` and refreshing the page shows stale navigation. 
   Only opening a new browser tab (fresh `sessionStorage`) picks up changes.
5. Additionally, the runtime connector returns `Last-Modified` but no `Cache-Control` 
   header. Per RFC 7234, browsers apply **heuristic caching** — they may silently serve 
   the cached response for up to 10% of the `Last-Modified` age without revalidating. 
   This means even a `fetch()` call could return stale content from the browser's own 
   HTTP cache.

## After

1. **`fragment.js` — `last-modified` validation for config fragments**:
   - On every page load, config is fetched with `{ cache: 'no-cache' }`, which forces 
     the browser to revalidate via `If-Modified-Since` (leveraging the `Last-Modified` 
     header from the upstream PRs). The browser still caches — it just must ask first.
   - If `Last-Modified` matches the stored value → sessionStorage cache is valid, skip 
     re-parsing (304-efficient).
   - If `Last-Modified` differs → re-parse HTML, update sessionStorage cache.
   - A module-level `configValidationCache` Map deduplicates concurrent calls — 
     `fetchNavHtml` invokes `loadFragment(config)` multiple times per page load 
     (top-nav, buttons, side-nav), but only ONE network request is made.

2. **`dev.mjs` — `Cache-Control: no-cache` for doc responses**:
   - The runtime connector omits `Cache-Control` on its responses. Without it, browsers 
     apply heuristic caching and may serve stale doc content from the HTTP cache without 
     ever contacting the server — making `Last-Modified` useless.
   - `dev.mjs` now sets `Cache-Control: no-cache` on doc responses when the upstream 
     didn't provide one. This ensures the browser always revalidates via 
     `If-Modified-Since` / `If-None-Match`, while still caching for 304 efficiency.

## How the full chain works
content server (port 3003) → Last-Modified: (adp-devsite-utils) runtime connector (port 3002) → forwards Last-Modified (runtime-connector) dev.mjs (port 3000) → forwards Last-Modified
→ adds Cache-Control: no-cache (this PR) browser HTTP cache → revalidates via If-Modified-Since (this PR, fetch no-cache) → 304 if unchanged / 200 if changed fragment.js sessionStorage → compares last-modified with cached (this PR) → skips re-parse on match / updates on mismatch