### PR TITLE
add no-layout option for iframe container

### DIFF
--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -326,7 +326,7 @@ export function buildGrid(main) {
     gridAreaMain.classList.add('grid-main-area');
   }
 
-  if(getMetadata('layout') === 'none' && gridAreaMain?.classList.contains('redoclyapiblock-container')){
+  if(getMetadata('layout') === 'none' && (gridAreaMain?.classList.contains('redoclyapiblock-container') || gridAreaMain?.classList.contains('iframe-container'))){
     main?.classList.add('no-layout');
   }
 


### PR DESCRIPTION
## Description
usage of iframe will create an empty side nav container. enabling no-layout option will disable this. Similar to [PR#602](https://github.com/AdobeDocs/adp-devsite/pull/602)

## Before
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/3030ce82-2428-4d5d-9e77-7ae1f2ca263a" />

## After
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/bb0beedc-e640-4d4f-b35b-ca78c94ae335" />
