### PR TITLE
feat(ai-assistant): add support for codeblocks

### DIFF
--- a/hlx_statics/blocks/ai-assistant/ai-assistant.css
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.css
@@ -422,6 +422,7 @@
     justify-content: center;
     padding: 24px;
     box-sizing: border-box;
+    z-index: 11;
 }
 
 .ai-assistant-panel .chat-window .chat-window-dialog-card {

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_api-client.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_api-client.js
@@ -396,7 +396,7 @@ export class AiApiClient {
     callbacks = {},
   }) {
     const defaultSystemPrompt = `
-      Use markdown formatting for the response.
+      Use markdown formatting and codeblocks for the response.
     `;
 
     /** @type {RequestBody} */

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -1,5 +1,7 @@
 // @ts-check
 import { createTag } from "../../scripts/lib-adobeio.js";
+import decoratePreformattedCode from "../../components/code.js";
+import { ensurePrismLoaded } from "../../scripts/prism-loader.js";
 import { aiApiClient } from "./ai-assistant_api-client.js";
 import { chatHistory } from "./ai-assistant_chat-history.js";
 import { createAiAvatar } from "./ai-assistant_chat-ui.js";
@@ -74,6 +76,8 @@ export class ChatBubble {
         bubble.dataset.messageId = this.id;
         // If we have an ID already (e.g., restored from history), append the actions
         contentElement.appendChild(this._actionsContainer);
+        // Restored-history bubbles never call completeBubble(), so decorate here.
+        this.#_decorateCodeBlocks(contentElement);
       }
       // Otherwise, the actions will be appended when completeBubble is called
     }
@@ -301,7 +305,7 @@ export class ChatBubble {
   }
 
   /**
-   * Adds the missing actions to an AI bubble
+   * Final processing that needs to be done after streaming finishes.
    */
   completeBubble() {
     if (this.source !== "ai" || !this._actionsContainer) return;
@@ -310,6 +314,52 @@ export class ChatBubble {
 
     const contentElement = this.element.querySelector(".chat-bubble-content");
     contentElement?.appendChild(this._actionsContainer);
+    if (contentElement) {
+      this.#_decorateCodeBlocks(contentElement);
+    }
+  }
+
+  /**
+   * @param {Element} contentElement - The `.chat-bubble-content` element
+   */
+  #_decorateCodeBlocks(contentElement) {
+    const preBlocks = contentElement.querySelectorAll("pre");
+    if (!preBlocks.length) return;
+
+    let decoratedAny = false;
+    preBlocks.forEach((pre) => {
+      // decoratePreformattedCode dereferences a <code> child unconditionally.
+      if (!pre.querySelector("code")) return;
+      decoratePreformattedCode(pre);
+      decoratedAny = true;
+    });
+
+    if (!decoratedAny) return;
+
+    ensurePrismLoaded().then(() => {
+      // @ts-expect-error - Prism is not on the Window type
+      window.Prism?.highlightAllUnder?.(contentElement);
+    });
+  }
+
+  /**
+   * Recomputes Prism's line-number row heights for every decorated code block
+   * inside a container.
+   * This is required to correctly align line numbers after restoring history.
+   * @param {Element | null | undefined} container
+   */
+  static resizeCodeBlockLineNumbers(container) {
+    const preBlocks = container?.querySelectorAll("pre.line-numbers");
+    if (!preBlocks?.length) return;
+
+    ensurePrismLoaded().then(() => {
+      // @ts-expect-error - Prism is not on the Window type
+      const resize = window.Prism?.plugins?.lineNumbers?.resize;
+      if (typeof resize !== "function") return;
+      preBlocks.forEach((pre) => {
+        resize(pre);
+      });
+    });
   }
 
   /**

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -330,6 +330,8 @@ export class ChatBubble {
     preBlocks.forEach((pre) => {
       // decoratePreformattedCode dereferences a <code> child unconditionally.
       if (!pre.querySelector("code")) return;
+      // The chat panel is narrow, so use the icon-only copy button.
+      pre.classList.add("copy-condensed");
       decoratePreformattedCode(pre);
       decoratedAny = true;
     });

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
@@ -82,6 +82,25 @@ export const openChatWindow = () => {
   ELEMENTS.CHAT_WINDOW.classList.add("show");
   ELEMENTS.CHAT_BUTTON.classList.add("hidden");
 
+  // Code blocks in restored-history bubbles are decorated while the window is
+  // hidden (scaled to 0), so Prism's line-number rows collapse onto line 1.
+  // Recompute them once the open transition settles and the window has real
+  // layout. transitionend is the precise signal; the timeout is a fallback in
+  // case the transition is skipped (e.g. reduced motion / 0s duration).
+  const chatWindow = ELEMENTS.CHAT_WINDOW;
+  let fixedLineNumbers = false;
+  const fixLineNumbers = (event) => {
+    // transitionend bubbles, so ignore descendant transitions and only react to
+    // the window's own transform settling (or the timeout, which has no event).
+    if (event && (event.target !== chatWindow || event.propertyName !== "transform")) return;
+    if (fixedLineNumbers) return;
+    fixedLineNumbers = true;
+    chatWindow.removeEventListener("transitionend", fixLineNumbers);
+    ChatBubble.resizeCodeBlockLineNumbers(ELEMENTS.CHAT_WINDOW_CONTENT);
+  };
+  chatWindow.addEventListener("transitionend", fixLineNumbers);
+  window.setTimeout(fixLineNumbers, 400);
+
   // Initial messages
   if (chatHistory.isEmpty()) {
     sendInitialMessages();

--- a/hlx_statics/scripts/prism-loader.js
+++ b/hlx_statics/scripts/prism-loader.js
@@ -1,0 +1,35 @@
+import { loadCSS } from "./lib-helix.js";
+
+/**
+ * Cached promise so the Prism import/config runs at most once per page,
+ * regardless of how many callers (docs code blocks, AI assistant, …) need it.
+ * @type {Promise<void> | null}
+ */
+let prismPromise = null;
+
+/**
+ * Load Prism. Call this before using `window.Prism`.
+ * @returns {Promise<void>} resolves once `window.Prism` is ready to use.
+ */
+export function ensurePrismLoaded() {
+  if (prismPromise) return prismPromise;
+
+  prismPromise = (async () => {
+    window.Prism = { manual: true };
+    loadCSS(`${window.hlx.codeBasePath}/styles/prism.css`);
+    await import("./prism.js");
+
+    // Ensure Prism autoloader knows where to fetch language components
+    if (
+      window.Prism &&
+      window.Prism.plugins &&
+      window.Prism.plugins.autoloader
+    ) {
+      window.Prism.plugins.autoloader.languages_path =
+        "/hlx_statics/scripts/prism-grammars/";
+      window.Prism.plugins.autoloader.use_minified = true;
+    }
+  })();
+
+  return prismPromise;
+}

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -24,6 +24,8 @@ import {
   getCodePlaygroundJsonPath
 } from './lib-helix.js';
 
+import { ensurePrismLoaded } from './prism-loader.js';
+
 import {
   buildAiAssistant,
   buildBreadcrumbs,
@@ -898,15 +900,7 @@ async function loadPrism(document) {
 
       if (!prismLoaded) {
         prismLoaded = true;
-        window.Prism = { manual: true };
-        loadCSS(`${window.hlx.codeBasePath}/styles/prism.css`);
-        import('./prism.js').then(() => {
-          // Ensure Prism autoloader knows where to fetch language components
-          if (window.Prism && window.Prism.plugins && window.Prism.plugins.autoloader) {
-            window.Prism.plugins.autoloader.languages_path = '/hlx_statics/scripts/prism-grammars/';
-            window.Prism.plugins.autoloader.use_minified = true;
-          }
-
+        ensurePrismLoaded().then(() => {
           // Register "Try it" button for code blocks with "try" class
           if (window.Prism?.plugins?.toolbar) {
             window.Prism.plugins.toolbar.registerButton('try-code', (env) => {

--- a/hlx_statics/styles/prism.css
+++ b/hlx_statics/styles/prism.css
@@ -181,6 +181,43 @@ div.code-toolbar>.toolbar>.toolbar-item>button {
     background: rgba(0, 0, 0, 0);
 }
 
+/* Condensed mode: icon-only copy button */
+div.code-toolbar:has(pre.copy-condensed) {
+    --copy-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cpath d='M11.75 18h-7.5C3.01 18 2 16.99 2 15.75v-7.5C2 7.01 3.01 6 4.25 6c.414 0 .75.336.75.75s-.336.75-.75.75c-.413 0-.75.337-.75.75v7.5c0 .413.337.75.75.75h7.5c.413 0 .75-.337.75-.75 0-.414.336-.75.75-.75s.75.336.75.75c0 1.24-1.01 2.25-2.25 2.25M6.75 5C6.336 5 6 4.664 6 4.25 6 3.01 7.01 2 8.25 2c.414 0 .75.336.75.75s-.336.75-.75.75c-.413 0-.75.337-.75.75 0 .414-.336.75-.75.75M13 3.5h-2c-.414 0-.75-.336-.75-.75S10.586 2 11 2h2c.414 0 .75.336.75.75s-.336.75-.75.75'/%3E%3Cpath d='M13 14h-2c-.414 0-.75-.336-.75-.75s.336-.75.75-.75h2c.414 0 .75.336.75.75s-.336.75-.75.75M15.75 14c-.414 0-.75-.336-.75-.75s.336-.75.75-.75c.413 0 .75-.337.75-.75 0-.414.336-.75.75-.75s.75.336.75.75c0 1.24-1.01 2.25-2.25 2.25M17.25 5c-.414 0-.75-.336-.75-.75 0-.413-.337-.75-.75-.75-.414 0-.75-.336-.75-.75s.336-.75.75-.75C16.99 2 18 3.01 18 4.25c0 .414-.336.75-.75.75M17.25 9.75c-.414 0-.75-.336-.75-.75V7c0-.414.336-.75.75-.75s.75.336.75.75v2c0 .414-.336.75-.75.75M6.75 9.75C6.336 9.75 6 9.414 6 9V7c0-.414.336-.75.75-.75s.75.336.75.75v2c0 .414-.336.75-.75.75M8.25 14C7.01 14 6 12.99 6 11.75c0-.414.336-.75.75-.75s.75.336.75.75c0 .413.337.75.75.75.414 0 .75.336.75.75s-.336.75-.75.75'/%3E%3C/svg%3E");
+    --check-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'%3E%3Cpath d='M7.864 15.734c-.222 0-.433-.098-.576-.27l-3.747-4.497c-.266-.319-.222-.792.096-1.057.317-.265.79-.223 1.056.096l3.154 3.786 7.44-9.469c.255-.326.728-.382 1.052-.127.326.256.383.728.127 1.053L8.454 15.447c-.14.179-.352.284-.579.287z'/%3E%3C/svg%3E");
+
+    & > .toolbar > .toolbar-item > button.copy-to-clipboard-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.4em;
+    
+        /* Visually hide the label but without display: none so it remains accessible */
+        & > span {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            clip: rect(0, 0, 0, 0);
+        }
+    
+        &::before {
+            content: "";
+            display: block;
+            width: 1em;
+            height: 1em;
+            background-color: currentColor;
+            -webkit-mask: var(--copy-icon) no-repeat center / contain;
+            mask: var(--copy-icon) no-repeat center / contain;
+        }
+    
+        /* swap to checkmark on copy success */
+        &[data-copy-state="copy-success"]::before {
+            -webkit-mask-image: var(--check-icon);
+            mask-image: var(--check-icon);
+        } 
+    }
+}
+
 pre.prism-loading {
     background: #e0e0e0;
     color: transparent !important;


### PR DESCRIPTION
Jira: https://jira.corp.adobe.com/browse/ADPGENAI-67

This is trying to reuse our existing code blocks powered by Prism in the AI Assistant bubbles.

A few notes about this:
- I extracted the import for Prism in a reusable function because it only got imported on pages with code blocks.
- I import Prism if a codeblock is detected in a chat bubble
- I added a "condensed copy button" mode that collapses the label into an icon 
- Let me know if I should move the prism-loader into a different location

### Test existing codeblock

STAGE: https://developer-stage.adobe.com/express/add-ons/docs/guides/getting-started/hello-world#edit-the-script
PR: https://feat-ai-assistant-code-block-decoration--adp-devsite--adobedocs.aem.page/express/add-ons/docs/guides/getting-started/hello-world#edit-the-script

### Test with AI Assistant

STAGE: https://developer-stage.adobe.com/express/add-ons/docs/guides/
PR: https://feat-ai-assistant-code-block-decoration--adp-devsite--adobedocs.aem.page/express/add-ons/docs/guides/

For both environments do the following in your browser console
```js
// 1. Modify sessionStorage with an example response
sessionStorage.setItem('ai-assistant-chat-history', JSON.stringify([{"content":"Hello, welcome to Adobe Developer Website!","source":"ai"},{"content":"What would you like to know today?","source":"ai","timestamp":1780921148269},{"content":"How do I initialize my App Builder application and what CLI commands are available for generating manifests, schemas, and runtime actions?","source":"user","timestamp":1780921154212},{"id":"2bde5a79-0857-466c-810d-f6dc55033a9a","content":"\n## Initializing Your App Builder Application\n\nBefore initializing your App Builder application, you need to complete these prerequisites:\n\n1. **Create a project in the Adobe Developer Console** - Create a new project or use an existing one\n2. **Add required services** to your project:\n   - **I/O Management API** (required for App Builder runtime actions)\n   - **I/O Events** (only if your app uses events)\n   - **I/O Events for Adobe Commerce** (only if your app uses events)\n   - **Adobe Commerce as a Cloud Service** (only for Adobe Commerce as a Cloud Service instances)\n3. **Set up App Builder** - Ensure you have the Adobe I/O CLI installed and configured\n\n### Running the Initialization\n\nTo initialize your App Builder project, run the following command based on your package manager:\n\n**npm:**\n```bash\nnpx @adobe/aio-commerce-lib-app init\n```\n\n**yarn:**\n```bash\n# For Yarn classic (v1), install first\nyarn add @adobe/aio-commerce-lib-app\nyarn exec aio-commerce-lib-app init\n\n# For Yarn Berry (v2+), pull directly from remote\nyarn dlx @adobe/aio-commerce-lib-app init\n```\n\n**pnpm:**\n```bash\npnpm dlx @adobe/aio-commerce-lib-app init\n```\n\n**bun:**\n```bash\nbun x @adobe/aio-commerce-lib-app init\n```\n\nThe initialization process will:\n- Create `app.commerce.config` with a template\n- Install required dependencies\n- Add a `postinstall` hook to `package.json`\n- Generate all required artifacts\n- Update `app.config.yaml` and `install.yaml` with appropriate extension references\n\n## Available CLI Commands\n\nAfter initialization, you can use the following CLI commands to generate different artifacts:\n\n| Command | Description |\n|---------|-------------|\n| `npx aio-commerce-lib-app generate all` | Generate all artifacts (manifest, schema, and runtime actions). If your schema contains password fields, configure an encryption key |\n| `npx aio-commerce-lib-app generate manifest` | Generate only the app manifest file |\n| `npx aio-commerce-lib-app generate actions` | Generate only runtime actions |\n| `npx aio-commerce-lib-app generate schema` | Generate only the configuration schema |\n\n**Note:** Replace `npx` with your package manager's equivalent:\n- **Yarn:** `yarn exec`\n- **PNPM:** `pnpm exec`\n- **Bun:** `bun x`\n\nThe `postinstall` hook automatically refreshes generated artifacts when you install or update the library. Additionally, `aio app build` runs `pre-app-build`, which regenerates runtime action sources from your current `app.commerce.config`.\n","source":"ai","references":[{"url":"https://developer.adobe.com/commerce/extensibility/app-management/initialize-app","title":"Initialize your app"}],"timestamp":1780921154223}]));
// 2. enable and reload page to pick up new sessionStorage data
ENABLE_AI_ASSISTANT();
```

This history should have a few code blocks that are rendered differently in the two environments.

| STAGE | PR |
|--------|--------|
| <img width="480" height="839" alt="image" src="https://github.com/user-attachments/assets/1346ef8b-5f08-434c-b5e8-a9cb39585f2e" /> | <img width="499" height="860" alt="image" src="https://github.com/user-attachments/assets/fa63fc4d-7069-4f93-8067-14014da6f5cb" /> |