### PR TITLE
fix: surface dev server startup errors

### DIFF
--- a/dev.mjs
+++ b/dev.mjs
@@ -179,4 +179,7 @@ app.listen(PORT, async () => {
   // Initialize devsite paths after server starts
   await fetchDevsitePaths();
   isInitialized = true;
+}).on('error', (err) => {
+  console.error(err);
+  process.exit(1);
 });


### PR DESCRIPTION
## Description

Surface dev server startup errors (like port conflicts) instead of failing silently. Same approach as [devsite-runtime-connector](https://github.com/aemsites/devsite-runtime-connector/blob/9fc6e2ef18bdb3b81daed7ec502a5f11343f7a5c/test/dev/server.ts#L30).

## Ticket

https://jira.corp.adobe.com/browse/DEVSITE-2430

## Test

1. Run `npm run dev`
2. In a second terminal, run `npm run dev` again
3. Verify the second instance shows: `Error: listen EADDRINUSE: address already in use :::3000`

## Before

Silent failure — no error message when port is in use.

<img width="1725" height="741" alt="code-before" src="https://github.com/user-attachments/assets/85f1f280-9c9d-40a1-99d5-607ab1689c5b" />

## After

`Error: listen EADDRINUSE: address already in use :::3000`

<img width="1728" height="740" alt="code-after" src="https://github.com/user-attachments/assets/f952d7e5-9750-47ef-a751-02691a66abbc" />
