### PR TITLE
exclude block headings from OnThisPage sidebar

### DIFF
--- a/hlx_statics/blocks/onthispage/onthispage.js
+++ b/hlx_statics/blocks/onthispage/onthispage.js
@@ -16,7 +16,7 @@ export default async function decorate(block) {
     block.append(aside);
 
     const mainContainer = document.querySelector('main');
-    const headings = mainContainer.querySelectorAll('h2:not(.side-nav h2):not(footer h2), h3:not(.side-nav h3):not(footer h3)');
+    const headings = mainContainer.querySelectorAll('.heading2:not(.side-nav .heading2):not(footer .heading2) h2, .heading3:not(.side-nav .heading3):not(footer .heading3) h3');
 
     Object.assign(aside.style, {
         display: 'flex',


### PR DESCRIPTION
## Problem
The OnThisPage sidebar was collecting all `h2/h3` elements from `<main>`, including headings that live inside block components. Several blocks produce or retain `h2/h3` nodes in the DOM after decoration:

- CodeBlock — the heading slot content (`<h3>Request</h3>, <h3>Response</h3>`) is copied into tab <button> elements via tab.innerHTML = tabContent.innerHTML, leaving live heading nodes inside buttons.
- AccordionItem — getAccordionItem() programmatically creates new `<h3>` elements for each accordion trigger.
- Cards / Columns — heading elements are kept in the DOM; only CSS classes are added.

These headings have no anchor links (they render as interactive controls, not navigable anchors), so including them in OnThisPage produced broken or meaningless sidebar entries.

## Solution
EDS's buildHeadings() auto-blocks runs early in the decoration pipeline and wraps only default-content headings — those that are direct children of a section div (`main > div > h2/h3`) — into `.heading2 / .heading3` block wrappers. Block headings are nested deeper inside their own block divs and are never promoted into these wrappers.

The fix changes both the OnThisPage heading collector and the hasHeading visibility check to target `.heading2` `h2` and `.heading3` `h3` instead of raw `h2/h3` — selecting only headings that came from the default content flow.

## Tests
[github-actions-test](https://github.com/AdobeDocs/adp-devsite-github-actions-test/commit/907416c773c71710d006f40b5c961b2f63fe8006)

## Comparison
[Before](https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/DEVSITE-2173/)
[After](https://devsite-2173--adp-devsite-stage--adobedocs.aem.page/github-actions-test/test/DEVSITE-2173/)