### PR TITLE
dissmiss contributor block

### DIFF
--- a/hlx_statics/blocks/contributors/contributors.css
+++ b/hlx_statics/blocks/contributors/contributors.css
@@ -1,4 +1,5 @@
 main div.contributors-wrapper div.contributors-content {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -9,6 +10,23 @@ main div.contributors-wrapper div.contributors-content {
     background: white;
     border: 1px solid lightgray;
     border-radius: 4px;
+}
+
+main div.contributors-wrapper button.contributors-dismiss {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    background: none;
+    border: none !important;
+    cursor: pointer;
+    font-size: 12px;
+    line-height: 1;
+    color: rgb(110, 110, 110);
+    padding: 2px 4px;
+}
+
+main div.contributors-wrapper button.contributors-dismiss:hover {
+    color: rgb(0, 0, 0);
 }
 
 main div.contributors-wrapper div.contributors-content > div.lastUpdateDetails,

--- a/hlx_statics/blocks/contributors/contributors.js
+++ b/hlx_statics/blocks/contributors/contributors.js
@@ -143,7 +143,13 @@ export default async function decorate(block) {
     btn.classList.add('selected');
   }
 
-  firstDiv.append(lastUpdate, feedback);
+  const dismissButton = document.createElement('button');
+  dismissButton.classList.add('contributors-dismiss');
+  dismissButton.setAttribute('aria-label', 'Dismiss');
+  dismissButton.innerHTML = '&#x2715;';
+  dismissButton.addEventListener('click', () => { block.style.display = 'none'; });
+
+  firstDiv.append(lastUpdate, feedback, dismissButton);
 
   const showModal = () => {
     const modal = document.querySelector('.contributor-modal');
@@ -158,6 +164,7 @@ export default async function decorate(block) {
     modal.classList.remove('show');
     setTimeout(() => {
       modal.style.display = 'none';
+      block.style.display = 'none';
     }, 10);
   }
 


### PR DESCRIPTION
## JIRA
[DEVSITE-2312](https://jira.corp.adobe.com/browse/DEVSITE-2312)

## Description
The product team believe some "thumb-down" was because the contributor block is annoying. This PR added a cross icon that allow user to dismiss the contributor block. Also, when the modal is closed, the contributor block goes away.

<img width="1347" height="321" alt="image" src="https://github.com/user-attachments/assets/7e602d01-f8d6-46ae-a6ae-a27bc3610c40" />
<img width="1303" height="258" alt="image" src="https://github.com/user-attachments/assets/4d1e55ab-4873-441a-b001-96f7985aff08" />
