### PR TITLE
DEVSITE-2388: Close top nav dropdowns on outside click

### DIFF
--- a/hlx_statics/blocks/header/header.js
+++ b/hlx_statics/blocks/header/header.js
@@ -864,6 +864,12 @@ function handleButtons(header) {
       });
     }
   });
+
+  document.addEventListener('click', (evt) => {
+    if (!header.contains(evt.target)) {
+      closeAllDropdowns();
+    }
+  });
 }
 
 // To add svg for version switcher

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -980,7 +980,15 @@ export function decorateProfile(profile) {
     } else {
       button.classList.remove('is-open');
       profileDropdownPopover.classList.remove('is-open');
-      profileDropdownPopover.ariaHidden = false;
+      profileDropdownPopover.ariaHidden = true;
+    }
+  });
+
+  document.addEventListener('click', (evt) => {
+    if (!parentContainer.contains(evt.target) && button.classList.contains('is-open')) {
+      button.classList.remove('is-open');
+      profileDropdownPopover.classList.remove('is-open');
+      profileDropdownPopover.ariaHidden = true;
     }
   });
 


### PR DESCRIPTION
JIRA: [DEVSITE-2388](https://jira.corp.adobe.com/browse/DEVSITE-2388)

## Issue
Top nav dropdown menus (including the profile dropdown) remained open when clicking elsewhere on the page, requiring users to explicitly click the toggle button again to dismiss them. 

## Solution
Added a document click listener in handleButtons (header.js) and decorateProfile (lib-adobeio.js) that closes any open dropdown when a click lands outside the header/profile container. Also fixed a pre-existing bug in decorateProfile where ariaHidden was incorrectly set to false on close.

## Test
https://devsite-2388--adp-devsite-stage--adobedocs.aem.page/github-actions-test/