### PR TITLE
fix: explicitly set charset to utf-8

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,5 +1,5 @@
+<meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-
 
 <script src="/hlx_statics/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
 


### PR DESCRIPTION
This sets our pages to explictly be utf-8. Normally our pages already set to uft-8 by default but in AdobeDocsPrivate, it seems to set it to a legacy charset: `'windows-1252'` which is causing some rendering issues. 

This is a little hard to test since our pages are all on utf-8 but if you look at:
https://charset--adp-devsite-stage--adobedocs.aem.page/app-builder/docs/intro_and_overview/

And inspect the head, you should see a value:
<meta charset="utf-8"/>

After we merge this into prod, we can test the other pages (https://developer-stage.adobe.com/autocrop-api/api/#operation/facadeJobStatus or https://developer-stage.adobe.com/harmonize-image/api/#operation/harmonizeAsync) and see if it fixes the rendering issues