### PR TITLE
updated shouldHideNavItem for wider parent search

### DIFF
--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -567,8 +567,27 @@ function activateTab(tabItem, isMainPage) {
   underlineItem.parentElement.classList.add("activeTab");
 }
 
-function shouldHideNavItem(linkPath, topNavPath) {
-  return !linkPath.startsWith(topNavPath);
+function shouldHideNavItem(linkPath, topNavPath, li) {
+  if (linkPath.startsWith(topNavPath)) {
+    return false;
+  }
+  // An item whose own link falls outside topNavPath may still belong to the active section
+  // if it is nested within an ancestor li whose link IS under topNavPath (e.g. a reference page
+  // linked from within the optimizer subtree). Walk up the DOM to check.
+  if (li) {
+    let ancestor = li.parentElement?.closest('li');
+    while (ancestor) {
+      const ancestorLink = ancestor.querySelector(':scope > a');
+      if (ancestorLink && !ancestorLink.getAttribute('href').startsWith('http')) {
+        const ancestorPath = new URL(ancestorLink.href, window.location.origin).pathname;
+        if (ancestorPath.startsWith(topNavPath)) {
+          return false;
+        }
+      }
+      ancestor = ancestor.parentElement?.closest('li');
+    }
+  }
+  return true;
 }
 
 function activeSubNav(actTab) {
@@ -594,7 +613,7 @@ function activeSubNav(actTab) {
           const nextLink = nextSibling.querySelector('a');
           if (nextLink) {
             const nextLinkPath = new URL(nextLink.href, window.location.origin).pathname;
-            if (shouldHideNavItem(nextLinkPath, topNavPath)) {
+            if (shouldHideNavItem(nextLinkPath, topNavPath, li)) {
               li.classList.add('hidden');
             }
           }
@@ -617,7 +636,7 @@ function activeSubNav(actTab) {
           showSidenav = true;
         }
 
-        if (!linkPath.startsWith(topNavPath)) {
+        if (shouldHideNavItem(linkPath, topNavPath, li)) {
           li.classList.add('hidden');
         }
       } else {


### PR DESCRIPTION
## Problem
`shouldHideNavItem` only checks if the link of the current `<li>` itself begins with `topNavPath`. If the link path of a page (such as a reference page under the optimizer subtree) is not under `topNavPath`, the navigation item will be hidden—even if it is nested within a parent `<li>` belonging to the current section in the DOM structure.

## Fix
When the link path of the current `<li>` does not match, traverse upwards along the DOM through ancestor `<li>`, checking if any ancestor's link belongs to `topNavPath`. If at least one ancestor meets the condition, the item will not be hidden.

## Test Available on Commerce-Service Repo eds-migration branch
https://github.com/AdobeDocs/commerce-services/tree/eds-migration

exmaple: line 29 of config.md
https://github.com/AdobeDocs/commerce-services/blob/eds-migration/src/pages/config.md?plain=1#L29
## Before
<img width="1728" height="984" alt="image" src="https://github.com/user-attachments/assets/d84853e5-462e-4e50-ad1f-55962e36212b" />

## After
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/b0100a7d-c006-48b0-a802-7a13f9bd03b2" />

