### PR TITLE
discoverblock update

### DIFF
--- a/hlx_statics/blocks/discoverblock/discoverblock.css
+++ b/hlx_statics/blocks/discoverblock/discoverblock.css
@@ -23,31 +23,40 @@ main div.discoverblock-wrapper div.discoverblock {
   margin-right: 32px;
 }
 
+main div.discoverblock-wrapper div.discoverblock.has-image {
+  display: flex;
+  align-items: flex-start;
+  gap: 26px;
+}
+
+main div.discoverblock-wrapper div.discoverblock.has-image > img.discover-image {
+  /* width/height come from inline styles set by discoverblock.js */
+  align-self: flex-start;
+}
+
+main div.discoverblock-wrapper div.discoverblock.has-image > div {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 /* Wrapper display */
 main div.discoverblock-wrapper {
   display: inline-flex;
   flex-direction: column;
   width: 320px;
-  padding-top:0px;
+  min-width: 280px;
+  padding-top: 0px;
+  vertical-align: top;
 }
 
-/* Responsive design for mobile and tablet */
 @media (max-width: 768px) {
   main div.discoverblock-wrapper {
     width: 100% !important;
+    min-width: 0;
   }
 }
 
-main div.discoverblock-container div.heading2-wrapper{
-  margin-bottom: 5px;
-}
-
-main div.discoverblock-container div.heading2-wrapper h2 {
-  border-bottom: 0px;
-  padding-bottom: 3px;
-}
-
-main div.discoverblock-container h2:not(.ai-assistant-wrapper h2) {
+main h2.discoverblock-heading {
   border-bottom: 1px solid #e1e1e1;
   margin-top: 40px;
   padding-top: 20px;
@@ -55,7 +64,7 @@ main div.discoverblock-container h2:not(.ai-assistant-wrapper h2) {
   margin-bottom: 0px;
 }
 
-main div.discoverblock-container h3:not(.ai-assistant-wrapper h3) {
+main h3.discoverblock-heading {
   width: 100%;
 }
 
@@ -84,11 +93,8 @@ main div.discoverblock-wrapper p {
   margin-bottom: 0;
 }
 
-main div.discoverblock-container .discover-heading-with-image {
+main .discoverblock-heading.discover-heading-with-image {
   padding-left: 126px;
   margin-bottom: 5px;
 }
 
-main div.discoverblock-wrapper div.discover-content-with-image {
-  padding-left: 126px;
-}

--- a/hlx_statics/blocks/discoverblock/discoverblock.js
+++ b/hlx_statics/blocks/discoverblock/discoverblock.js
@@ -30,11 +30,6 @@ export default async function decorate(block) {
     image.classList.add('discover-image');
 
     block.insertBefore(image, block.firstChild);
-
-    const buttonContainer = block.querySelector('.button-container');
-    if (buttonContainer && buttonContainer.parentElement) {
-      buttonContainer.parentElement.classList.add('discover-content-with-image');
-    }
   } else if (width) {
     wrapper.style.width = width;
   }

--- a/hlx_statics/blocks/discoverblock/discoverblock.js
+++ b/hlx_statics/blocks/discoverblock/discoverblock.js
@@ -1,60 +1,54 @@
-import { createTag, decorateAnchorLink } from "../../scripts/lib-adobeio.js";
+import { decorateAnchorLink } from "../../scripts/lib-adobeio.js";
 
 /**
  * decorates the discover block
  * @param {Element} block The discover block element
  */
 export default async function decorate(block) {
-   block.setAttribute('daa-lh', 'discover');
+  block.setAttribute('daa-lh', 'discover');
 
   block.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((h) => {
     decorateAnchorLink(h);
   });
-  // Set width based on data-width attribute
+
   const width = block.getAttribute('data-width');
   const wrapper = block.closest('.discoverblock-wrapper');
 
-  // If there's an image, set the block width to 2*1280/12 and position image on the left
   const hasImage = block.querySelector('img') !== null;
   if (hasImage) {
     let imageWidth = (2 * 1280) / 12;
     imageWidth = imageWidth + 156;
     wrapper.style.width = imageWidth + 'px';
 
-    // Get the image
     const image = block.querySelector('img');
 
-    // Set image width to 100px and move it to the beginning
     image.style.width = '100px';
     image.style.height = 'auto';
     image.style.flexShrink = '0';
-    image.style.position = 'absolute';
 
-    // Move the image to be the first child (leftmost position)
+    block.classList.add('has-image');
+    image.classList.add('discover-image');
+
     block.insertBefore(image, block.firstChild);
 
-    // Find button-container's parent and give it a class name
     const buttonContainer = block.querySelector('.button-container');
     if (buttonContainer && buttonContainer.parentElement) {
       buttonContainer.parentElement.classList.add('discover-content-with-image');
     }
   } else if (width) {
-    // if data-width exists, override the default width with the data-width.
     wrapper.style.width = width;
   }
 
   const heading = block.querySelector('h1, h2, h3, h4, h5, h6');
   if (heading) {
-    // Check if block has image and add class to heading if it does
     if (hasImage) {
       heading.classList.add('discover-heading-with-image');
     }
     const headingClone = heading.cloneNode(true);
 
-    // Insert heading before the wrapper
+    headingClone.classList.add('discoverblock-heading');
     wrapper.parentElement.insertBefore(headingClone, wrapper);
 
-    // Remove the original heading from the block content
     heading.remove();
   }
 }


### PR DESCRIPTION
This should fix both tickets. 

https://jira.corp.adobe.com/browse/DEVSITE-2464
Double horizontal line on h2 heading.
before:
https://developer-stage.adobe.com/commerce/cloud-tools/
now:
https://devsite-2195--adp-devsite--adobedocs.aem.page/commerce/cloud-tools/

https://jira.corp.adobe.com/browse/DEVSITE-2195
Resize the page to see the problem overlapping.
before:
https://developer-stage.adobe.com/dev-docs-reference/blocks/discoverblock/

now:
https://devsite-2195--adp-devsite--adobedocs.aem.page/dev-docs-reference/blocks/discoverblock/
