### PR TITLE
avoid building side nav for redocly

### DIFF
--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -334,7 +334,9 @@ async function loadEager(doc) {
     mainContainer.classList.add('dev-biz');
   }
 
-  buildSideNav(main);
+  if (!main.classList.contains('no-layout')) {
+    buildSideNav(main);
+  }
   buildSiteWideBanner(main);
 
   document.body.classList.add('appear');


### PR DESCRIPTION
## Problem
Originally the side-nav-container will be build for all pages, but the API reference page using redocly has its own nav bar, the side-nav-container will be just a empty div and take a lot of space.

## Fix
added a condition for side-nav-container creation, if the element have class "no-layout", buildSideNav should be skipped

## Before (currently on https://stage--adp-devsite-stage--adobedocs.aem.page/commerce/services/reference/rest/)
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/a95c1122-d8ff-4127-863e-70c15a0621a0" />


## After
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/cf14d0b3-936b-470e-826f-e318d0601d22" />
