### PR TITLE
fix: transform icon shortcodes in local dev

### DIFF
--- a/dev.mjs
+++ b/dev.mjs
@@ -7,6 +7,25 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const PORT = process.env.DEV_PORT || 3000;
 
+// From: https://github.com/adobe/helix-html-pipeline/blob/fd858b582f92f953ace385abf97b3148801722e0/src/steps/rewrite-icons.js#L16
+const ICON_PATTERN = /(?<!(?:https?|urn)[^\s]*):(#?[a-z_-]+[a-z\d]*):/gi;
+
+// Based on: https://github.com/adobe/helix-html-pipeline/blob/fd858b582f92f953ace385abf97b3148801722e0/src/steps/rewrite-icons.js#L24-L35
+function rewriteIcons(html) {
+  const codeBlocks = [];
+  let processed = html.replace(/<(code|pre)[^>]*>[\s\S]*?<\/\1>/gi, (match) => {
+    codeBlocks.push(match);
+    return `__CODE_BLOCK_${codeBlocks.length - 1}__`;
+  });
+
+  processed = processed.replace(ICON_PATTERN, (match, iconName) => {
+    const name = iconName.startsWith('#') ? iconName.substring(1) : iconName;
+    return `<span class="icon icon-${name}"></span>`;
+  });
+
+  return processed.replace(/__CODE_BLOCK_(\d+)__/g, (_, index) => codeBlocks[index]);
+}
+
 const corsOptions = {
   origin: 'http://127.0.0.1:3000/',
   credentials: true,
@@ -131,6 +150,7 @@ app.use(async (req, res) => {
 
   if (source === 'docs' && contentType.includes('text/html')) {
     body = await resp.text();
+    body = rewriteIcons(body);
     // inject the head.html
     const [pre, post] = body.split('</head>');
     body = `${pre}


### PR DESCRIPTION
## Description

**Issue:** Icon shortcodes (`:icon-name:`) render on deploy but display as raw text in local dev.

**Root cause:** AEM's [`rewrite-icons.js`](https://github.com/adobe/helix-html-pipeline/blob/fd858b582f92f953ace385abf97b3148801722e0/src/steps/rewrite-icons.js#L16-L35) transforms `:icon:` → `<span>` on deploy. Local dev ([`dev.mjs`](https://github.com/AdobeDocs/adp-devsite/blob/1a7fcff7/dev.mjs#L132-L140)) bypasses AEM.

**Fix:** `dev.mjs` now transforms icon shortcodes, mimicking AEM's behavior:
- Uses AEM's regex pattern (avoids URL false positives)
- Skips `<code>`/`<pre>` blocks
- DevDocs only (DevBiz unaffected)

**Ticket:** [DEVSITE-2440](https://jira.corp.adobe.com/browse/DEVSITE-2440)

## Test

**DevDocs** ([3 servers](https://developer-stage.adobe.com/dev-docs-reference/localdev/): `dev-docs-reference`, `adp-devsite`, `devsite-runtime-connector`)

### 1. Fix verification — Icon renders in Superhero

| Before (local) | After (local) | Expected (stage) |
|----------------|---------------|------------------|
| <img width="520" height="387" alt="test-1-before" src="https://github.com/user-attachments/assets/2525251b-837f-4ea5-acbc-7f6e9cf6d3be" /> | <img width="521" height="384" alt="test-1-after" src="https://github.com/user-attachments/assets/3d906833-a5b4-42fe-b440-9ba872071ae8" /> | <img width="520" height="386" alt="test-1-stage" src="https://github.com/user-attachments/assets/97b90727-5686-46c4-90d8-1557a32ba6c9" /> |

### 2. Code block protection — No change expected

| After (local) | Expected (stage) |
|---------------|------------------|
| <img width="597" height="363" alt="test-2-after" src="https://github.com/user-attachments/assets/551f94b7-8090-461e-ba6e-07723da177e3" /> | <img width="594" height="355" alt="test-2-stage" src="https://github.com/user-attachments/assets/4e0454ed-1e1c-43b0-84ad-f093c4e5ae7f" /> |

**DevBiz** ([1 server](https://github.com/AdobeDocs/adp-devsite#local-development): `adp-devsite` via `npm run dev:aem`)

### 3. Sanity — No change expected

| After (local) | Expected (stage) |
|---------------|------------------|
| <img width="1485" height="1045" alt="test-3-local" src="https://github.com/user-attachments/assets/3c35b882-6690-4fb1-b803-862ad2888c1c" /> | <img width="1495" height="1044" alt="test-3-stage" src="https://github.com/user-attachments/assets/aec7b9e8-bd36-4c19-b14f-8b5cbbb9539d" /> |