### PR TITLE
Devsite 1996 - fixed inconsistency of external-icon

### DIFF
--- a/hlx_statics/blocks/resources/resources.css
+++ b/hlx_statics/blocks/resources/resources.css
@@ -10,7 +10,7 @@ main div.resources-wrapper ul{
 main div.resources-wrapper li{
     margin-top:15px;
     display:flex;
-    align-items: flex-end;
+    align-items: center;
 }
 
 main div.resources-wrapper h3{

--- a/hlx_statics/blocks/resources/resources.css
+++ b/hlx_statics/blocks/resources/resources.css
@@ -1,5 +1,6 @@
-main div.resources-wrapper a{
+main div.resources-wrapper li > a{
     font-size: 16px;
+    flex: 1;
 }
 
 main div.resources-wrapper ul{
@@ -9,6 +10,7 @@ main div.resources-wrapper ul{
 main div.resources-wrapper li{
     margin-top:15px;
     display:flex;
+    align-items: flex-end;
 }
 
 main div.resources-wrapper h3{
@@ -27,6 +29,5 @@ main div.resources-wrapper div.external-icon {
     width: 16px;
     height: 16px;
     margin-left: 8px;
-    margin-top:3px;
     vertical-align: middle;
 }

--- a/hlx_statics/blocks/resources/resources.js
+++ b/hlx_statics/blocks/resources/resources.js
@@ -13,7 +13,7 @@ export default async function decorate(block) {
     const href = link.getAttribute('href');
     if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
       const externalLink = createTag('div', {class: 'external-icon'});
-      externalLink.innerHTML = `<svg viewBox="0 0 36 36" className="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" role="img">
+      externalLink.innerHTML = `<svg viewBox="0 0 36 36" class="spectrum-Icon spectrum-Icon--sizeS" focusable="false" aria-hidden="true" role="img">
       <path d="M33 18h-2a1 1 0 0 0-1 1v11H6V6h11a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v30a1 1 0 0 0 1 1h30a1 1 0 0 0 1-1V19a1 1 0 0 0-1-1z"></path>
       <path d="M33.5 2H22.754a.8.8 0 0 0-.754.8.784.784 0 0 0 .235.56l3.786 3.79-7.042 7.042a1 1 0 0 0 0 1.415l1.414 1.414a1 1 0 0 0 1.414 0l7.043-7.042 3.786 3.785A.781.781 0 0 0 33.2 14a.8.8 0 0 0 .8-.754V2.5a.5.5 0 0 0-.5-.5z"></path>
       </svg>`;


### PR DESCRIPTION
Jira: [DEVSITE-1996](https://jira.corp.adobe.com/browse/DEVSITE-1996)

fixed className to class for styling and added styles for icons in `<li>`

## comparison
- stage: https://developer-stage.adobe.com/commerce/cloud-tools
- devsite-1996: https://devsite-1996--adp-devsite-stage--adobedocs.aem.page/commerce/cloud-tools/