### PR TITLE
increased the brightness of code highlight

### DIFF
--- a/hlx_statics/styles/prism.css
+++ b/hlx_statics/styles/prism.css
@@ -220,7 +220,7 @@ pre[class*=language-].no-line-numbers {
   right: 0;
   padding: inherit 0;
   margin-top: 2em;
-  background: hsla(24, 20%, 50%, .16);
+  background: hsla(24, 20%, 50%, .35);
   pointer-events: none;
   line-height: inherit;
   white-space: pre

--- a/hlx_statics/styles/prism.css
+++ b/hlx_statics/styles/prism.css
@@ -218,9 +218,10 @@ pre[class*=language-].no-line-numbers {
   position: absolute;
   left: 0;
   right: 0;
+  width: auto !important;
   padding: inherit 0;
   margin-top: 2em;
-  background: hsla(24, 20%, 50%, .35);
+  background: rgba(99, 154, 255, 0.18);
   pointer-events: none;
   line-height: inherit;
   white-space: pre


### PR DESCRIPTION

# Color change and Bug fixed in this PR: highlight overflow when the browser width decrease to half of screen width

## Before
<img width="877" height="335" alt="image" src="https://github.com/user-attachments/assets/190aff75-4c79-4626-a84a-6a8d790f933a" />

## After
<img width="817" height="330" alt="image" src="https://github.com/user-attachments/assets/2c9a9842-2342-48ae-bde0-6fa3edcc9358" />

