### PR TITLE
fix : miniresource card design issue

### DIFF
--- a/hlx_statics/blocks/mini-resource-card/mini-resource-card.css
+++ b/hlx_statics/blocks/mini-resource-card/mini-resource-card.css
@@ -4,7 +4,7 @@ main div.mini-resource-card-wrapper:has(.mini-resource-card.background-color-whi
 
 main div.mini-resource-card-wrapper div.mini-resource-card .card-container {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(var(--grid-columns, 3), 1fr);
   column-gap: 10px;
   row-gap: 30px;
   margin-top: auto;

--- a/hlx_statics/blocks/mini-resource-card/mini-resource-card.js
+++ b/hlx_statics/blocks/mini-resource-card/mini-resource-card.js
@@ -62,8 +62,10 @@ export default async function decorate(block) {
         decorateButtons(containerParent);
     }
     const grid_div = createTag('div', { class: 'card-container' });
+    let cardCount = 0;
     block.querySelectorAll('.mini-resource-card > div').forEach((resource) => {
         if (resource.querySelector(".button-container")) return;
+        cardCount += 1;
         removeEmptyPTags(resource);
         grid_div.appendChild(resource);
 
@@ -82,6 +84,9 @@ export default async function decorate(block) {
         pictureContainer.append(picture);
 
     });
+    if (cardCount > 0) {
+        grid_div.style.setProperty('--grid-columns', Math.min(cardCount, 3));
+    }
     block.appendChild(grid_div);
     if (block.classList.contains('primarybutton')) {
         block.appendChild(containerParent);


### PR DESCRIPTION
## Description

In the Mini Resources Card component, when only two cards are added, they appear aligned to the left because the layout is designed for three columns.

To improve the alignment, I updated the layout to adjust based on the card count. This helps center the cards properly when fewer items are present. However, the component currently supports a maximum of three cards only.

## Jira

https://jira.corp.adobe.com/browse/DEVSITE-2476

## Test URL

Previous : https://main--adp-devsite-stage--adobedocs.aem.page/test/baskar/mini-resource-card
Updated : https://mini-resource-code-bug--adp-devsite-stage--adobedocs.aem.page/test/baskar/mini-resource-card
