### PR TITLE
Devsite 1747

### DIFF
--- a/hlx_statics/blocks/header/header.js
+++ b/hlx_statics/blocks/header/header.js
@@ -996,6 +996,27 @@ function handleMenuButton(header) {
       document.body.style.overflow = ''; // Restore scrolling
     }
   });
+
+  // Suppress the slide-out animation when resizing from desktop to mobile.
+  // Without this, the sidenav animates from its desktop position to the hidden
+  // mobile position even though it was never visible on desktop.
+  const mobileQuery = window.matchMedia('(max-width: 768px)');
+  mobileQuery.addEventListener('change', () => {
+    const sideNav = document.querySelector('.side-nav');
+    if (!sideNav) return;
+    sideNav.classList.add('no-transition');
+    // Close the menu when switching between breakpoints
+    if (menuBtn.checked) {
+      menuBtn.checked = false;
+      sideNav.classList.remove('is-visible');
+      document.body.style.overflow = '';
+    }
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        sideNav.classList.remove('no-transition');
+      });
+    });
+  });
 }
 
 function hideSpinner() {

--- a/hlx_statics/blocks/side-nav/side-nav.css
+++ b/hlx_statics/blocks/side-nav/side-nav.css
@@ -255,6 +255,10 @@ main div.side-nav-wrapper .side-nav-menu-section .nav-playground-button a{
     transform: translateX(0);
   }
 
+  main div.side-nav-wrapper div.side-nav.no-transition {
+    transition: none;
+  }
+
   main div.side-nav-wrapper .side-nav-menu-section,
   main div.side-nav-wrapper .side-nav-section-label {
     display: block;


### PR DESCRIPTION
## Jira
[DEVSITE-1747](https://jira.corp.adobe.com/browse/DEVSITE-1747)

## Issue
- On desktop, .side-nav has no transform (natural position)
- When resizing to mobile, CSS applies transform: translateX(-256px) with transition: transform 0.3s ease-out
- The browser animates the sidenav sliding from its desktop position to the hidden mobile position — the unwanted "closing" animation

## Fix
- Add a CSS rule to suppress transition when .no-transition class is present
- Add a JS matchMedia listener that applies/removes the class during breakpoint crossings 

## Test
- Stage: https://stage--adp-devsite--adobedocs.aem.live/github-actions-test/test/no-sidenav-2
- DEVSITE-1747 Fix: https://devsite-1747--adp-devsite--adobedocs.aem.live/github-actions-test/test/no-sidenav-2