### PR TITLE
fix : infocard hover issue

### DIFF
--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -104,6 +104,8 @@ main :is(div.info-card-wrapper div.info-card.wide, div.infocard-wrapper div.info
   }
 }
 
-:is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) a:-webkit-any-link {
+main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) a,
+main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) a:hover,
+main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) a:focus {
   text-decoration: none;
 }


### PR DESCRIPTION
## Description

Fix : In the Info Card block, when no link is provided, hovering over the card still adds an underline to the text. 

## Jira

https://jira.corp.adobe.com/browse/DEVSITE-2479

## Test URL

Previous : https://main--adp-devsite-stage--adobedocs.aem.page/test/baskar/info-card
Updated : https://infocard-bug--adp-devsite-stage--adobedocs.aem.page/test/baskar/info-card