### PR TITLE
feat: enable text color on non-default superhero variants

### DIFF
--- a/hlx_statics/blocks/superhero/superhero.css
+++ b/hlx_statics/blocks/superhero/superhero.css
@@ -1,3 +1,28 @@
+main div.superhero-wrapper div.superhero a:not(.spectrum-Button) {
+  color: inherit !important;
+  text-decoration: underline;
+}
+
+main div.superhero-wrapper div.superhero.text-color-white,
+main div.superhero-wrapper div.superhero.text-color-white :is(h1, h2, h3, h4, h5, h6, p) {
+  color: rgb(255, 255, 255) !important;
+}
+
+main div.superhero-wrapper div.superhero.text-color-black,
+main div.superhero-wrapper div.superhero.text-color-black :is(h1, h2, h3, h4, h5, h6, p) {
+  color: rgb(0, 0, 0) !important;
+}
+
+main div.superhero-wrapper div.superhero.text-color-gray,
+main div.superhero-wrapper div.superhero.text-color-gray :is(h1, h2, h3, h4, h5, h6, p) {
+  color: rgb(110, 110, 110) !important;
+}
+
+main div.superhero-wrapper div.superhero.text-color-navy,
+main div.superhero-wrapper div.superhero.text-color-navy :is(h1, h2, h3, h4, h5, h6, p) {
+  color: rgb(15, 55, 95) !important;
+}
+
 main div.superhero-wrapper div.superhero span.icon {
   display: inline-block;
 }
@@ -159,7 +184,6 @@ main div.superhero-wrapper div.superhero.half-width > div:last-child video {
 
 main div.superhero-wrapper div.superhero.half-width p.spectrum-Body--sizeL {
   margin-top: 0 !important;
-  color: rgb(80, 80, 80) !important;
 }
 
 main div.superhero-wrapper:has(div.superhero.half-width) {
@@ -206,20 +230,6 @@ main div.superhero-wrapper div.superhero.half-width h3 {
 
 main div.superhero-wrapper div.superhero.half-width h1 + p.last-of-type {
   margin-bottom: 0 !important;
-}
-
-main div.superhero-wrapper div.superhero.half-width a:not(.spectrum-Button) {
-  text-decoration: underline;
-}
-
-main div.superhero-wrapper div.superhero.half-width.text-color-white h1,
-main div.superhero-wrapper div.superhero.half-width.text-color-white a,
-main div.superhero-wrapper div.superhero.half-width.text-color-white p {
-  color: white !important;
-}
-
-main div.superhero-wrapper div.superhero.half-width.text-color-black {
-  color: black;
 }
 
 main div.superhero-wrapper div.superhero.half-width.over-gradient p.button-container:not(strong) a:not(.spectrum-Button--accent) {
@@ -294,22 +304,6 @@ main div.superhero-wrapper div.superhero.default .all-button-container > p {
 main div.superhero-wrapper div.superhero.default .all-button-container {
   display: inline-flex;
   gap: 16px;
-}
-
-main div.superhero-wrapper div.superhero.default.text-color-white {
-  color: rgb(255, 255, 255);
-}
-
-main div.superhero-wrapper div.superhero.default.text-color-black {
-  color: rgb(0, 0, 0);
-}
-
-main div.superhero-wrapper div.superhero.default.text-color-gray {
-  color: rgb(110, 110, 110);
-}
-
-main div.superhero-wrapper div.superhero.default.text-color-navy {
-  color: rgb(15, 55, 95);
 }
 
 @media screen and (max-width: 1280px) {

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -45,6 +45,10 @@ function hasAnyClass(block, classes) {
   return classes.some((c) => block.classList.contains(c));
 }
 
+function getTextColorModifier(block) {
+  return Object.values(TEXT_COLORS).find((color) => block.classList.contains(`text-color-${color}`));
+}
+
 function unwrapIcons(block) {
   block.querySelectorAll('span.icon').forEach((span) => {
     span.textContent = '';  
@@ -56,6 +60,7 @@ function unwrapIcons(block) {
 
 async function decorateDevBizCentered(block) {
   const defaultTextColor = TEXT_COLORS.white;
+  const textColor = getTextColorModifier(block);
 
   removeEmptyPTags(block);
   decorateButtons(block);
@@ -69,7 +74,7 @@ async function decorateDevBizCentered(block) {
   block.classList.add('spectrum--dark');
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeXXL');
-    h.style.color = defaultTextColor;
+    if (!textColor) h.style.color = defaultTextColor;
     h.parentElement.classList.add('superhero-content');
     h.parentElement.append(button_div);
   });
@@ -77,7 +82,7 @@ async function decorateDevBizCentered(block) {
   block.querySelectorAll('p').forEach((p) => {
     if (!p.classList.contains('icon-container')) {
       p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
-      p.style.color = defaultTextColor;
+      if (!textColor) p.style.color = defaultTextColor;
     }
     if (p.classList.contains('button-container')) {
       button_div.append(p);
@@ -189,9 +194,8 @@ async function decorateDevBizDefault(block) {
   div.append(...newChildren);
   block.replaceChildren(div);
 
-  const defaultTextColor = TEXT_COLORS.white;
-  let textColor = Object.values(TEXT_COLORS).find((color) => block.classList.contains(`text-color-${color}`)) ?? defaultTextColor;
-  block.classList.add(`text-color-${defaultTextColor}`);
+  const textColor = getTextColorModifier(block) ?? TEXT_COLORS.white;
+  block.classList.add(`text-color-${textColor}`);
 
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     h.style.color = textColor;
@@ -355,14 +359,6 @@ function applyDataAttributeStyles(block) {
     wrapper.style.background = background;
   } else {
     block.style.background = background;
-  }
-
-  const defaultTextColor = variant === VARIANTS.halfWidth ? TEXT_COLORS.black : TEXT_COLORS.white;
-  const textColor = block.getAttribute('data-textcolor') || defaultTextColor;
-  if (Object.keys(TEXT_COLORS).includes(textColor)) {
-    block.querySelectorAll('h1, h2, h3, h4, h5, h6, p').forEach((el) => {
-      el.style.color = textColor;
-    });
   }
 }
 


### PR DESCRIPTION
## Description

Fixes the text color modifier on non-default **Superhero** variants ([DEVSITE-2289](https://jira.corp.adobe.com/browse/DEVSITE-2289)): `Centered` and `Centered XL` ignored it entirely; `Half-Width` applied it to the heading only. All variants now apply it to heading, text, and inline links, for both DevBiz and DevDocs.

Also fixes two related color inconsistencies:
- Inline links are now underlined ([DEVSITE-2008](https://jira.corp.adobe.com/browse/DEVSITE-2008)) — buttons unaffected
- Default variant heading color now matches body (was a brighter shade with `navy`)

## Test

| Variant | Authoring | Modifier | Before | After |
|---|---|---|---|---|
| Default | DevDocs | none | [unchanged](https://stage--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/default/) | [unchanged](https://superhero-text-color--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/default/) |
| Default | DevDocs | `textColor="navy"` | [broken](https://stage--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/default/with-text-and-background-color) | [fixed](https://superhero-text-color--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/default/with-text-and-background-color) |
| Centered | DevDocs | none | [unchanged](https://stage--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/centered/) | [unchanged](https://superhero-text-color--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/centered/) |
| Centered | DevDocs | `textColor="navy"` | [broken](https://stage--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/centered/with-text-and-background-color) | [fixed](https://superhero-text-color--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/centered/with-text-and-background-color) |
| Centered XL | DevDocs | none | [unchanged](https://stage--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/centeredxl/) | [unchanged](https://superhero-text-color--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/centeredxl/) |
| Centered XL | DevDocs | `textColor="navy"` | [broken](https://stage--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/centeredxl/with-text-and-background-color) | [fixed](https://superhero-text-color--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/centeredxl/with-text-and-background-color) |
| Half-Width | DevDocs | none | [unchanged](https://stage--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/halfwidth/) | [unchanged](https://superhero-text-color--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/halfwidth/) |
| Half-Width | DevDocs | `textColor="navy"` | [broken](https://stage--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/halfwidth/with-text-and-background-color) | [fixed](https://superhero-text-color--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/superhero/halfwidth/with-text-and-background-color) |
| Default | DevBiz | none | [unchanged](https://stage--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=0) | [unchanged](https://superhero-text-color--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=0) |
| Default | DevBiz | `text-color-gray` | [broken](https://stage--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=2) | [fixed](https://superhero-text-color--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=2) |
| Centered | DevBiz | none | [unchanged](https://stage--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=3) | [unchanged](https://superhero-text-color--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=3) |
| Centered | DevBiz | `text-color-gray` | [broken](https://stage--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=5) | [fixed](https://superhero-text-color--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=5) |
| Centered XL | DevBiz | none | [unchanged](https://stage--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=6) | [unchanged](https://superhero-text-color--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=6) |
| Centered XL | DevBiz | `text-color-gray` | [broken](https://stage--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=8) | [fixed](https://superhero-text-color--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=8) |
| Half-Width | DevBiz | none | [unchanged](https://stage--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=9) | [unchanged](https://superhero-text-color--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=9) |
| Half-Width | DevBiz | `text-color-gray` | [broken](https://stage--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=11) | [fixed](https://superhero-text-color--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/superhero&index=11) |