### PR TITLE
Release June 4th

### DIFF
--- a/hlx_statics/blocks/ai-assistant/ai-assistant.css
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.css
@@ -100,7 +100,7 @@
     }
 
     &.show {
-        width: 400px;
+        width: 460px;
         height: 100%;
         border-radius: 8px;
         visibility: visible;
@@ -151,8 +151,21 @@
         margin: 0;
         font-size: 18px;
         font-weight: 700;
-        flex: 1;
-        margin-left: 12px;
+        margin-inline: 12px;
+    }
+
+    .chat-window-badge {
+        box-sizing: border-box;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2px 11px;
+        background-color: rgb(255, 232, 240);
+        color: black;
+        border-radius: 7px;
+        font-size: 12px;
+        min-height: 24px;
+        line-height: 14px;
     }
 
     .chat-window-close,

--- a/hlx_statics/blocks/ai-assistant/ai-assistant.css
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.css
@@ -25,6 +25,7 @@
     );
     --container-padding: 40px;
     --button-size: 48px;
+    --opening-transition-duration: 0.25s;
 
     display: flex;
     flex-direction: column-reverse;
@@ -51,6 +52,9 @@
         var(--ai-border-linear-gradient) border-box;
     align-self: flex-end;
     pointer-events: auto;
+    visibility: visible;
+    transition: visibility 0s linear
+        calc(var(--opening-transition-duration) * 0.9);
 
     &:hover {
         --background-color: #f0f0f0;
@@ -58,6 +62,7 @@
 
     &.hidden {
         visibility: hidden;
+        transition: visibility 0s linear;
     }
 }
 
@@ -65,13 +70,11 @@
 * MARK: Chat Window
 */
 .ai-assistant-panel .chat-window {
-    --transition-duration: 0.25s;
-    width: var(--button-size);
-    height: var(--button-size);
-    border-radius: calc(var(--button-size) / 2);
-    background:
-        linear-gradient(#ffffff, #ffffff) padding-box,
-        var(--ai-border-linear-gradient) border-box;
+    --chat-window-width: 460px;
+    width: var(--chat-window-width);
+    height: 100%;
+    border-radius: 8px;
+    background: #fff;
     /* Drop shadow/elevated (pretty much copy pasta from Figma) */
     box-shadow:
         0 0 2px 0 rgba(0, 0, 0, 0.12),
@@ -80,48 +83,25 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    transform: translateY(var(--button-size));
+    transform: scale(0);
+    transform-origin: calc(100% - var(--button-size) / 2)
+        calc(100% - var(--button-size) / 2);
+    translate: 0 var(--button-size);
     visibility: hidden;
-    border: solid transparent;
-    border-width: 2px;
+    border: 0;
 
     transition:
-        width var(--transition-duration) ease-out var(--transition-duration),
-        height var(--transition-duration) ease-out var(--transition-duration),
-        border-radius var(--transition-duration) ease-out,
-        border-width var(--transition-duration) linear,
-        visibility 0s linear calc(var(--transition-duration) * 2);
-
-    .chat-window-header,
-    .chat-window-content,
-    .chat-window-input-section {
-        opacity: 0;
-        transition: opacity var(--transition-duration) ease-out 0s;
-    }
+        transform var(--opening-transition-duration) cubic-bezier(0.5, 0, 1, 1),
+        visibility 0s linear var(--opening-transition-duration);
 
     &.show {
-        width: 460px;
-        height: 100%;
-        border-radius: 8px;
         visibility: visible;
         transition:
-            width var(--transition-duration) ease-out,
-            height var(--transition-duration) ease-out,
-            border-radius var(--transition-duration) ease-out
-                var(--transition-duration),
-            border-width var(--transition-duration) linear
-                var(--transition-duration),
-            visibility 0s linear 0s;
+            transform var(--opening-transition-duration)
+                cubic-bezier(0, 0, 0.4, 1),
+            visibility 0s linear;
         pointer-events: auto;
-        border-width: 0px;
-
-        .chat-window-header,
-        .chat-window-content,
-        .chat-window-input-section {
-            opacity: 1;
-            transition: opacity var(--transition-duration) ease-out
-                calc(var(--transition-duration) * 2);
-        }
+        transform: scale(1);
     }
 
     .chat-ai-avatar {

--- a/hlx_statics/blocks/ai-assistant/ai-assistant.css
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.css
@@ -42,7 +42,9 @@
 
     position: relative;
     width: var(--button-size);
+    min-width: var(--button-size);
     height: var(--button-size);
+    min-height: var(--button-size);
     border-radius: 50%;
     border: 2px solid transparent;
     padding: 0;

--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -35,6 +35,20 @@ export default async function decorate(block) {
     document.body,
     "https://unpkg.com/marked@^17/lib/marked.umd.js",
     () => {
+      // @ts-expect-error - marked is not on the Window object
+      window.marked.use({
+        renderer: {
+          /**
+           * @param {Object} options
+           * @param {string} options.href
+           * @param {string} options.title
+           * @param {string} options.text
+           */
+          link({ href, title, text }) {
+            return `<a href="${href}" title="${title || text}" daa-ll="${title || text}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+          },
+        },
+      });
       addExtraScriptWithLoad(
         document.body,
         "https://unpkg.com/dompurify@^3/dist/purify.min.js",

--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -45,7 +45,7 @@ export default async function decorate(block) {
            * @param {string} options.text
            */
           link({ href, title, text }) {
-            return `<a href="${href}" title="${title || text}" daa-ll="Devsite AI Assistant:Message:Link:${title || text}|${href}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+            return `<a href="${href}" title="${title || text}" daa-ll="DevsiteAI Assistant:Message:Link:${title || text}|${href}" target="_blank" rel="noopener noreferrer">${text}</a>`;
           },
         },
       });

--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -45,7 +45,7 @@ export default async function decorate(block) {
            * @param {string} options.text
            */
           link({ href, title, text }) {
-            return `<a href="${href}" title="${title || text}" daa-ll="${title || text}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+            return `<a href="${href}" title="${title || text}" daa-ll="Devsite AI Assistant:Message:Link:${title || text}|${href}" target="_blank" rel="noopener noreferrer">${text}</a>`;
           },
         },
       });

--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -6,6 +6,7 @@ import {
 
 import { aiApiClient } from "./ai-assistant_api-client.js";
 import {
+  onUserScroll,
   restoreChatHistory,
   toggleChatWindow,
 } from "./ai-assistant_chat-controller.js";
@@ -67,6 +68,7 @@ export default async function decorate(block) {
 
   block.appendChild(panel);
 
+  ELEMENTS.CHAT_WINDOW_CONTENT?.addEventListener("scroll", onUserScroll);
   ELEMENTS.CHAT_BUTTON?.addEventListener("click", toggleChatWindow);
   ELEMENTS.CHAT_WINDOW_CLEAR_BUTTON?.addEventListener("click", () =>
     chatWindow.appendChild(createClearDialog()),

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_api-client.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_api-client.js
@@ -93,7 +93,7 @@ const STAGE_API_URL =
 const PROD_API_URL =
   "https://devsite-rag.app-builder.adp.adobe.io/v1/inference";
 const API_KEY = "ai-assistant-devsite-rag-demo-01";
-const PROD_API_KEY = "test-prod-rag-devsite";
+const PROD_API_KEY = "devsite-rag";
 const IS_PROD = isProdEnvironment(window.location.host);
 
 export class AiApiClient {

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_api-client.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_api-client.js
@@ -92,7 +92,7 @@ const STAGE_API_URL =
   "https://devsite-rag.stg.app-builder.corp.adp.adobe.io/v1/inference";
 const PROD_API_URL =
   "https://devsite-rag.app-builder.adp.adobe.io/v1/inference";
-const API_KEY = "ai-assistant-devsite-rag-demo-01";
+const STAGE_API_KEY = "ai-assistant-devsite-rag-demo-01";
 const PROD_API_KEY = "devsite-rag";
 const IS_PROD = isProdEnvironment(window.location.host);
 
@@ -424,5 +424,5 @@ export class AiApiClient {
 
 export const aiApiClient = new AiApiClient({
   baseUrl: IS_PROD ? PROD_API_URL : STAGE_API_URL,
-  apiKey: IS_PROD ? PROD_API_KEY : API_KEY,
+  apiKey: IS_PROD ? PROD_API_KEY : STAGE_API_KEY,
 });

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_api-client.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_api-client.js
@@ -1,5 +1,6 @@
 // @ts-check
-import { AI_API_BASE_URL, AI_API_KEY } from "./ai-assistant_constants.js";
+
+import { isProdEnvironment } from "../../scripts/lib-adobeio.js";
 
 /**
  * @typedef {Object} RequestBody
@@ -87,11 +88,19 @@ import { AI_API_BASE_URL, AI_API_KEY } from "./ai-assistant_constants.js";
  * @property {(error: unknown) => void} onError
  */
 
+const STAGE_API_URL =
+  "https://devsite-rag.stg.app-builder.corp.adp.adobe.io/v1/inference";
+const PROD_API_URL =
+  "https://devsite-rag.app-builder.adp.adobe.io/v1/inference";
+const API_KEY = "ai-assistant-devsite-rag-demo-01";
+const PROD_API_KEY = "test-prod-rag-devsite";
+const IS_PROD = isProdEnvironment(window.location.host);
+
 export class AiApiClient {
-  static STREAMING_ENDPOINT = "/v1/inference/retrieve/generate/stream";
-  static NON_STREAMING_ENDPOINT = "/v1/inference/retrieve/generate";
-  static COLLECTIONS_ENDPOINT = "/v1/inference/collections";
-  static FEEDBACK_ENDPOINT = "/v1/inference/feedback";
+  static STREAMING_ENDPOINT = "/retrieve/generate/stream";
+  static NON_STREAMING_ENDPOINT = "/retrieve/generate";
+  static COLLECTIONS_ENDPOINT = "/collections";
+  static FEEDBACK_ENDPOINT = "/feedback";
   static LOCAL_STORAGE_COLLECTIONS_KEY = "ai-assistant__collections";
   static LOCAL_STORAGE_COLLECTION_TTL = 1 * 24 * 60 * 60 * 1000; // 1 day
 
@@ -414,6 +423,6 @@ export class AiApiClient {
 }
 
 export const aiApiClient = new AiApiClient({
-  baseUrl: AI_API_BASE_URL,
-  apiKey: AI_API_KEY,
+  baseUrl: IS_PROD ? PROD_API_URL : STAGE_API_URL,
+  apiKey: IS_PROD ? PROD_API_KEY : API_KEY,
 });

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -42,7 +42,6 @@ export class ChatBubble {
     const bubble = createTag("div", { class: "chat-bubble" });
     const contentElement = createTag("div", {
       class: "chat-bubble-content",
-      "daa-lh": "AI Assistant - Message bubble",
     });
 
     if (this.source === "ai") {
@@ -114,7 +113,7 @@ export class ChatBubble {
           class: "chat-bubble-copy",
           type: "button",
           "aria-label": COPY_BUTTON_LABEL,
-          "daa-ll": COPY_BUTTON_LABEL,
+          "daa-ll": "Devsite AI Assistant:Message:Button:Copy",
         })
       );
     button.innerHTML = COPY_ICON_SVG;
@@ -184,7 +183,7 @@ export class ChatBubble {
         class: "chat-bubble-feedback",
         type: "button",
         "aria-label": THUMB_UP_LABEL,
-        "daa-ll": THUMB_UP_LABEL,
+        "daa-ll": "Devsite AI Assistant:Message:Button:Upvote",
       })
     );
     thumbUpButton.innerHTML = THUMB_UP_ICON_SVG;
@@ -197,7 +196,7 @@ export class ChatBubble {
         class: "chat-bubble-feedback",
         type: "button",
         "aria-label": THUMB_DOWN_LABEL,
-        "daa-ll": THUMB_DOWN_LABEL,
+        "daa-ll": "Devsite AI Assistant:Message:Button:Downvote",
       })
     );
     thumbDownButton.innerHTML = THUMB_DOWN_ICON_SVG;
@@ -332,7 +331,6 @@ export class ChatBubble {
 
     const wrapper = createTag("div", {
       class: "chat-bubble-sources",
-      "daa-lh": "AI Assistant - Message sources",
     });
     const heading = createTag("p", { class: "chat-bubble-sources-heading" });
     heading.textContent = "Sources:";
@@ -347,7 +345,10 @@ export class ChatBubble {
         rel: "noopener noreferrer",
       });
       a.textContent = title || url;
-      a.setAttribute("daa-ll", a.textContent);
+      a.setAttribute(
+        "daa-ll",
+        `Devsite AI Assistant:Message:Sources:Link:${a.textContent}|${url}`,
+      );
       li.appendChild(a);
       list.appendChild(li);
     });

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -255,7 +255,18 @@ export class ChatBubble {
       // @ts-expect-error - DOMPurify is not on the Window object
       contentElement.innerHTML = window.DOMPurify.sanitize(
         // @ts-expect-error - marked is not on the Window object
-        window.marked.parse(this.content),
+        window.marked.parse(this.content, {
+          renderer: {
+            /**
+             * @param {string} href
+             * @param {string} title
+             * @param {string} text
+             */
+            link(href, title, text) {
+              return `<a href="${href}" title="${title || text}" daa-ll="${title || text}" target="_blank">${text}</a>`;
+            },
+          },
+        }),
       );
     }
   }

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -263,7 +263,7 @@ export class ChatBubble {
              * @param {string} text
              */
             link(href, title, text) {
-              return `<a href="${href}" title="${title || text}" daa-ll="${title || text}" target="_blank">${text}</a>`;
+              return `<a href="${href}" title="${title || text}" daa-ll="${title || text}" target="_blank" rel="noopener noreferrer">${text}</a>`;
             },
           },
         }),

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -40,7 +40,10 @@ export class ChatBubble {
    */
   #_init() {
     const bubble = createTag("div", { class: "chat-bubble" });
-    const contentElement = createTag("div", { class: "chat-bubble-content" });
+    const contentElement = createTag("div", {
+      class: "chat-bubble-content",
+      "daa-lh": "AI Assistant - Message bubble",
+    });
 
     if (this.source === "ai") {
       if (!this.isContinuingConversation) {
@@ -111,6 +114,7 @@ export class ChatBubble {
           class: "chat-bubble-copy",
           type: "button",
           "aria-label": COPY_BUTTON_LABEL,
+          "daa-ll": COPY_BUTTON_LABEL,
         })
       );
     button.innerHTML = COPY_ICON_SVG;
@@ -180,6 +184,7 @@ export class ChatBubble {
         class: "chat-bubble-feedback",
         type: "button",
         "aria-label": THUMB_UP_LABEL,
+        "daa-ll": THUMB_UP_LABEL,
       })
     );
     thumbUpButton.innerHTML = THUMB_UP_ICON_SVG;
@@ -192,6 +197,7 @@ export class ChatBubble {
         class: "chat-bubble-feedback",
         type: "button",
         "aria-label": THUMB_DOWN_LABEL,
+        "daa-ll": THUMB_DOWN_LABEL,
       })
     );
     thumbDownButton.innerHTML = THUMB_DOWN_ICON_SVG;
@@ -324,7 +330,10 @@ export class ChatBubble {
 
     this.references = references;
 
-    const wrapper = createTag("div", { class: "chat-bubble-sources" });
+    const wrapper = createTag("div", {
+      class: "chat-bubble-sources",
+      "daa-lh": "AI Assistant - Message sources",
+    });
     const heading = createTag("p", { class: "chat-bubble-sources-heading" });
     heading.textContent = "Sources:";
     wrapper.appendChild(heading);
@@ -338,6 +347,7 @@ export class ChatBubble {
         rel: "noopener noreferrer",
       });
       a.textContent = title || url;
+      a.setAttribute("daa-ll", a.textContent);
       li.appendChild(a);
       list.appendChild(li);
     });

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -113,7 +113,7 @@ export class ChatBubble {
           class: "chat-bubble-copy",
           type: "button",
           "aria-label": COPY_BUTTON_LABEL,
-          "daa-ll": "Devsite AI Assistant:Message:Button:Copy",
+          "daa-ll": "DevsiteAI Assistant:Message:Button:Copy",
         })
       );
     button.innerHTML = COPY_ICON_SVG;
@@ -183,7 +183,7 @@ export class ChatBubble {
         class: "chat-bubble-feedback",
         type: "button",
         "aria-label": THUMB_UP_LABEL,
-        "daa-ll": "Devsite AI Assistant:Message:Button:Upvote",
+        "daa-ll": "DevsiteAI Assistant:Message:Button:Upvote",
       })
     );
     thumbUpButton.innerHTML = THUMB_UP_ICON_SVG;
@@ -196,7 +196,7 @@ export class ChatBubble {
         class: "chat-bubble-feedback",
         type: "button",
         "aria-label": THUMB_DOWN_LABEL,
-        "daa-ll": "Devsite AI Assistant:Message:Button:Downvote",
+        "daa-ll": "DevsiteAI Assistant:Message:Button:Downvote",
       })
     );
     thumbDownButton.innerHTML = THUMB_DOWN_ICON_SVG;
@@ -347,7 +347,7 @@ export class ChatBubble {
       a.textContent = title || url;
       a.setAttribute(
         "daa-ll",
-        `Devsite AI Assistant:Message:Sources:Link:${a.textContent}|${url}`,
+        `DevsiteAI Assistant:Message:Sources:Link:${a.textContent}|${url}`,
       );
       li.appendChild(a);
       list.appendChild(li);

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -255,18 +255,7 @@ export class ChatBubble {
       // @ts-expect-error - DOMPurify is not on the Window object
       contentElement.innerHTML = window.DOMPurify.sanitize(
         // @ts-expect-error - marked is not on the Window object
-        window.marked.parse(this.content, {
-          renderer: {
-            /**
-             * @param {string} href
-             * @param {string} title
-             * @param {string} text
-             */
-            link(href, title, text) {
-              return `<a href="${href}" title="${title || text}" daa-ll="${title || text}" target="_blank" rel="noopener noreferrer">${text}</a>`;
-            },
-          },
-        }),
+        window.marked.parse(this.content),
       );
     }
   }

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
@@ -18,6 +18,34 @@ import {
   updateSuggestedQuestions,
 } from "./ai-assistant_suggested-questions.js";
 
+let userScrolledUp = false;
+let lastScrollTop = 0;
+
+/**
+ * Handles scroll events in the chat window to detect when the user scrolls up or back to the bottom.
+ * Sets/resets a flag to pause or resume auto-scrolling during streaming.
+ * Uses scroll direction rather than absolute position so programmatic downward scrolls
+ * during streaming don't mask the user's upward intent.
+ *
+ * @param {Event} event - The scroll event from the chat container element
+ */
+export const onUserScroll = (event) => {
+  if (event.type !== "scroll" || !event.target) {
+    return;
+  }
+  const container = /** @type {HTMLDivElement} */ (event.target);
+  const distanceFromBottom =
+    container.scrollHeight - container.clientHeight - container.scrollTop;
+  const scrolledUp = container.scrollTop < lastScrollTop;
+  lastScrollTop = container.scrollTop;
+
+  if (userScrolledUp && distanceFromBottom < 10) {
+    userScrolledUp = false;
+  } else if (!userScrolledUp && scrolledUp && distanceFromBottom > 100) {
+    userScrolledUp = true;
+  }
+};
+
 /**
  * @param {Partial<{delay: number}>} [options]
  */
@@ -166,6 +194,8 @@ export const handleUserQuery = async (
   messageContentOverride,
   collectionId = null,
 ) => {
+  userScrolledUp = false;
+  lastScrollTop = 0;
   let messageContent = messageContentOverride;
   const textarea = /** @type {HTMLTextAreaElement} */ (ELEMENTS.CHAT_TEXTAREA);
 
@@ -222,7 +252,10 @@ export const handleUserQuery = async (
           targetBubble.hideThinking();
           targetBubble.showStreamingCursor();
           targetBubble.updateContent(responseContent);
-          targetBubble.scrollIntoView();
+          if (!userScrolledUp && ELEMENTS.CHAT_WINDOW_CONTENT) {
+            ELEMENTS.CHAT_WINDOW_CONTENT.scrollTop =
+              ELEMENTS.CHAT_WINDOW_CONTENT.scrollHeight;
+          }
         }
       },
       onCitation: (data) => {
@@ -245,7 +278,10 @@ export const handleUserQuery = async (
               content: responseContent,
               references,
             });
-            targetBubble.scrollIntoView();
+            if (!userScrolledUp && ELEMENTS.CHAT_WINDOW_CONTENT) {
+              ELEMENTS.CHAT_WINDOW_CONTENT.scrollTop =
+                ELEMENTS.CHAT_WINDOW_CONTENT.scrollHeight;
+            }
           }
         }
       },
@@ -256,7 +292,11 @@ export const handleUserQuery = async (
           responseContent = "_Response stopped by user._";
           targetBubble.updateContent(responseContent);
           updateSuggestedQuestions(await getCollectionsQuestions());
-          window.setTimeout(showSuggestedQuestions, suggestedQuestionsDelayMs);
+          window.setTimeout(
+            () =>
+              showSuggestedQuestions({ shouldScrollIntoView: !userScrolledUp }),
+            suggestedQuestionsDelayMs,
+          );
           return;
         }
         targetBubble.completeBubble();
@@ -264,10 +304,17 @@ export const handleUserQuery = async (
           content: responseContent,
           references: accumulatedReferences,
         });
-        targetBubble.scrollIntoView();
+        if (!userScrolledUp && ELEMENTS.CHAT_WINDOW_CONTENT) {
+          ELEMENTS.CHAT_WINDOW_CONTENT.scrollTop =
+            ELEMENTS.CHAT_WINDOW_CONTENT.scrollHeight;
+        }
 
         updateSuggestedQuestions(null);
-        window.setTimeout(showSuggestedQuestions, suggestedQuestionsDelayMs);
+        window.setTimeout(
+          () =>
+            showSuggestedQuestions({ shouldScrollIntoView: !userScrolledUp }),
+          suggestedQuestionsDelayMs,
+        );
         await fetchAiSuggestedQuestions();
       },
       onError: (error) => {
@@ -276,7 +323,11 @@ export const handleUserQuery = async (
         console.error("[AI Assistant] Error:", error);
         showErrorMessage();
         getCollectionsQuestions().then(updateSuggestedQuestions);
-        window.setTimeout(showSuggestedQuestions, suggestedQuestionsDelayMs);
+        window.setTimeout(
+          () =>
+            showSuggestedQuestions({ shouldScrollIntoView: !userScrolledUp }),
+          suggestedQuestionsDelayMs,
+        );
       },
     },
   });

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-ui.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-ui.js
@@ -43,7 +43,7 @@ export const createChatWindowHeader = () => {
     class: "chat-window-clear",
     type: "button",
     "aria-label": CHAT_BUTTON_LABEL_CLEAR,
-    "daa-ll": CHAT_BUTTON_LABEL_CLEAR,
+    "daa-ll": "Open clear dialog",
   });
   const clearButtonIcon = createTag("img", {
     src: "/hlx_statics/icons/delete.svg",

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-ui.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-ui.js
@@ -31,7 +31,6 @@ export const createAiAvatar = () => {
 export const createChatWindowHeader = () => {
   const chatWindowHeader = createTag("header", {
     class: "chat-window-header",
-    "daa-lh": "AI Assistant - Window header",
   });
   chatWindowHeader.appendChild(createAiAvatar());
   const label = createTag("h2", {
@@ -47,7 +46,7 @@ export const createChatWindowHeader = () => {
     class: "chat-window-clear",
     type: "button",
     "aria-label": CHAT_BUTTON_LABEL_CLEAR,
-    "daa-ll": "Open clear dialog",
+    "daa-ll": "Devsite AI Assistant:Clear dialog:Open",
   });
   const clearButtonIcon = createTag("img", {
     src: "/hlx_statics/icons/delete.svg",
@@ -60,7 +59,7 @@ export const createChatWindowHeader = () => {
     class: "chat-window-close",
     type: "button",
     "aria-label": CHAT_BUTTON_LABEL_CLOSE,
-    "daa-ll": CHAT_BUTTON_LABEL_CLOSE,
+    "daa-ll": "Devsite AI Assistant:Close",
   });
   const closeButtonIcon = createTag("img", {
     src: "/hlx_statics/icons/dismiss.svg",
@@ -85,7 +84,6 @@ export const createChatWindowHeader = () => {
 export const createInputSection = () => {
   const inputSection = createTag("div", {
     class: "chat-window-input-section",
-    "daa-lh": "AI Assistant - Input section",
   });
   const textarea = /** @type {HTMLTextAreaElement} */ (
     createTag("textarea", {
@@ -95,14 +93,14 @@ export const createInputSection = () => {
     })
   );
   const disclaimerText = createTag("div", { class: "chat-disclaimer-text" });
-  disclaimerText.innerHTML = `By using AI Assistant, you agree to the <a href="https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html" target="_blank" rel="noopener noreferrer" daa-ll="Generative AI User Guidelines">Generative AI User Guidelines</a>.`;
+  disclaimerText.innerHTML = `By using AI Assistant, you agree to the <a href="https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html" target="_blank" rel="noopener noreferrer" daa-ll="Devsite AI Assistant:Disclaimer:Link:Generative AI User Guidelines">Generative AI User Guidelines</a>.`;
 
   const sendButton = /** @type {HTMLButtonElement} */ (
     createTag("button", {
       class: "chat-send-button",
       type: "button",
       "aria-label": "Send message",
-      "daa-ll": "Send message",
+      "daa-ll": "Devsite AI Assistant:Send message",
     })
   );
   const sendButtonIcon = createTag("img", {
@@ -157,7 +155,7 @@ export const createChatButton = () => {
     "aria-expanded": "false",
     "aria-haspopup": "dialog",
     "aria-label": CHAT_BUTTON_LABEL_OPEN,
-    "daa-ll": CHAT_BUTTON_LABEL_OPEN,
+    "daa-ll": "Devsite AI Assistant:Open",
   });
   chatButton.innerHTML = `<svg width="26" height="26" viewBox="0 0 26 26" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeXL"><path d="M8.1248 24.6977C7.99531 24.6977 7.86582 24.6723 7.74267 24.6202C7.38339 24.4666 7.1498 24.1137 7.1498 23.7227V19.4977H6.1748C3.48721 19.4977 1.2998 17.3103 1.2998 14.6227V7.47266C1.2998 4.78506 3.48721 2.59766 6.1748 2.59766H11.3139C11.8521 2.59766 12.2889 3.03438 12.2889 3.57266C12.2889 4.11093 11.8521 4.54766 11.3139 4.54766H6.1748C4.56251 4.54766 3.2498 5.86036 3.2498 7.47266V14.6227C3.2498 16.235 4.56251 17.5477 6.1748 17.5477H8.1248C8.66308 17.5477 9.0998 17.9844 9.0998 18.5227V21.4299L12.8487 17.8206C13.0303 17.6454 13.2728 17.5477 13.5254 17.5477H19.8248C21.4371 17.5477 22.7498 16.235 22.7498 14.6227V12.9697C22.7498 12.4315 23.1865 11.9947 23.7248 11.9947C24.2631 11.9947 24.6998 12.4315 24.6998 12.9697V14.6227C24.6998 17.3103 22.5124 19.4977 19.8248 19.4977H13.9189L8.80147 24.4247C8.61611 24.6037 8.37236 24.6977 8.1248 24.6977Z" fill="#292929"/><path d="M17.2617 11.8078C17.0167 11.8078 16.7704 11.7443 16.5482 11.6161C16.0074 11.3051 15.7332 10.6868 15.8639 10.0774L16.4619 7.31493L14.5639 5.22147C14.145 4.75936 14.0726 4.08778 14.3837 3.54823C14.696 3.00868 15.3206 2.73446 15.9223 2.86395L18.6848 3.4619L20.7783 1.56395C21.2404 1.14627 21.9158 1.07517 22.4515 1.38368C22.9924 1.69472 23.2666 2.31297 23.1358 2.92234L22.5379 5.68484L24.4358 7.7783C24.8548 8.24041 24.9271 8.91199 24.6161 9.45154C24.3038 9.99237 23.6843 10.2691 23.0774 10.1358L20.3149 9.53788L18.2215 11.4358C17.9511 11.6808 17.6083 11.8078 17.2617 11.8078ZM17.0979 5.11355L18.0856 6.2028C18.3929 6.53796 18.5211 7.01022 18.4246 7.46218L18.1136 8.90184L19.2028 7.91414C19.5392 7.60691 20.0166 7.47996 20.4622 7.57517L21.9018 7.88621L20.9141 6.79696C20.6069 6.4618 20.4787 5.98954 20.5752 5.53758L20.8862 4.09793L19.797 5.08564C19.4618 5.39413 18.987 5.52362 18.5376 5.4246L17.0979 5.11355Z" fill="#292929"/><path d="M10.3125 14.9542C10.1449 14.9542 9.97734 14.911 9.82499 14.8234C9.45809 14.6114 9.2702 14.1874 9.35907 13.7735L9.59012 12.7071L8.8576 11.8997C8.57322 11.5861 8.5237 11.124 8.73572 10.7571C8.94774 10.3902 9.37429 10.2099 9.78563 10.2912L10.852 10.5222L11.6594 9.78972C11.9743 9.50535 12.4339 9.45583 12.802 9.66785C13.1689 9.87987 13.3568 10.3039 13.2679 10.7178L13.0369 11.7842L13.7694 12.5916C14.0538 12.9051 14.1033 13.3673 13.8913 13.7342C13.6793 14.1011 13.2515 14.2851 12.8414 14.2001L11.775 13.969L10.9676 14.7016C10.7835 14.8679 10.5486 14.9542 10.3125 14.9542Z" fill="#292929"/></svg>`;
   ELEMENTS.CHAT_BUTTON = chatButton;
@@ -169,7 +167,6 @@ export const createClearDialog = () => {
 
   const card = createTag("section", {
     class: "chat-window-dialog-card",
-    "daa-lh": "AI Assistant - Clear dialog",
   });
 
   const heading = createTag("h2", { class: "chat-window-dialog-heading" });
@@ -186,7 +183,7 @@ export const createClearDialog = () => {
   const cancelButton = createTag("button", {
     class: "chat-window-dialog-cancel",
     type: "button",
-    "daa-ll": "Cancel",
+    "daa-ll": "Devsite AI Assistant:Clear dialog:Cancel",
   });
   cancelButton.textContent = "Cancel";
   cancelButton.addEventListener("click", () => dialog.remove());
@@ -194,7 +191,7 @@ export const createClearDialog = () => {
   const clearButton = createTag("button", {
     class: "chat-window-dialog-clear",
     type: "button",
-    "daa-ll": "Clear",
+    "daa-ll": "Devsite AI Assistant:Clear dialog:Clear",
   });
   clearButton.textContent = "Clear";
   clearButton.addEventListener("click", () => {

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-ui.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-ui.js
@@ -39,6 +39,10 @@ export const createChatWindowHeader = () => {
     id: CHAT_WINDOW_LABEL_ID,
   });
   label.textContent = "Adobe Developer AI assistant";
+
+  const betaBadge = createTag("div", { class: "chat-window-badge" });
+  betaBadge.textContent = "Beta";
+
   const clearButton = createTag("button", {
     class: "chat-window-clear",
     type: "button",
@@ -66,6 +70,8 @@ export const createChatWindowHeader = () => {
   closeButton.appendChild(closeButtonIcon);
 
   chatWindowHeader.appendChild(label);
+  chatWindowHeader.append(betaBadge);
+  chatWindowHeader.appendChild(createTag("div", { style: "flex: 1;" }));
   chatWindowHeader.appendChild(clearButton);
   chatWindowHeader.appendChild(closeButton);
   ELEMENTS.CHAT_WINDOW_CLEAR_BUTTON = clearButton;

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-ui.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-ui.js
@@ -46,7 +46,7 @@ export const createChatWindowHeader = () => {
     class: "chat-window-clear",
     type: "button",
     "aria-label": CHAT_BUTTON_LABEL_CLEAR,
-    "daa-ll": "Devsite AI Assistant:Clear dialog:Open",
+    "daa-ll": "DevsiteAI Assistant:Clear dialog:Open",
   });
   const clearButtonIcon = createTag("img", {
     src: "/hlx_statics/icons/delete.svg",
@@ -59,7 +59,7 @@ export const createChatWindowHeader = () => {
     class: "chat-window-close",
     type: "button",
     "aria-label": CHAT_BUTTON_LABEL_CLOSE,
-    "daa-ll": "Devsite AI Assistant:Close",
+    "daa-ll": "DevsiteAI Assistant:Close",
   });
   const closeButtonIcon = createTag("img", {
     src: "/hlx_statics/icons/dismiss.svg",
@@ -93,14 +93,14 @@ export const createInputSection = () => {
     })
   );
   const disclaimerText = createTag("div", { class: "chat-disclaimer-text" });
-  disclaimerText.innerHTML = `By using AI Assistant, you agree to the <a href="https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html" target="_blank" rel="noopener noreferrer" daa-ll="Devsite AI Assistant:Disclaimer:Link:Generative AI User Guidelines">Generative AI User Guidelines</a>.`;
+  disclaimerText.innerHTML = `By using AI Assistant, you agree to the <a href="https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html" target="_blank" rel="noopener noreferrer" daa-ll="DevsiteAI Assistant:Disclaimer:Link:Generative AI User Guidelines">Generative AI User Guidelines</a>.`;
 
   const sendButton = /** @type {HTMLButtonElement} */ (
     createTag("button", {
       class: "chat-send-button",
       type: "button",
       "aria-label": "Send message",
-      "daa-ll": "Devsite AI Assistant:Send message",
+      "daa-ll": "DevsiteAI Assistant:Send message",
     })
   );
   const sendButtonIcon = createTag("img", {
@@ -155,7 +155,7 @@ export const createChatButton = () => {
     "aria-expanded": "false",
     "aria-haspopup": "dialog",
     "aria-label": CHAT_BUTTON_LABEL_OPEN,
-    "daa-ll": "Devsite AI Assistant:Open",
+    "daa-ll": "DevsiteAI Assistant:Open",
   });
   chatButton.innerHTML = `<svg width="26" height="26" viewBox="0 0 26 26" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeXL"><path d="M8.1248 24.6977C7.99531 24.6977 7.86582 24.6723 7.74267 24.6202C7.38339 24.4666 7.1498 24.1137 7.1498 23.7227V19.4977H6.1748C3.48721 19.4977 1.2998 17.3103 1.2998 14.6227V7.47266C1.2998 4.78506 3.48721 2.59766 6.1748 2.59766H11.3139C11.8521 2.59766 12.2889 3.03438 12.2889 3.57266C12.2889 4.11093 11.8521 4.54766 11.3139 4.54766H6.1748C4.56251 4.54766 3.2498 5.86036 3.2498 7.47266V14.6227C3.2498 16.235 4.56251 17.5477 6.1748 17.5477H8.1248C8.66308 17.5477 9.0998 17.9844 9.0998 18.5227V21.4299L12.8487 17.8206C13.0303 17.6454 13.2728 17.5477 13.5254 17.5477H19.8248C21.4371 17.5477 22.7498 16.235 22.7498 14.6227V12.9697C22.7498 12.4315 23.1865 11.9947 23.7248 11.9947C24.2631 11.9947 24.6998 12.4315 24.6998 12.9697V14.6227C24.6998 17.3103 22.5124 19.4977 19.8248 19.4977H13.9189L8.80147 24.4247C8.61611 24.6037 8.37236 24.6977 8.1248 24.6977Z" fill="#292929"/><path d="M17.2617 11.8078C17.0167 11.8078 16.7704 11.7443 16.5482 11.6161C16.0074 11.3051 15.7332 10.6868 15.8639 10.0774L16.4619 7.31493L14.5639 5.22147C14.145 4.75936 14.0726 4.08778 14.3837 3.54823C14.696 3.00868 15.3206 2.73446 15.9223 2.86395L18.6848 3.4619L20.7783 1.56395C21.2404 1.14627 21.9158 1.07517 22.4515 1.38368C22.9924 1.69472 23.2666 2.31297 23.1358 2.92234L22.5379 5.68484L24.4358 7.7783C24.8548 8.24041 24.9271 8.91199 24.6161 9.45154C24.3038 9.99237 23.6843 10.2691 23.0774 10.1358L20.3149 9.53788L18.2215 11.4358C17.9511 11.6808 17.6083 11.8078 17.2617 11.8078ZM17.0979 5.11355L18.0856 6.2028C18.3929 6.53796 18.5211 7.01022 18.4246 7.46218L18.1136 8.90184L19.2028 7.91414C19.5392 7.60691 20.0166 7.47996 20.4622 7.57517L21.9018 7.88621L20.9141 6.79696C20.6069 6.4618 20.4787 5.98954 20.5752 5.53758L20.8862 4.09793L19.797 5.08564C19.4618 5.39413 18.987 5.52362 18.5376 5.4246L17.0979 5.11355Z" fill="#292929"/><path d="M10.3125 14.9542C10.1449 14.9542 9.97734 14.911 9.82499 14.8234C9.45809 14.6114 9.2702 14.1874 9.35907 13.7735L9.59012 12.7071L8.8576 11.8997C8.57322 11.5861 8.5237 11.124 8.73572 10.7571C8.94774 10.3902 9.37429 10.2099 9.78563 10.2912L10.852 10.5222L11.6594 9.78972C11.9743 9.50535 12.4339 9.45583 12.802 9.66785C13.1689 9.87987 13.3568 10.3039 13.2679 10.7178L13.0369 11.7842L13.7694 12.5916C14.0538 12.9051 14.1033 13.3673 13.8913 13.7342C13.6793 14.1011 13.2515 14.2851 12.8414 14.2001L11.775 13.969L10.9676 14.7016C10.7835 14.8679 10.5486 14.9542 10.3125 14.9542Z" fill="#292929"/></svg>`;
   ELEMENTS.CHAT_BUTTON = chatButton;
@@ -183,7 +183,7 @@ export const createClearDialog = () => {
   const cancelButton = createTag("button", {
     class: "chat-window-dialog-cancel",
     type: "button",
-    "daa-ll": "Devsite AI Assistant:Clear dialog:Cancel",
+    "daa-ll": "DevsiteAI Assistant:Clear dialog:Cancel",
   });
   cancelButton.textContent = "Cancel";
   cancelButton.addEventListener("click", () => dialog.remove());
@@ -191,7 +191,7 @@ export const createClearDialog = () => {
   const clearButton = createTag("button", {
     class: "chat-window-dialog-clear",
     type: "button",
-    "daa-ll": "Devsite AI Assistant:Clear dialog:Clear",
+    "daa-ll": "DevsiteAI Assistant:Clear dialog:Clear",
   });
   clearButton.textContent = "Clear";
   clearButton.addEventListener("click", () => {

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-ui.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-ui.js
@@ -29,7 +29,10 @@ export const createAiAvatar = () => {
  * Creates the chat window header
  */
 export const createChatWindowHeader = () => {
-  const chatWindowHeader = createTag("header", { class: "chat-window-header" });
+  const chatWindowHeader = createTag("header", {
+    class: "chat-window-header",
+    "daa-lh": "AI Assistant - Window header",
+  });
   chatWindowHeader.appendChild(createAiAvatar());
   const label = createTag("h2", {
     class: "chat-window-label",
@@ -40,6 +43,7 @@ export const createChatWindowHeader = () => {
     class: "chat-window-clear",
     type: "button",
     "aria-label": CHAT_BUTTON_LABEL_CLEAR,
+    "daa-ll": CHAT_BUTTON_LABEL_CLEAR,
   });
   const clearButtonIcon = createTag("img", {
     src: "/hlx_statics/icons/delete.svg",
@@ -52,6 +56,7 @@ export const createChatWindowHeader = () => {
     class: "chat-window-close",
     type: "button",
     "aria-label": CHAT_BUTTON_LABEL_CLOSE,
+    "daa-ll": CHAT_BUTTON_LABEL_CLOSE,
   });
   const closeButtonIcon = createTag("img", {
     src: "/hlx_statics/icons/dismiss.svg",
@@ -72,7 +77,10 @@ export const createChatWindowHeader = () => {
  * Creates the input section
  */
 export const createInputSection = () => {
-  const inputSection = createTag("div", { class: "chat-window-input-section" });
+  const inputSection = createTag("div", {
+    class: "chat-window-input-section",
+    "daa-lh": "AI Assistant - Input section",
+  });
   const textarea = /** @type {HTMLTextAreaElement} */ (
     createTag("textarea", {
       placeholder: "Type your message...",
@@ -81,13 +89,14 @@ export const createInputSection = () => {
     })
   );
   const disclaimerText = createTag("div", { class: "chat-disclaimer-text" });
-  disclaimerText.innerHTML = `By using AI Assistant, you agree to the <a href="https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html" target="_blank" rel="noopener noreferrer">Generative AI User Guidelines</a>.`;
+  disclaimerText.innerHTML = `By using AI Assistant, you agree to the <a href="https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html" target="_blank" rel="noopener noreferrer" daa-ll="Generative AI User Guidelines">Generative AI User Guidelines</a>.`;
 
   const sendButton = /** @type {HTMLButtonElement} */ (
     createTag("button", {
       class: "chat-send-button",
       type: "button",
       "aria-label": "Send message",
+      "daa-ll": "Send message",
     })
   );
   const sendButtonIcon = createTag("img", {
@@ -142,6 +151,7 @@ export const createChatButton = () => {
     "aria-expanded": "false",
     "aria-haspopup": "dialog",
     "aria-label": CHAT_BUTTON_LABEL_OPEN,
+    "daa-ll": CHAT_BUTTON_LABEL_OPEN,
   });
   chatButton.innerHTML = `<svg width="26" height="26" viewBox="0 0 26 26" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeXL"><path d="M8.1248 24.6977C7.99531 24.6977 7.86582 24.6723 7.74267 24.6202C7.38339 24.4666 7.1498 24.1137 7.1498 23.7227V19.4977H6.1748C3.48721 19.4977 1.2998 17.3103 1.2998 14.6227V7.47266C1.2998 4.78506 3.48721 2.59766 6.1748 2.59766H11.3139C11.8521 2.59766 12.2889 3.03438 12.2889 3.57266C12.2889 4.11093 11.8521 4.54766 11.3139 4.54766H6.1748C4.56251 4.54766 3.2498 5.86036 3.2498 7.47266V14.6227C3.2498 16.235 4.56251 17.5477 6.1748 17.5477H8.1248C8.66308 17.5477 9.0998 17.9844 9.0998 18.5227V21.4299L12.8487 17.8206C13.0303 17.6454 13.2728 17.5477 13.5254 17.5477H19.8248C21.4371 17.5477 22.7498 16.235 22.7498 14.6227V12.9697C22.7498 12.4315 23.1865 11.9947 23.7248 11.9947C24.2631 11.9947 24.6998 12.4315 24.6998 12.9697V14.6227C24.6998 17.3103 22.5124 19.4977 19.8248 19.4977H13.9189L8.80147 24.4247C8.61611 24.6037 8.37236 24.6977 8.1248 24.6977Z" fill="#292929"/><path d="M17.2617 11.8078C17.0167 11.8078 16.7704 11.7443 16.5482 11.6161C16.0074 11.3051 15.7332 10.6868 15.8639 10.0774L16.4619 7.31493L14.5639 5.22147C14.145 4.75936 14.0726 4.08778 14.3837 3.54823C14.696 3.00868 15.3206 2.73446 15.9223 2.86395L18.6848 3.4619L20.7783 1.56395C21.2404 1.14627 21.9158 1.07517 22.4515 1.38368C22.9924 1.69472 23.2666 2.31297 23.1358 2.92234L22.5379 5.68484L24.4358 7.7783C24.8548 8.24041 24.9271 8.91199 24.6161 9.45154C24.3038 9.99237 23.6843 10.2691 23.0774 10.1358L20.3149 9.53788L18.2215 11.4358C17.9511 11.6808 17.6083 11.8078 17.2617 11.8078ZM17.0979 5.11355L18.0856 6.2028C18.3929 6.53796 18.5211 7.01022 18.4246 7.46218L18.1136 8.90184L19.2028 7.91414C19.5392 7.60691 20.0166 7.47996 20.4622 7.57517L21.9018 7.88621L20.9141 6.79696C20.6069 6.4618 20.4787 5.98954 20.5752 5.53758L20.8862 4.09793L19.797 5.08564C19.4618 5.39413 18.987 5.52362 18.5376 5.4246L17.0979 5.11355Z" fill="#292929"/><path d="M10.3125 14.9542C10.1449 14.9542 9.97734 14.911 9.82499 14.8234C9.45809 14.6114 9.2702 14.1874 9.35907 13.7735L9.59012 12.7071L8.8576 11.8997C8.57322 11.5861 8.5237 11.124 8.73572 10.7571C8.94774 10.3902 9.37429 10.2099 9.78563 10.2912L10.852 10.5222L11.6594 9.78972C11.9743 9.50535 12.4339 9.45583 12.802 9.66785C13.1689 9.87987 13.3568 10.3039 13.2679 10.7178L13.0369 11.7842L13.7694 12.5916C14.0538 12.9051 14.1033 13.3673 13.8913 13.7342C13.6793 14.1011 13.2515 14.2851 12.8414 14.2001L11.775 13.969L10.9676 14.7016C10.7835 14.8679 10.5486 14.9542 10.3125 14.9542Z" fill="#292929"/></svg>`;
   ELEMENTS.CHAT_BUTTON = chatButton;
@@ -151,7 +161,10 @@ export const createChatButton = () => {
 export const createClearDialog = () => {
   const dialog = createTag("div", { class: "chat-window-dialog" });
 
-  const card = createTag("section", { class: "chat-window-dialog-card" });
+  const card = createTag("section", {
+    class: "chat-window-dialog-card",
+    "daa-lh": "AI Assistant - Clear dialog",
+  });
 
   const heading = createTag("h2", { class: "chat-window-dialog-heading" });
   heading.textContent = "Clear conversation";
@@ -167,6 +180,7 @@ export const createClearDialog = () => {
   const cancelButton = createTag("button", {
     class: "chat-window-dialog-cancel",
     type: "button",
+    "daa-ll": "Cancel",
   });
   cancelButton.textContent = "Cancel";
   cancelButton.addEventListener("click", () => dialog.remove());
@@ -174,6 +188,7 @@ export const createClearDialog = () => {
   const clearButton = createTag("button", {
     class: "chat-window-dialog-clear",
     type: "button",
+    "daa-ll": "Clear",
   });
   clearButton.textContent = "Clear";
   clearButton.addEventListener("click", () => {

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_constants.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_constants.js
@@ -1,8 +1,4 @@
 // @ts-check
-/** TODO: This should be different based on the environment */
-export const AI_API_BASE_URL =
-  "https://devsite-rag.stg.app-builder.corp.adp.adobe.io";
-export const AI_API_KEY = "ai-assistant-devsite-rag-demo-01";
 export const CHAT_BUTTON_LABEL_OPEN = "Open AI Assistant";
 export const CHAT_BUTTON_LABEL_CLOSE = "Close AI Assistant";
 export const CHAT_BUTTON_LABEL_MINIMIZE = "Minimize AI Assistant";

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_suggested-questions.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_suggested-questions.js
@@ -57,7 +57,7 @@ export const updateSuggestedQuestions = (questions) => {
     const button = createTag("button", {
       type: "button",
       class: "chat-suggested-questions-button",
-      "daa-ll": `Devsite AI Assistant:Suggested questions:${label}`,
+      "daa-ll": `DevsiteAI Assistant:Suggested questions:${label}`,
     });
     const icon = createTag("img", {
       src: "/hlx_statics/icons/arrow-curved.svg",

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_suggested-questions.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_suggested-questions.js
@@ -57,6 +57,7 @@ export const updateSuggestedQuestions = (questions) => {
     const button = createTag("button", {
       type: "button",
       class: "chat-suggested-questions-button",
+      "daa-ll": label,
     });
     const icon = createTag("img", {
       src: "/hlx_statics/icons/arrow-curved.svg",
@@ -97,7 +98,10 @@ export const createSuggestedQuestionsSection = () => {
   const wrapper = createTag("div", { class: "chat-suggested-questions" });
   const title = createTag("p", { class: "chat-suggested-questions-title" });
   title.textContent = "or choose from the following:";
-  const list = createTag("div", { class: "chat-suggested-questions-list" });
+  const list = createTag("div", {
+    class: "chat-suggested-questions-list",
+    "daa-lh": "AI Assistant - Suggested questions",
+  });
 
   wrapper.appendChild(title);
   wrapper.appendChild(list);

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_suggested-questions.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_suggested-questions.js
@@ -112,14 +112,24 @@ export const createSuggestedQuestionsSection = () => {
   return wrapper;
 };
 
-export const showSuggestedQuestions = () => {
+/**
+ * Shows the suggested questions section with optional scroll behavior.
+ * @param {Object} [options={}] - Options object
+ * @param {boolean} [options.shouldScrollIntoView=true] - Whether to scroll the element into view
+ */
+export const showSuggestedQuestions = ({
+  shouldScrollIntoView = true,
+} = {}) => {
   const el = ELEMENTS.CHAT_SUGGESTED_QUESTIONS;
   if (el) {
     el.classList.remove("hidden");
     el.classList.remove("animate-fade-in");
     requestAnimationFrame(() => {
       el.classList.add("animate-fade-in");
-      el.scrollIntoView({ behavior: "smooth" });
+      if (shouldScrollIntoView && ELEMENTS.CHAT_WINDOW_CONTENT) {
+        ELEMENTS.CHAT_WINDOW_CONTENT.scrollTop =
+          ELEMENTS.CHAT_WINDOW_CONTENT.scrollHeight;
+      }
     });
   }
 };

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_suggested-questions.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_suggested-questions.js
@@ -57,7 +57,7 @@ export const updateSuggestedQuestions = (questions) => {
     const button = createTag("button", {
       type: "button",
       class: "chat-suggested-questions-button",
-      "daa-ll": label,
+      "daa-ll": `Devsite AI Assistant:Suggested questions:${label}`,
     });
     const icon = createTag("img", {
       src: "/hlx_statics/icons/arrow-curved.svg",
@@ -100,7 +100,6 @@ export const createSuggestedQuestionsSection = () => {
   title.textContent = "or choose from the following:";
   const list = createTag("div", {
     class: "chat-suggested-questions-list",
-    "daa-lh": "AI Assistant - Suggested questions",
   });
 
   wrapper.appendChild(title);

--- a/hlx_statics/blocks/edition/edition.js
+++ b/hlx_statics/blocks/edition/edition.js
@@ -7,12 +7,13 @@ export default async function decorate(block) {
     const colorMap = {
         'red': 'rgb(187, 2, 2)',
         'green': 'rgb(0, 128, 0)',
-        'blue': 'rgb(4, 105, 227)'
+        'blue': 'rgb(4, 105, 227)',
+        'grey': 'rgb(71,71,71)'
     };
 
     // Get background color from data attribute or class name
     let requestedColor = block.getAttribute('data-backgroundcolor')?.toLowerCase();
-    
+
     // If no data attribute, check for class name like 'background-color-blue'
     if (!requestedColor) {
         const classList = Array.from(block.classList);
@@ -21,7 +22,7 @@ export default async function decorate(block) {
             requestedColor = colorClass.replace('background-color-', '');
         }
     }
-    
+
     const backgroundColor = colorMap[requestedColor] || colorMap['red'];
 
     block.querySelectorAll('.edition > div > div').forEach((div) => {

--- a/hlx_statics/blocks/edition/edition.js
+++ b/hlx_statics/blocks/edition/edition.js
@@ -8,7 +8,7 @@ export default async function decorate(block) {
         'red': 'rgb(187, 2, 2)',
         'green': 'rgb(0, 128, 0)',
         'blue': 'rgb(4, 105, 227)',
-        'grey': 'rgb(71,71,71)'
+        'gray': 'rgb(71,71,71)'
     };
 
     // Get background color from data attribute or class name

--- a/hlx_statics/blocks/embed/embed.js
+++ b/hlx_statics/blocks/embed/embed.js
@@ -35,7 +35,7 @@ const getDefaultEmbed = (url, loop, controls, vidTitle, isShort, autoplay) => {
     params.push('mute=1');
   }
   const query = params.length ? `?${params.join('&')}` : '';
-  const titleAttr = vidTitle ? `title="${vidTitle}"` : `title="Content from ${url.hostname}"`;
+  const titleAttr = `title="${vidTitle ? vidTitle : `Content from ${url.hostname}`}"`;
   const embedHTML = `<div style="left: 0; width: 55vw; height: 45vh; max-height: fit-content; position: relative; padding-bottom: 56.25%;">
     <iframe src="${url.href}${query}" 
     style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen
@@ -49,7 +49,7 @@ const embedIG = (url, loop, controls, vidTitle, isShort, autoplay) => {
   const link = url.href.split('?')[0] + 'embed/captioned';
   const embedHTML = `<div class="igReel">
   <iframe src="${link}?autoplay=${autoplay}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen
-    scrolling="no" allow="encrypted-media" ${vidTitle ? `title=${vidTitle}` : `title="Content from" ${url.hostname}`} loading="lazy">
+    scrolling="no" allow="encrypted-media" title="${vidTitle ? vidTitle : `Content from ${url.hostname}`}" loading="lazy">
   </iframe>
 </div>`;
 loadScript("https://www.instagram.com/embed.js");
@@ -97,7 +97,7 @@ const embedYTPlaylist = (url, loop, controls, vidTitle, isShort, autoplay) => {
   const embedHTML = `<div style="left: 0; width: 100%; height: 100%; position: relative; padding-bottom: 56.25%;">
   <iframe
   style="opacity: 1" src="${src}" data-src="${src}" allow="encrypted-media; accelerometer; gyroscope; picture-in-picture" allowfullscreen
-  ${vidTitle ? `title=${vidTitle}` : `title="Content from YouTube"`} scrolling="no">
+  title="${vidTitle ? vidTitle : 'Content from YouTube'}" scrolling="no">
    </iframe>
   </div>`;
   return embedHTML;
@@ -106,7 +106,7 @@ const embedTikTok = (url, loop, controls, vidTitle, isShort, autoplay) => {
   const [, vidID] = url.pathname.split('video/')
   return `<div style="left: 0; width: 325px; height: 736px;  position: relative;">
     <iframe src="https://www.tiktok.com/embed/${vidID}?autoplay=${autoplay}" style="border: 0; top: 0; left: 0; width: 100%; height: 736px; position: absolute;" allowfullscreen
-      scrolling="no" allow="accelerometer encrypted-media" title=${vidTitle ? vidTitle : `Content from ${url.hostname}`} loading="lazy">
+      scrolling="no" allow="accelerometer encrypted-media" title="${vidTitle ? vidTitle : `Content from ${url.hostname}`}" loading="lazy">
     </iframe>
   </div>`;
 }
@@ -170,7 +170,7 @@ const embedVimeo = (url, loop, controls, vidTitle, isShort, autoplay) => {
       style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" 
       frameborder="0" allow="fullscreen; encrypted-media; accelerometer; gyroscope; picture-in-picture"  
       allowfullscreen
-      ${vidTitle ? `title=${vidTitle}` : `title="Content from" ${url.hostname}`} loading="lazy"></iframe>
+      title="${vidTitle ? vidTitle : `Content from ${url.hostname}`}" loading="lazy"></iframe>
     </div>`;
   return embedHTML;
 };

--- a/hlx_statics/blocks/header/header.js
+++ b/hlx_statics/blocks/header/header.js
@@ -304,7 +304,8 @@ async function initSearch() {
           // Process each hit
           //
           results.set(instantsearch.highlight({ hit, attribute: "title" }), {
-            url: hit.url,
+            // Add anchor link if it exists to URL
+            url: hit.fragment ? `${hit.url}${hit.fragment}` : hit.url,
             product: hit.product,
             content: instantsearch.snippet({ hit, attribute: 'content' }),
           });
@@ -497,11 +498,16 @@ async function initSearch() {
     const allProductsCheckbox = document.getElementById('checkbox-all-products');
     const productsToShow = allProductsCheckbox.checked ? allProducts : selectedProducts;
 
-    const productsWith = [], productsWithout = [];
-    productsToShow.forEach((p) =>
-      productsWithResults.has(p) ? productsWith.push(p) : productsWithout.push(p)
-    );
-    const sorted = [...productsWith, ...productsWithout];
+    let sorted;
+    if (allProductsCheckbox.checked) {
+      const productsWith = [], productsWithout = [];
+      productsToShow.forEach((p) =>
+        productsWithResults.has(p) ? productsWith.push(p) : productsWithout.push(p)
+      );
+      sorted = [...productsWith, ...productsWithout];
+    } else {
+      sorted = productsToShow; // preserve selected order regardless of results
+    }
 
     // render each group
     sorted.forEach((product) => {
@@ -556,11 +562,16 @@ async function initSearch() {
       ? allProducts
       : selectedProducts;
 
-    const withHits = [], withoutHits = [];
-    productsToShow.forEach((p) =>
-      productsWithResults.has(p) ? withHits.push(p) : withoutHits.push(p)
-    );
-    const sorted = [...withHits, ...withoutHits];
+    let sorted;
+    if (allProductsCheckbox.checked) {
+      const withHits = [], withoutHits = [];
+      productsToShow.forEach((p) =>
+        productsWithResults.has(p) ? withHits.push(p) : withoutHits.push(p)
+      );
+      sorted = [...withHits, ...withoutHits];
+    } else {
+      sorted = productsToShow; // preserve selected order regardless of results
+    }
 
     // render each section
     sorted.forEach((product) => {

--- a/hlx_statics/blocks/header/header.js
+++ b/hlx_statics/blocks/header/header.js
@@ -70,11 +70,25 @@ async function initSearch() {
 
   const { connectAutocomplete } = instantsearch.connectors;
 
-  const searchClient = window.algoliasearch.algoliasearch(ALGOLIA_CONFIG.APP_KEY, ALGOLIA_CONFIG.API_KEY);
+  const algoliaClient = window.algoliasearch.algoliasearch(ALGOLIA_CONFIG.APP_KEY, ALGOLIA_CONFIG.API_KEY);
   const SUGGESTION_MAX_RESULTS = 50;
   const SEARCH_MAX_RESULTS = 100;
-  const SEARCH_MIN_QUERY_LENGTH = 3;
-  const isSearchableQuery = (q) => q.trim().length >= SEARCH_MIN_QUERY_LENGTH;
+  const isSearchableQuery = (q) => q.trim() !== '';
+  const searchClient = { // "To prevent the initial empty query, you must wrap a custom search client around..." source: https://www.algolia.com/doc/guides/building-search-ui/going-further/conditional-requests/js
+    ...algoliaClient,
+    search(requests) {
+      if (requests.every(({ params }) => !isSearchableQuery(params.query ?? ''))) {
+        return Promise.resolve({
+          results: requests.map(() => ({
+            hits: [], nbHits: 0, nbPages: 0, page: 0,
+            processingTimeMS: 0, hitsPerPage: 0,
+            exhaustiveNbHits: false, query: '', params: '',
+          })),
+        });
+      }
+      return algoliaClient.search(requests);
+    },
+  };
 
   const indices = window.adp_search.indices
   const indexToProduct = window.adp_search.index_to_product;
@@ -230,8 +244,12 @@ async function initSearch() {
         if (event.key === 'Enter') {
           searchCleared = false; // Reset cleared flag when user presses Enter
           const trimmed = searchInput.value.trim();
-          if (trimmed !== '' && !isSearchableQuery(trimmed)) {
-            event.preventDefault();
+          if (trimmed === '') { // If users presses enter with an empty query while in a full search, clear results and show suggestions again
+            searchResults.classList.remove('has-results');
+            searchResults.style.visibility = 'hidden';
+            outerSearchSuggestions.style.display = 'flex';
+            suggestionsFlag = true;
+            searchExecuted = false;
             return;
           }
           helper.setQuery(searchInput.value).search();
@@ -405,24 +423,7 @@ async function initSearch() {
     });
   }
 
-  // Function that is called after each search render to hide/show product checkboxes
-  function updateCheckboxVisibility(productsWithResults) {
-    const allSelected = selectedProducts.length === allProducts.length;
-
-    // loop over each product‐wrapper
-    document.querySelectorAll('.search-checkbox-div[data-product]').forEach((div) => {
-      const product = div.dataset.product;
-      if (allSelected) {
-        // only show those with results
-        div.style.display = productsWithResults.has(product) ? '' : 'none';
-      } else {
-        // specific‐product mode: show all product checkboxes
-        div.style.display = '';
-      }
-    });
-  }
-
-  // Function that attaches event listeners to each checkbox
+// Function that attaches event listeners to each checkbox
   function attachCheckboxEventListeners() {
     const allProductsCheckbox = document.getElementById('checkbox-all-products');
     const productCheckboxes = document.querySelectorAll('.filters input[type="checkbox"]:not(#checkbox-all-products)');
@@ -447,6 +448,9 @@ async function initSearch() {
         selectedProducts = Array.from(productCheckboxes)
           .filter((cb) => cb.checked) // Get checked product checkboxes
           .map((cb) => cb.value);
+        if (checkbox.checked) { // Add new selected product to the beginning of the list to prioritize it in results
+          selectedProducts = [checkbox.value, ...selectedProducts.filter((p) => p !== checkbox.value)];
+        }
 
         if (selectedProducts.length === 0) {
           // If no products selected, revert to "All Products"
@@ -475,9 +479,6 @@ async function initSearch() {
 
     // figure out which products have at least one hit
     const productsWithResults = new Set(productGroupedResults.keys());
-
-    // hide/show checkboxes based on current results + mode
-    updateCheckboxVisibility(productsWithResults);
 
     // determine display order
     const allProductsCheckbox = document.getElementById('checkbox-all-products');
@@ -536,7 +537,6 @@ async function initSearch() {
 
     // compute who has any suggestions
     const productsWithResults = new Set(productGroupedResults.keys());
-    updateCheckboxVisibility(productsWithResults);
 
     const allProductsCheckbox = document.getElementById('checkbox-all-products');
     const productsToShow = allProductsCheckbox.checked

--- a/hlx_statics/blocks/header/header.js
+++ b/hlx_statics/blocks/header/header.js
@@ -139,9 +139,17 @@ async function initSearch() {
   let results = new Map();
 
   search.start();
+  
+  let currentDynamicWidgets = []; // Widgets that change on each call
+  let staticWidgetsAdded = false; // One-time widgets
 
   // Function to initialize or update the search
   function updateSearch() {
+    // Remove widgets from the previous call before adding new ones
+    if (currentDynamicWidgets.length) {
+      search.removeWidgets(currentDynamicWidgets);
+      currentDynamicWidgets = [];
+    }
     // Get indices corresponding to selected products
     const selectedIndices = indices.filter((indexName) => {
       const product = indexToProduct[indexName];
@@ -157,14 +165,14 @@ async function initSearch() {
      // Calculate hits dynamically based number of selected indices
     const hits = Math.min(15, Math.max(4, Math.floor(SUGGESTION_MAX_RESULTS / selectedIndices.length)));
 
-     // Add common widgets like hits per index and how long results are (content)
-     search.addWidgets([
-       instantsearch.widgets.configure({
-         hitsPerPage: hits,
-         attributesToHighlight: ['title', 'content'],
-         attributesToSnippet: ['content:50'],
-       }),
-     ]);
+     // Add common widgets like hits per index and how long results are (content) - and save reference so it can be removed on the next call
+     const configureWidget = instantsearch.widgets.configure({
+       hitsPerPage: hits,
+       attributesToHighlight: ['title', 'content'],
+       attributesToSnippet: ['content:50'],
+     });
+     currentDynamicWidgets.push(configureWidget);
+     search.addWidgets([configureWidget]);
 
     // Custom InstantSearch search box to deal with suggestions and full results which depends on user input
     function customSearchBox() { return { init({ helper }) {
@@ -316,21 +324,25 @@ async function initSearch() {
     }
 
     const customMergedHits = connectAutocomplete(mergedHits);
-    search.addWidgets([
-      customSearchBox(),
-      customMergedHits({
-        container: document.querySelector(searchBoxContainer)
-      }),
-    ]);
-
-    // Loop through rest of indices
-    selectedIndices.slice(1).forEach((indexName) => {
+    // Only add the search box and hits renderer once — fixes event listeners duplicates
+    if (!staticWidgetsAdded) {
       search.addWidgets([
-        instantsearch.widgets.index({
-          indexName: indexName,
+        customSearchBox(),
+        customMergedHits({
+          container: document.querySelector(searchBoxContainer)
         }),
       ]);
-    });
+      staticWidgetsAdded = true;
+    }
+
+    // Instead of looping through other indices - add a child index widget for rest of indices (the main index is always searched, so it doesn't need a widget)
+    const indexWidgets = selectedIndices
+      .filter((indexName) => indexName !== initialIndex)
+      .map((indexName) => instantsearch.widgets.index({ indexName }));
+    if (indexWidgets.length) {
+      currentDynamicWidgets.push(...indexWidgets);
+      search.addWidgets(indexWidgets);
+    }
 
     search.refresh();
   }

--- a/hlx_statics/blocks/header/header.js
+++ b/hlx_statics/blocks/header/header.js
@@ -253,7 +253,6 @@ async function initSearch() {
           searchCleared = false; // Reset cleared flag when user presses Enter
           const trimmed = searchInput.value.trim();
           if (trimmed === '') { // If users presses enter with an empty query while in a full search, clear results and show suggestions again
-            console.log('TEST 1');
             searchResults.classList.remove('has-results');
             searchResults.style.visibility = 'hidden';
             outerSearchSuggestions.style.display = 'flex';

--- a/hlx_statics/blocks/header/header.js
+++ b/hlx_statics/blocks/header/header.js
@@ -253,6 +253,7 @@ async function initSearch() {
           searchCleared = false; // Reset cleared flag when user presses Enter
           const trimmed = searchInput.value.trim();
           if (trimmed === '') { // If users presses enter with an empty query while in a full search, clear results and show suggestions again
+            console.log('TEST 1');
             searchResults.classList.remove('has-results');
             searchResults.style.visibility = 'hidden';
             outerSearchSuggestions.style.display = 'flex';
@@ -1130,33 +1131,33 @@ export default async function decorate(block) {
 
     // check if documentation template then retrieve from config otherwise default back to google drive path
     let navPath;
-    if (IS_DEV_DOCS) {
-      const topNavHtml = await fetchTopNavHtml();
-      if (topNavHtml) {
-        navigationLinks.innerHTML += topNavHtml;
-      }
-    } else {
-      navPath = cfg.nav || getClosestFranklinSubfolder(window.location.origin,'nav');
-      let fragment = await loadFragment(navPath);
-      if (fragment == null) {
-        // load the default nav in franklin_assets folder nav
-        fragment = await loadFragment(getClosestFranklinSubfolder(window.location.origin, 'nav', true));
-      }
-      const ul = fragment.querySelector("ul");
-      ul.classList.add("menu");
-      ul.setAttribute("id", "navigation-links");
-      fragment.querySelectorAll("li").forEach((li, index) => {
-        if (index == 0) {
-          if (isTopLevelNav(window.location.pathname)) {
-            const homeLink = ul.querySelector('li:nth-child(1)');
-            homeLink.className = 'navigation-home';
-          } else {
-            li.classList.add("navigation-products");
-          }
-        }
-      });
-      navigationLinks = ul;
-    }
+    // if (IS_DEV_DOCS) {
+    //   const topNavHtml = await fetchTopNavHtml();
+    //   if (topNavHtml) {
+    //     navigationLinks.innerHTML += topNavHtml;
+    //   }
+    // } else {
+    //   navPath = cfg.nav || getClosestFranklinSubfolder(window.location.origin,'nav');
+    //   let fragment = await loadFragment(navPath);
+    //   if (fragment == null) {
+    //     // load the default nav in franklin_assets folder nav
+    //     fragment = await loadFragment(getClosestFranklinSubfolder(window.location.origin, 'nav', true));
+    //   }
+    //   const ul = fragment.querySelector("ul");
+    //   ul.classList.add("menu");
+    //   ul.setAttribute("id", "navigation-links");
+    //   fragment.querySelectorAll("li").forEach((li, index) => {
+    //     if (index == 0) {
+    //       if (isTopLevelNav(window.location.pathname)) {
+    //         const homeLink = ul.querySelector('li:nth-child(1)');
+    //         homeLink.className = 'navigation-home';
+    //       } else {
+    //         li.classList.add("navigation-products");
+    //       }
+    //     }
+    //   });
+    //   navigationLinks = ul;
+    // }
 
     navigationLinks.querySelectorAll('li > ul').forEach((dropDownList, index) => {
       let dropdownLinkDropdownHTML = '';

--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -36,6 +36,14 @@ main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)
   background-color: white;
 }
 
+main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) .cards-card-body > :is(h1, h2, h3, h4, h5, h6) {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+}
+
 main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) .cards-card-image {
   line-height: 0;
 }
@@ -71,6 +79,14 @@ main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)
 
 main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) .card-heading {
   color: rgb(0, 0, 0);
+}
+
+main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) .cards-card-body > p {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  line-clamp: 3;
+  -webkit-line-clamp: 3;
 }
 
 main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) p {

--- a/hlx_statics/blocks/onthispage/onthispage.js
+++ b/hlx_statics/blocks/onthispage/onthispage.js
@@ -16,7 +16,7 @@ export default async function decorate(block) {
     block.append(aside);
 
     const mainContainer = document.querySelector('main');
-    const headings = mainContainer.querySelectorAll('h2:not(.side-nav h2):not(footer h2), h3:not(.side-nav h3):not(footer h3)');
+    const headings = mainContainer.querySelectorAll('.heading2:not(.side-nav .heading2):not(footer .heading2) h2, .heading3:not(.side-nav .heading3):not(footer .heading3) h3');
 
     Object.assign(aside.style, {
         display: 'flex',

--- a/hlx_statics/blocks/superhero/superhero.css
+++ b/hlx_statics/blocks/superhero/superhero.css
@@ -1,3 +1,28 @@
+main div.superhero-wrapper div.superhero a:not(.spectrum-Button) {
+  color: inherit !important;
+  text-decoration: underline;
+}
+
+main div.superhero-wrapper div.superhero.text-color-white,
+main div.superhero-wrapper div.superhero.text-color-white :is(h1, h2, h3, h4, h5, h6, p) {
+  color: rgb(255, 255, 255) !important;
+}
+
+main div.superhero-wrapper div.superhero.text-color-black,
+main div.superhero-wrapper div.superhero.text-color-black :is(h1, h2, h3, h4, h5, h6, p) {
+  color: rgb(0, 0, 0) !important;
+}
+
+main div.superhero-wrapper div.superhero.text-color-gray,
+main div.superhero-wrapper div.superhero.text-color-gray :is(h1, h2, h3, h4, h5, h6, p) {
+  color: rgb(110, 110, 110) !important;
+}
+
+main div.superhero-wrapper div.superhero.text-color-navy,
+main div.superhero-wrapper div.superhero.text-color-navy :is(h1, h2, h3, h4, h5, h6, p) {
+  color: rgb(15, 55, 95) !important;
+}
+
 main div.superhero-wrapper div.superhero span.icon {
   display: inline-block;
 }
@@ -159,7 +184,6 @@ main div.superhero-wrapper div.superhero.half-width > div:last-child video {
 
 main div.superhero-wrapper div.superhero.half-width p.spectrum-Body--sizeL {
   margin-top: 0 !important;
-  color: rgb(80, 80, 80) !important;
 }
 
 main div.superhero-wrapper:has(div.superhero.half-width) {
@@ -206,20 +230,6 @@ main div.superhero-wrapper div.superhero.half-width h3 {
 
 main div.superhero-wrapper div.superhero.half-width h1 + p.last-of-type {
   margin-bottom: 0 !important;
-}
-
-main div.superhero-wrapper div.superhero.half-width a:not(.spectrum-Button) {
-  text-decoration: underline;
-}
-
-main div.superhero-wrapper div.superhero.half-width.text-color-white h1,
-main div.superhero-wrapper div.superhero.half-width.text-color-white a,
-main div.superhero-wrapper div.superhero.half-width.text-color-white p {
-  color: white !important;
-}
-
-main div.superhero-wrapper div.superhero.half-width.text-color-black {
-  color: black;
 }
 
 main div.superhero-wrapper div.superhero.half-width.over-gradient p.button-container:not(strong) a:not(.spectrum-Button--accent) {
@@ -294,22 +304,6 @@ main div.superhero-wrapper div.superhero.default .all-button-container > p {
 main div.superhero-wrapper div.superhero.default .all-button-container {
   display: inline-flex;
   gap: 16px;
-}
-
-main div.superhero-wrapper div.superhero.default.text-color-white {
-  color: rgb(255, 255, 255);
-}
-
-main div.superhero-wrapper div.superhero.default.text-color-black {
-  color: rgb(0, 0, 0);
-}
-
-main div.superhero-wrapper div.superhero.default.text-color-gray {
-  color: rgb(110, 110, 110);
-}
-
-main div.superhero-wrapper div.superhero.default.text-color-navy {
-  color: rgb(15, 55, 95);
 }
 
 @media screen and (max-width: 1280px) {

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -45,6 +45,10 @@ function hasAnyClass(block, classes) {
   return classes.some((c) => block.classList.contains(c));
 }
 
+function getTextColorModifier(block) {
+  return Object.values(TEXT_COLORS).find((color) => block.classList.contains(`text-color-${color}`));
+}
+
 function unwrapIcons(block) {
   block.querySelectorAll('span.icon').forEach((span) => {
     span.textContent = '';  
@@ -56,6 +60,7 @@ function unwrapIcons(block) {
 
 async function decorateDevBizCentered(block) {
   const defaultTextColor = TEXT_COLORS.white;
+  const textColor = getTextColorModifier(block);
 
   removeEmptyPTags(block);
   decorateButtons(block);
@@ -69,7 +74,7 @@ async function decorateDevBizCentered(block) {
   block.classList.add('spectrum--dark');
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     h.classList.add('spectrum-Heading', 'spectrum-Heading--sizeXXL');
-    h.style.color = defaultTextColor;
+    if (!textColor) h.style.color = defaultTextColor;
     h.parentElement.classList.add('superhero-content');
     h.parentElement.append(button_div);
   });
@@ -77,7 +82,7 @@ async function decorateDevBizCentered(block) {
   block.querySelectorAll('p').forEach((p) => {
     if (!p.classList.contains('icon-container')) {
       p.classList.add('spectrum-Body', 'spectrum-Body--sizeL');
-      p.style.color = defaultTextColor;
+      if (!textColor) p.style.color = defaultTextColor;
     }
     if (p.classList.contains('button-container')) {
       button_div.append(p);
@@ -189,9 +194,8 @@ async function decorateDevBizDefault(block) {
   div.append(...newChildren);
   block.replaceChildren(div);
 
-  const defaultTextColor = TEXT_COLORS.white;
-  let textColor = Object.values(TEXT_COLORS).find((color) => block.classList.contains(`text-color-${color}`)) ?? defaultTextColor;
-  block.classList.add(`text-color-${defaultTextColor}`);
+  const textColor = getTextColorModifier(block) ?? TEXT_COLORS.white;
+  block.classList.add(`text-color-${textColor}`);
 
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     h.style.color = textColor;
@@ -355,14 +359,6 @@ function applyDataAttributeStyles(block) {
     wrapper.style.background = background;
   } else {
     block.style.background = background;
-  }
-
-  const defaultTextColor = variant === VARIANTS.halfWidth ? TEXT_COLORS.black : TEXT_COLORS.white;
-  const textColor = block.getAttribute('data-textcolor') || defaultTextColor;
-  if (Object.keys(TEXT_COLORS).includes(textColor)) {
-    block.querySelectorAll('h1, h2, h3, h4, h5, h6, p').forEach((el) => {
-      el.style.color = textColor;
-    });
   }
 }
 

--- a/hlx_statics/blocks/superhero/superhero.js
+++ b/hlx_statics/blocks/superhero/superhero.js
@@ -136,7 +136,7 @@ async function decorateDevBizHalfWidth(block) {
     const muted = !isControl || wantAutoplay;
 
     const videoContainer = createTag('div', { class: 'superhero-video-container' });
-    const videoTag = `<video src=${videoURL?.href} alt=${videoURL?.textContent} ${isAutoplay ? 'autoplay' : ''} playsinline ${muted ? 'muted' : ''} ${isControl ? 'controls' : ''} ${isLoop ? 'loop' : ''}></video>`;
+    const videoTag = `<video src="${videoURL?.href}" alt="${videoURL?.textContent}" ${isAutoplay ? 'autoplay' : ''} playsinline ${muted ? 'muted' : ''} ${isControl ? 'controls' : ''} ${isLoop ? 'loop' : ''}></video>`;
     videoContainer.innerHTML = videoTag;
     block.lastElementChild.replaceWith(videoContainer);
   }

--- a/hlx_statics/blocks/tab/tab.css
+++ b/hlx_statics/blocks/tab/tab.css
@@ -123,6 +123,10 @@ main div.tab-wrapper .code-toolbar {
 
 main div.tab-wrapper .tab.vertical {
     flex-direction: row;
+    align-items: stretch;
+    width: 100%;
+    margin: 0;
+    gap: 0;
 }
 
 main div.tab-wrapper .tab.vertical .tabs-wrapper,
@@ -130,14 +134,55 @@ main div.tab-wrapper .tab.horizontal {
     flex-direction: column;
 }
 
-main div.tab-wrapper .tab.vertical>.tabs-wrapper {
+main div.tab-wrapper .tab.vertical > .tabs-wrapper {
     display: flex;
     flex-direction: column;
-    width: 350px;
+    width: 240px;
+    min-width: 180px;
+    flex-shrink: 0;
+    gap: 4px;
+    padding: 16px 12px;
+    margin-bottom: 0;
+    box-sizing: border-box;
+    border-right: 1px solid rgba(0, 0, 0, 0.1);
 }
 
-main div.tab-wrapper .tab.vertical>.content-wrapper {
-    width: 80%;
+main div.tab-wrapper .tab.vertical > .content-wrapper {
+    flex: 1;
+    min-width: 0;
+    padding: 16px 24px;
+    width: auto;
+}
+
+main div.tab-wrapper .tab.vertical .tab-button {
+    width: 100%;
+    height: auto;
+    min-height: 54px;
+    margin: 0;
+    padding: 10px 14px;
+    border-radius: 8px;
+    text-align: left;
+    white-space: normal;
+    line-height: 1.35;
+    font-size: 14px;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 12px;
+}
+
+main div.tab-wrapper .tab.vertical .tab-icon {
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+main div.tab-wrapper .tab.vertical .tab-icon img {
+    width: 36px;
+    height: 36px;
+    object-fit: contain;
 }
 
 main div.tab-wrapper .tab {
@@ -162,10 +207,13 @@ main div.tab-wrapper > div.background-color-navy .tab-button:not(.active) .tab-t
 }
 
 main div.tab-wrapper > div.background-color-navy .tab-button:hover .tab-title {
-    color: #000;
+    color: white;
 }
 
-main div.tab-wrapper > div:not(.background-color-navy) .tab-button , 
+main div.tab-wrapper > div:not(.background-color-navy) .tab-button {
+    background: #eee;
+}
+
 main div.tab-wrapper > div.background-color-navy .tab-button:hover,
 main div.tab-wrapper > div.background-color-navy .tab-button.active {
     background: #eee;
@@ -220,4 +268,77 @@ main div.tab-wrapper .sub-tabs-wrapper>pre[class*=language-].line-numbers {
 
 main div.tab-wrapper div.tab pre[class*=language-].no-line-numbers .line-highlight {
     transform: translateY(-1.6em);
+}
+
+
+main div.tab-wrapper:has(.tab.vertical.background-color-navy) {
+    background-color: rgb(15, 55, 95);
+    padding: 0;
+}
+
+main div.tab-wrapper .tab.vertical.background-color-navy > .tabs-wrapper {
+    background-color: rgb(15, 55, 95);
+    border-right-color: rgba(255, 255, 255, 0.15);
+    padding: 20px 12px;
+}
+
+main div.tab-wrapper .tab.vertical.background-color-navy .tab-title {
+    color: rgba(255, 255, 255, 0.9);
+}
+
+main div.tab-wrapper .tab.vertical.background-color-navy .tab-button {
+    background: transparent;
+    border: none;
+}
+
+main div.tab-wrapper .tab.vertical.background-color-navy .tab-button:hover {
+    background-color: rgba(255, 255, 255, 0.08);
+    color: white;
+}
+
+main div.tab-wrapper .tab.vertical.background-color-navy .tab-button.active {
+    background-color: rgba(255, 255, 255, 0.18);
+    color: white;
+}
+
+main div.tab-wrapper .tab.vertical.background-color-navy .tab-button.active .tab-title,
+main div.tab-wrapper .tab.vertical.background-color-navy .tab-button:hover .tab-title {
+    color: white;
+}
+
+main div.tab-wrapper .tab.vertical.background-color-navy > .content-wrapper {
+    background-color: #111a35;
+    padding: 20px 24px;
+}
+
+@media only screen and (max-width: 860px) {
+    main div.tab-wrapper .tab.vertical {
+        flex-direction: column;
+    }
+
+    main div.tab-wrapper .tab.vertical > .tabs-wrapper {
+        width: 100%;
+        min-width: unset;
+        flex-direction: row;
+        flex-wrap: wrap;
+        border-right: none;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+        padding: 8px;
+    }
+
+    main div.tab-wrapper .tab.vertical.background-color-navy > .tabs-wrapper {
+        border-bottom-color: rgba(255, 255, 255, 0.15);
+        border-right: none;
+    }
+
+    main div.tab-wrapper .tab.vertical .tab-button {
+        width: auto;
+        min-height: unset;
+        white-space: nowrap;
+    }
+
+    main div.tab-wrapper .tab.vertical > .content-wrapper {
+        padding: 12px 16px;
+        width: 100%;
+    }
 }

--- a/hlx_statics/blocks/tab/tab.js
+++ b/hlx_statics/blocks/tab/tab.js
@@ -86,7 +86,7 @@ const createSubTabs = (table) => {
 }
 
 export default async function decorate(block) {
-  block.querySelectorAll(':scope > div > div > code').forEach((code) => {
+  block.querySelectorAll(':scope > div > div > pre > code').forEach((code) => {
     const match = code.textContent.trim().match(/^(data-[^=]+)=(.*)$/);
     if (!match) return;
     const [, attr, value] = match;

--- a/hlx_statics/blocks/tab/tab.js
+++ b/hlx_statics/blocks/tab/tab.js
@@ -86,11 +86,22 @@ const createSubTabs = (table) => {
 }
 
 export default async function decorate(block) {
-  let orientation;
-  if (IS_DEV_DOCS) {
-    orientation = block.getAttribute('data-orientation') || 'horizontal';
+  block.querySelectorAll(':scope > div > div > code').forEach((code) => {
+    const match = code.textContent.trim().match(/^(data-[^=]+)=(.*)$/);
+    if (!match) return;
+    const [, attr, value] = match;
+    if (attr === 'data-orientation') {
+      block.setAttribute('data-orientation', value.trim());
+    } else if (attr === 'data-classname') {
+      value.trim().split(/\s+/).filter(Boolean).forEach((cls) => block.classList.add(cls));
+    }
+  });
+
+  const dataOrientation = block.getAttribute('data-orientation');
+  const orientation = dataOrientation || (block.classList.contains('vertical') ? 'vertical' : 'horizontal');
+  if (!block.classList.contains(orientation)) {
+    block.classList.add(orientation);
   }
-  block.classList.add(orientation);
   block.setAttribute('daa-lh', 'tab');
 
   const tabsWrapper = document.createElement('div');

--- a/hlx_statics/blocks/tab/tab.js
+++ b/hlx_statics/blocks/tab/tab.js
@@ -123,7 +123,7 @@ export default async function decorate(block) {
       const tabButton = document.createElement('button');
       tabButton.className = 'tab-button';
       tabButton.innerHTML = `
-        <div class="tab-icon">${tabImage}</div>
+        ${tabImage ? `<div class="tab-icon">${tabImage}</div>` : ''}
         <span class="tab-title">${tabTitle}</span>
       `;
       tabButton.setAttribute('data-tab', `tab${tabCount}`);

--- a/hlx_statics/components/code.js
+++ b/hlx_statics/components/code.js
@@ -106,7 +106,7 @@ function applyDataAttributesFromCodeClasses(pre, code) {
 
       parts.forEach((item) => {
         if (!item.includes('language-') && item.includes('=')) {
-          const match = item.match(/^-?([^=]+)="?([^"]*)"?$/);
+          const match = item.match(/^-?([^=]+)="([^"]*)"/);
           if (match) {
             const attrName = `data-${match[1]}`;
             const attrValue = match[2];
@@ -119,7 +119,10 @@ function applyDataAttributesFromCodeClasses(pre, code) {
       code.classList.remove(cls);
       pre.classList.remove(cls);
       if (languagePart) {
-        const cleanClass = languagePart.trim();
+        let cleanClass = languagePart.trim();
+        if (cls.includes('disableLineNumbers') && !cleanClass.includes('disableLineNumbers')) {
+          cleanClass += '-disableLineNumbers';
+        }
         code.classList.add(cleanClass);
         pre.classList.add(cleanClass);
       }

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -770,8 +770,8 @@ async function loadLazy(doc) {
     const hasResources = Boolean(document.querySelector('.resources-wrapper'));
     const hasCredential = Boolean(document.querySelector('.getcredential-wrapper'));
     const hasHeading = main.querySelectorAll('h2:not(.side-nav h2):not(footer h2), h3:not(.side-nav h3):not(footer h3)').length !== 0;
-    const noToc = document.querySelector('meta[name="no-toc"]')?.content === 'true';
-    const hasOnThisPage = !hasHero && hasHeading && !hasCredential && !noToc;
+    const noOnThisPage = document.querySelector('meta[name="noonthispage"]')?.content === 'true';
+    const hasOnThisPage = !hasHero && hasHeading && !hasCredential && !noOnThisPage;
 
     const hasAside = hasOnThisPage || hasResources;
     if (hasAside) {

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -770,8 +770,8 @@ async function loadLazy(doc) {
     const hasResources = Boolean(document.querySelector('.resources-wrapper'));
     const hasCredential = Boolean(document.querySelector('.getcredential-wrapper'));
     const hasHeading = main.querySelectorAll('h2:not(.side-nav h2):not(footer h2), h3:not(.side-nav h3):not(footer h3)').length !== 0;
-    const noOnThisPage = document.querySelector('meta[name="noonthispage"]')?.content === 'true';
-    const hasOnThisPage = !hasHero && hasHeading && !hasCredential && !noOnThisPage;
+    const hideOnThisPage = document.querySelector('meta[name="hideonthispage"]')?.content === 'true';
+    const hasOnThisPage = !hasHero && hasHeading && !hasCredential && !hideOnThisPage;
 
     const hasAside = hasOnThisPage || hasResources;
     if (hasAside) {

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -770,7 +770,8 @@ async function loadLazy(doc) {
     const hasResources = Boolean(document.querySelector('.resources-wrapper'));
     const hasCredential = Boolean(document.querySelector('.getcredential-wrapper'));
     const hasHeading = main.querySelectorAll('h2:not(.side-nav h2):not(footer h2), h3:not(.side-nav h3):not(footer h3)').length !== 0;
-    const hasOnThisPage = !hasHero && hasHeading && !hasCredential;
+    const noToc = document.querySelector('meta[name="no-toc"]')?.content === 'true';
+    const hasOnThisPage = !hasHero && hasHeading && !hasCredential && !noToc;
 
     const hasAside = hasOnThisPage || hasResources;
     if (hasAside) {


### PR DESCRIPTION
## Release — `stage` → `main`

> **Commits ahead:** 33
> **Merge base:** `2048863`
> **Generated:** 2026-06-04

### Changes included

| # | PR | Title | Jira | Author | Approved by |
|---|-----|-------|------|--------|-------------|
| 1 | [#627](https://github.com/AdobeDocs/adp-devsite/pull/627) | fix highlight attributes | DEVSITE-2075 | @louisachu | @melissag-ensemble |
| 2 | [#631](https://github.com/AdobeDocs/adp-devsite/pull/631) | fix : info card text overflow issue | DEVSITE-2432 | @BaskarMitrah | @melissag-ensemble |
| 3 | [#633](https://github.com/AdobeDocs/adp-devsite/pull/633) | fix : unquoted src and alt attributes in superhero video tag | DEVSITE-2421 | @BaskarMitrah | @melissag-ensemble |
| 4 | [#634](https://github.com/AdobeDocs/adp-devsite/pull/634) | fix : malformed title attributes in embed block | DEVSITE-2420 | @BaskarMitrah | @melissag-ensemble |
| 5 | [#624](https://github.com/AdobeDocs/adp-devsite/pull/624) | feat(ai-assistant): added basic analytics | — | @davids-ensemble | @melissag-ensemble |
| 6 | [#625](https://github.com/AdobeDocs/adp-devsite/pull/625) | feat(ai-assistant): prevent auto-scroll when user scrolls up | — | @davids-ensemble | @melissag-ensemble |
| 7 | [#628](https://github.com/AdobeDocs/adp-devsite/pull/628) | feat(ai-assistant): prod env | — | @davids-ensemble | @melissag-ensemble |
| 8 | [#629](https://github.com/AdobeDocs/adp-devsite/pull/629) | feat(ai-assistant): add Beta badge and widen chat window to 460px | — | @davids-ensemble | @melissag-ensemble |
| 9 | [#637](https://github.com/AdobeDocs/adp-devsite/pull/637) | fix(ai-assistant): fixed marked crashing because of undefined renderer | — | @davids-ensemble | @melissag-ensemble |
| 10 | [#638](https://github.com/AdobeDocs/adp-devsite/pull/638) | feat(ai-assistant): new panel animation | — | @davids-ensemble | @melissag-ensemble |
| 11 | [#632](https://github.com/AdobeDocs/adp-devsite/pull/632) | DEVSITE-2416 - read hideOnThisPage from md metadata | DEVSITE-2416 | @jiangy10 | @louisachu, @timkim |
| 12 | [#635](https://github.com/AdobeDocs/adp-devsite/pull/635) | exclude block headings from OnThisPage sidebar | DEVSITE-2173 | @jiangy10 | @melissag-ensemble |
| 13 | [#641](https://github.com/AdobeDocs/adp-devsite/pull/641) | update edition color | DEVSITE-2434 | @louisachu | @melissag-ensemble |
| 14 | [#642](https://github.com/AdobeDocs/adp-devsite/pull/642) | Devsite 2260 | DEVSITE-2260 | @jiangy10 | @timkim |
| 15 | [#640](https://github.com/AdobeDocs/adp-devsite/pull/640) | feat: enable text color on non-default superhero variants | DEVSITE-2289, DEVSITE-2008 | @melissag-ensemble | @louisachu |
| 16 | [#643](https://github.com/AdobeDocs/adp-devsite/pull/643) | fix: no empty searches, product boxes jumpiness, and lag between product checks | DEVSITE-2425 | @dianeba3 | @timkim |
| 17 | [#646](https://github.com/AdobeDocs/adp-devsite/pull/646) | feat(ai-assistant): improve daa-ll tracking identifiers | — | @davids-ensemble | @timkim |
| 18 | [#639](https://github.com/AdobeDocs/adp-devsite/pull/639) | fix(ai-assistant): fixed chat button size | — | @davids-ensemble | @timkim |

---

### Descriptions

#### [1] #627 — fix highlight attributes

**Jira:** [DEVSITE-2075](https://jira.corp.adobe.com/browse/DEVSITE-2075)
**Author:** @louisachu
**Approved by:** @melissag-ensemble
**Merged:** 2026-05-25

Fixes a bug where the `disableNumberLine` attribute and unnamed data attributes caused `data-line-offset` to stop working in code blocks. Without the fix, line-offset highlighting would silently fail when those attribute combinations were present.

---

#### [2] #631 — fix : info card text overflow issue

**Jira:** [DEVSITE-2432](https://jira.corp.adobe.com/browse/DEVSITE-2432)
**Author:** @BaskarMitrah
**Approved by:** @melissag-ensemble
**Merged:** 2026-05-27

Fixes a text overflow bug in the Info Card block where long heading and description text would render beyond its container boundaries.

---

#### [3] #633 — fix : unquoted src and alt attributes in superhero video tag

**Jira:** [DEVSITE-2421](https://jira.corp.adobe.com/browse/DEVSITE-2421)
**Author:** @BaskarMitrah
**Approved by:** @melissag-ensemble
**Merged:** 2026-05-27

Fixes malformed HTML in the Superhero block's video tag by properly quoting the `src` and `alt` attribute values.

---

#### [4] #634 — fix : malformed title attributes in embed block

**Jira:** [DEVSITE-2420](https://jira.corp.adobe.com/browse/DEVSITE-2420)
**Author:** @BaskarMitrah
**Approved by:** @melissag-ensemble
**Merged:** 2026-05-28

Fixes malformed `title` attribute values in the Embed block to produce valid HTML markup.

---

#### [5] #624 — feat(ai-assistant): added basic analytics

**Jira:** — ⚠️ No Jira ticket
**Author:** @davids-ensemble
**Approved by:** @melissag-ensemble
**Merged:** 2026-05-28

Adds DAA analytics tracking to the AI Assistant, including `daa-lh`/`daa-ll` attributes on interactive elements and tracking attributes on rendered links.

---

#### [6] #625 — feat(ai-assistant): prevent auto-scroll when user scrolls up

**Jira:** — ⚠️ No Jira ticket
**Author:** @davids-ensemble
**Approved by:** @melissag-ensemble
**Merged:** 2026-05-28

Adds behavior to the AI Assistant chat panel so that auto-scrolling to new messages is paused when the user has manually scrolled upward to review earlier content.

---

#### [7] #628 — feat(ai-assistant): prod env

**Jira:** — ⚠️ No Jira ticket
**Author:** @davids-ensemble
**Approved by:** @melissag-ensemble
**Merged:** 2026-05-28

Wires the AI Assistant to a production API endpoint and key, using `isProdEnvironment()` to automatically switch between stage and production configurations based on the current host.

---

#### [8] #629 — feat(ai-assistant): add Beta badge and widen chat window to 460px

**Jira:** — ⚠️ No Jira ticket
**Author:** @davids-ensemble
**Approved by:** @melissag-ensemble
**Merged:** 2026-05-28

Adds a "Beta" badge to the AI Assistant panel header and widens the chat window to 460px to improve readability.

---

#### [9] #637 — fix(ai-assistant): fixed marked crashing because of undefined renderer

**Jira:** — ⚠️ No Jira ticket
**Author:** @davids-ensemble
**Approved by:** @melissag-ensemble
**Merged:** 2026-06-01

Fixes a crash in the AI Assistant's Markdown rendering by switching from passing a custom renderer directly to `marked.parse` (which overwrites the entire renderer) to using `marked.use`, which correctly merges the custom link function into the default renderer.

---

#### [10] #638 — feat(ai-assistant): new panel animation

**Jira:** — ⚠️ No Jira ticket
**Author:** @davids-ensemble
**Approved by:** @melissag-ensemble
**Merged:** 2026-06-01

Replaces the AI Assistant panel's open/close animation with a revised version that meets updated design requirements.

---

#### [11] #632 — DEVSITE-2416 - read hideOnThisPage from md metadata to hide ON THIS PAGE

**Jira:** [DEVSITE-2416](https://jira.corp.adobe.com/browse/DEVSITE-2416)
**Author:** @jiangy10
**Approved by:** @louisachu, @timkim
**Merged:** 2026-06-01

Adds a `hideOnThisPage: true` metadata flag that, when set in a page's frontmatter, suppresses the "On This Page" sidebar navigation from rendering on that page.

---

#### [12] #635 — exclude block headings from OnThisPage sidebar

**Jira:** [DEVSITE-2173](https://jira.corp.adobe.com/browse/DEVSITE-2173)
**Author:** @jiangy10
**Approved by:** @melissag-ensemble
**Merged:** 2026-06-01

Fixes the OnThisPage sidebar collector to target only default-content headings (those wrapped by EDS auto-blocks as `.heading2`/`.heading3`) rather than all raw `h2`/`h3` elements in `<main>`, preventing headings inside block components like CodeBlock, AccordionItem, and Cards from generating broken sidebar entries.

---

#### [13] #641 — update edition color

**Jira:** [DEVSITE-2434](https://jira.corp.adobe.com/browse/DEVSITE-2434)
**Author:** @louisachu
**Approved by:** @melissag-ensemble
**Merged:** 2026-06-02

Adds a new color variant to the Edition badge component, extending the available styling options for content authors.

---

#### [14] #642 — Devsite 2260

**Jira:** [DEVSITE-2260](https://jira.corp.adobe.com/browse/DEVSITE-2260)
**Author:** @jiangy10
**Approved by:** @timkim
**Merged:** 2026-06-02

Fixes the layout of the Vertical Tab block to address display issues with the vertical tab decoration and image rendering.

---

#### [15] #640 — feat: enable text color on non-default superhero variants

**Jira:** [DEVSITE-2289](https://jira.corp.adobe.com/browse/DEVSITE-2289), [DEVSITE-2008](https://jira.corp.adobe.com/browse/DEVSITE-2008)
**Author:** @melissag-ensemble
**Approved by:** @louisachu
**Merged:** 2026-06-03

Fixes the `textColor` modifier on Superhero block variants (Centered, Centered XL, Half-Width) for both DevBiz and DevDocs — previously ignored or partially applied. Also ensures inline links within the hero are underlined and that the default variant's heading color is consistent with body text.

---

#### [16] #643 — fix: no empty searches, product boxes jumpiness, and lag between product checks

**Jira:** [DEVSITE-2425](https://jira.corp.adobe.com/browse/DEVSITE-2425)
**Author:** @dianeba3
**Approved by:** @timkim
**Merged:** 2026-06-03

Resolves three search UI bugs: wraps the Algolia search client to return empty local results for blank queries (preventing unnecessary API calls), removes checkbox visibility toggling that caused product filter jumpiness, and re-registers dynamic widgets on each filter change to eliminate lag when switching between products. Also adds anchor fragment support to search result URLs.

---

#### [17] #646 — feat(ai-assistant): improve daa-ll tracking identifiers

**Jira:** — ⚠️ No Jira ticket
**Author:** @davids-ensemble
**Approved by:** @timkim
**Merged:** 2026-06-04

Updates the `daa-ll` attribute values in the AI Assistant to use more descriptive and consistent identifiers, improving the quality of analytics data captured.

---

#### [18] #639 — fix(ai-assistant): fixed chat button size

**Jira:** — ⚠️ No Jira ticket
**Author:** @davids-ensemble
**Approved by:** @timkim
**Merged:** 2026-06-04

Fixes the sizing of the AI Assistant's chat toggle button so it renders at the correct dimensions.

---

### Notes

- PRs **#624, #625, #628, #629, #637, #638, #646, #639** have no associated Jira ticket. ⚠️ No Jira ticket
- All 18 PRs have at least one approver on record.
- 3 additional open PRs (#636, #645, #647) have commits targeting `stage` but are **not yet merged** and are excluded from this release.