### PR TITLE
fix: issue fixed the devBiz tab block issue

### DIFF
--- a/hlx_statics/blocks/tab/tab.css
+++ b/hlx_statics/blocks/tab/tab.css
@@ -130,6 +130,10 @@ main div.tab-wrapper .code-toolbar {
 
 main div.tab-wrapper .tab.vertical {
     flex-direction: row;
+}
+
+main.dev-docs  div.tab-wrapper .tab.vertical {
+    flex-direction: row;
     align-items: stretch;
     width: 100%;
     margin: 0;

--- a/hlx_statics/blocks/tab/tab.css
+++ b/hlx_statics/blocks/tab/tab.css
@@ -133,7 +133,6 @@ main div.tab-wrapper .tab.vertical {
 }
 
 main.dev-docs  div.tab-wrapper .tab.vertical {
-    flex-direction: row;
     align-items: stretch;
     width: 100%;
     margin: 0;


### PR DESCRIPTION
## Description

Vertical Tab Block issue in dev biz 

In the devBiz we have no nav bar on the left and right. 

In this [PR](https://github.com/AdobeDocs/adp-devsite/pull/642/) added width: 100% so it takes whole screen for the vertical tabs.  

Issue happend Here: https://github.com/AdobeDocs/adp-devsite/pull/642/changes#diff-2b19c2abe07a4ee4fd1566314d215b483d33fb458d7a72b0537479918eaa8072R127

## Jira

[DEVSITE](https://jira.corp.adobe.com/browse/DEVSITE-2474)

## Test URL

**DevBiz:** 
Previous : https://stage--adp-devsite-stage--adobedocs.aem.page/test/baskar/code-block
Updated : https://devsite-2474--adp-devsite-stage--adobedocs.aem.page/test/baskar/code-block

**DevDoc:**
Previous : https://stage--adp-devsite-stage--adobedocs.aem.page/github-actions-test/blocks/tab/
Update: https://devsite-2474--adp-devsite-stage--adobedocs.aem.page/github-actions-test/blocks/tab/
