### PR TITLE
fix(ai-assistant): fixed marked crashing because of undefined renderer

### DIFF
--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -35,6 +35,20 @@ export default async function decorate(block) {
     document.body,
     "https://unpkg.com/marked@^17/lib/marked.umd.js",
     () => {
+      // @ts-expect-error - marked is not on the Window object
+      window.marked.use({
+        renderer: {
+          /**
+           * @param {Object} options
+           * @param {string} options.href
+           * @param {string} options.title
+           * @param {string} options.text
+           */
+          link({ href, title, text }) {
+            return `<a href="${href}" title="${title || text}" daa-ll="${title || text}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+          },
+        },
+      });
       addExtraScriptWithLoad(
         document.body,
         "https://unpkg.com/dompurify@^3/dist/purify.min.js",

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -255,18 +255,7 @@ export class ChatBubble {
       // @ts-expect-error - DOMPurify is not on the Window object
       contentElement.innerHTML = window.DOMPurify.sanitize(
         // @ts-expect-error - marked is not on the Window object
-        window.marked.parse(this.content, {
-          renderer: {
-            /**
-             * @param {string} href
-             * @param {string} title
-             * @param {string} text
-             */
-            link(href, title, text) {
-              return `<a href="${href}" title="${title || text}" daa-ll="${title || text}" target="_blank" rel="noopener noreferrer">${text}</a>`;
-            },
-          },
-        }),
+        window.marked.parse(this.content),
       );
     }
   }


### PR DESCRIPTION
Turns out using a custom renderer on `marked.parse` overwrites the entire renderer, not just the specified functions.

I moved the custom renderer into `marked.use` which merges the link function into the default renderer.

I also changed the link function signature to the correct one.