### PR TITLE
update the copy button

### DIFF
--- a/hlx_statics/blocks/code/code.css
+++ b/hlx_statics/blocks/code/code.css
@@ -1,6 +1,12 @@
 main div.code-wrapper pre[class*=language-],
 main div.nested-code-wrapper pre[class*=language-] {
     border-radius: 4px;
+    padding-top: 3.5em;
+}
+
+main div.code-wrapper pre[class*=language-] .line-highlight,
+main div.nested-code-wrapper pre[class*=language-] .line-highlight {
+    margin-top: 3.5em;
 }
 
 main div.code-wrapper pre[class*=language-].no-line-numbers .line-highlight,

--- a/hlx_statics/blocks/codeblock/codeblock.css
+++ b/hlx_statics/blocks/codeblock/codeblock.css
@@ -1,6 +1,11 @@
 main div.codeblock-wrapper pre[class*="language-"] {
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
+  padding-top: 3.5em;
+}
+
+main div.codeblock-wrapper pre[class*="language-"] .line-highlight {
+  margin-top: 3.5em;
 }
 
 main div.codeblock-wrapper {

--- a/hlx_statics/blocks/tab/tab.css
+++ b/hlx_statics/blocks/tab/tab.css
@@ -32,6 +32,14 @@ main div.tab-wrapper > div:not(.background-color-navy) .tab-button:hover {
     color: white;
 }
 
+main div.tab-wrapper div.code-toolbar pre.line-numbers {
+    padding-top: 3.5em;
+}
+
+main div.tab-wrapper div.code-toolbar pre.line-numbers .line-highlight {
+    margin-top: 3.5em;
+}
+
 main div.tab-wrapper div.code-toolbar>.toolbar>.toolbar-item>button {
     padding: 12px;
     height: 32px;
@@ -55,7 +63,6 @@ main div.tab-wrapper .line-numbers-rows>span {
 @media only screen and (max-width: 860px) {
 
     main div.tab-wrapper div.code-toolbar>.toolbar>.toolbar-item>button {
-        padding: 0;
         height: 25px;
         right: 0px;
     }
@@ -223,7 +230,7 @@ main div.tab-wrapper div.background-color-navy .code-toolbar pre {
     background-color: #111a35;
     border-radius: 2vh;
 }
- 
+
 main div.sub-content-wrapper .code-toolbar pre {
     border-radius: 0%;
 }


### PR DESCRIPTION
The problem with page rendering over is fixed but the copy button is overlapping the code. 
Before:
https://main--adp-devsite--adobedocs.aem.live/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/tab&index=3

https://developer-stage.adobe.com/dev-docs-reference/blocks/codeblock/code-block-with-picklist

Fix:
https://devsite-1642--adp-devsite--adobedocs.aem.live/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/tab&index=3

https://devsite-1642--adp-devsite--adobedocs.aem.live/dev-docs-reference/blocks/codeblock/code-block-with-picklist

If you goto the mobile views, copy button will overlap 
<img width="1165" height="583" alt="Screenshot 2026-06-05 at 1 59 33 PM" src="https://github.com/user-attachments/assets/f08af61e-4370-414c-82ed-54f77c40d970" />

Now:
<img width="1515" height="639" alt="Screenshot 2026-06-05 at 2 02 29 PM" src="https://github.com/user-attachments/assets/88aa1a03-2b5c-4d0b-8990-14236dfa90b6" />

