### PR TITLE
test: change src of images for Superhero

### DIFF
--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -117,7 +117,8 @@ async function decorateDevBizHalfWidth(block) {
 
   if (backgroundImage) {
     const placeholderDiv = block.querySelector('div:nth-child(2)');
-    const picSrc = placeholderDiv.querySelectorAll('picture img')[0].currentSrc;
+    const picSrc = placeholderDiv.querySelectorAll('picture img')[0].src;
+    console.log("picSrc: " + picSrc);
     Object.assign(wrapper.style, {
       backgroundImage: `url(${picSrc})`,
       backgroundRepeat: 'no-repeat',
@@ -192,7 +193,8 @@ async function decorateDevBizDefault(block) {
   });
 
   const img = block.querySelector('picture > img');
-  const url = img?.getAttribute('src');
+  const url = img.src;
+  console.log("url src: " + url);
   const pictureElement = block.querySelector('picture');
 
   const parentDiv = pictureElement?.parentElement;


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/DEVSITE-2364

Test to see if using the images direct src attribute fixes the image bug in Superhero blocks in private pages. The bug seems to be different in private sites because it isn't the same false local mode error there [just isn't an image](https://developer-stage.adobe.com/private-eds/support/#) in those blocks at all. It looks like currentSrc can sometimes be empty  or faulty

confirming that this change does not affect public pages:

- https://devsite-2364-superhero--adp-devsite--adobedocs.aem.page/dev-docs-reference/blocks/superhero/default/with-background-image

- https://devsite-2364-superhero--adp-devsite--adobedocs.aem.live/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=8