### PR TITLE
feat: enable ai assistant by default on stage

### DIFF
--- a/hlx_statics/scripts/lib-helix.js
+++ b/hlx_statics/scripts/lib-helix.js
@@ -115,6 +115,9 @@ export const IS_DEV_DOCS = Boolean(getMetadata('githubblobpath'));
 /**
  * A set of utilities to enable and disable the ai assistant
  */
+if (localStorage.getItem('ai-assistant-enabled') !== 'false') {
+  localStorage.setItem('ai-assistant-enabled', 'true');
+}
 export const IS_AI_ASSISTANT_ENABLED = localStorage.getItem('ai-assistant-enabled') === 'true';
 window.ENABLE_AI_ASSISTANT = () => {
   localStorage.setItem('ai-assistant-enabled', 'true');

--- a/hlx_statics/scripts/scripts.js
+++ b/hlx_statics/scripts/scripts.js
@@ -801,7 +801,7 @@ async function loadLazy(doc) {
     }
   }
 
-  if (IS_AI_ASSISTANT_ENABLED) {
+  if (IS_AI_ASSISTANT_ENABLED && isStageEnvironment(window.location.host, true)) {
     buildAiAssistant(main);
     loadAiAssistant(doc.querySelector('.ai-assistant-wrapper'));
   }


### PR DESCRIPTION
This enables the ai assitant to appear on our site by default but only on stage. 