### PR TITLE
update on the horizontalline error

### DIFF
--- a/hlx_statics/blocks/horizontalline/horizontalline.css
+++ b/hlx_statics/blocks/horizontalline/horizontalline.css
@@ -1,0 +1,2 @@
+/* Block-specific styles intentionally empty.
+   Global hr styles live in styles/styles.css. */

--- a/hlx_statics/blocks/horizontalline/horizontalline.js
+++ b/hlx_statics/blocks/horizontalline/horizontalline.js
@@ -1,0 +1,8 @@
+/**
+ * Replaces the block's authored content with a single <hr> element.
+ * @param {Element} block The horizontalline block element
+ */
+export default async function decorate(block) {
+  block.innerHTML = '';
+  block.appendChild(document.createElement('hr'));
+}

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -256,20 +256,6 @@ export function buildCodes(container) {
 }
 
 /**
- * Builds all hr blocks inside a container
- * @param {*} container The container to inspect
- */
-export function decorateHR(container) {
-  const hrWrappers = container.querySelectorAll('main div.horizontalline-wrapper div.horizontalline');
-
-  hrWrappers.forEach(hrWrapper => {
-    const hr = document.createElement('hr');
-    hrWrapper.innerHTML = ''
-    hrWrapper.appendChild(hr)
-  });
-}
-
-/**
  * Builds all embed blocks inside a container
  * @param {*} container The container to inspect
  */

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -49,7 +49,6 @@ import {
   isProdEnvironment,
   addExtraScript,
   addExtraScriptWithLoad,
-  decorateHR,
   buildNextPrev,
   buildResources,
   checkExternalLink,
@@ -201,7 +200,6 @@ export function decorateMain(main) {
   decorateSections(main);
   decorateBlocks(main);
   decorateNestedCodes(main);
-  decorateHR(main);
   checkExternalLink(main);
 }
 


### PR DESCRIPTION
Previous:
https://developer-stage.adobe.com/express/add-ons/docs/guides/learn/fundamentals/terminology#manifest-configuration
<img width="1473" height="574" alt="Screenshot 2026-06-09 at 12 25 41 PM" src="https://github.com/user-attachments/assets/b3e4835d-3ac9-4a40-aca6-4208b4f651e3" />


Now:
https://devsite-2237--adp-devsite--adobedocs.aem.page/express/add-ons/docs/guides/learn/fundamentals/terminology#manifest-configuration
<img width="1480" height="570" alt="Screenshot 2026-06-09 at 12 25 06 PM" src="https://github.com/user-attachments/assets/26bd8402-eace-419e-87bf-de51adad3ecd" />
