### PR TITLE
6/25/26 EDS Release — stage → main

### DIFF
--- a/dev.mjs
+++ b/dev.mjs
@@ -7,6 +7,25 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const PORT = process.env.DEV_PORT || 3000;
 
+// From: https://github.com/adobe/helix-html-pipeline/blob/fd858b582f92f953ace385abf97b3148801722e0/src/steps/rewrite-icons.js#L16
+const ICON_PATTERN = /(?<!(?:https?|urn)[^\s]*):(#?[a-z_-]+[a-z\d]*):/gi;
+
+// Based on: https://github.com/adobe/helix-html-pipeline/blob/fd858b582f92f953ace385abf97b3148801722e0/src/steps/rewrite-icons.js#L24-L35
+function rewriteIcons(html) {
+  const codeBlocks = [];
+  let processed = html.replace(/<(code|pre)[^>]*>[\s\S]*?<\/\1>/gi, (match) => {
+    codeBlocks.push(match);
+    return `__CODE_BLOCK_${codeBlocks.length - 1}__`;
+  });
+
+  processed = processed.replace(ICON_PATTERN, (match, iconName) => {
+    const name = iconName.startsWith('#') ? iconName.substring(1) : iconName;
+    return `<span class="icon icon-${name}"></span>`;
+  });
+
+  return processed.replace(/__CODE_BLOCK_(\d+)__/g, (_, index) => codeBlocks[index]);
+}
+
 const corsOptions = {
   origin: 'http://127.0.0.1:3000/',
   credentials: true,
@@ -131,6 +150,7 @@ app.use(async (req, res) => {
 
   if (source === 'docs' && contentType.includes('text/html')) {
     body = await resp.text();
+    body = rewriteIcons(body);
     // inject the head.html
     const [pre, post] = body.split('</head>');
     body = `${pre}

--- a/dev.mjs
+++ b/dev.mjs
@@ -179,4 +179,7 @@ app.listen(PORT, async () => {
   // Initialize devsite paths after server starts
   await fetchDevsitePaths();
   isInitialized = true;
+}).on('error', (err) => {
+  console.error(err);
+  process.exit(1);
 });

--- a/hlx_statics/blocks/cards/cards.css
+++ b/hlx_statics/blocks/cards/cards.css
@@ -123,6 +123,10 @@ main div.cards-wrapper div.cards.wide div.three-card > div:last-child {
   main div.cards-wrapper div.cards > div {
     padding: 40px 0;
   }
+  main div.cards-wrapper {
+    width: 90% !important;
+    margin: auto;
+  }
 }
 
 @media screen and (max-width: 425px) {

--- a/hlx_statics/blocks/cards/cards.css
+++ b/hlx_statics/blocks/cards/cards.css
@@ -127,6 +127,12 @@ main div.cards-wrapper div.cards.wide div.three-card > div:last-child {
     width: 90% !important;
     margin: auto;
   }
+  main.dev-biz div.cards-wrapper div.cards.wide div.three-card {
+    width: 100% !important;
+  }
+  main.dev-biz div.cards-wrapper div.cards {
+    flex-direction: column;
+  }
 }
 
 @media screen and (max-width: 425px) {

--- a/hlx_statics/blocks/cards/cards.css
+++ b/hlx_statics/blocks/cards/cards.css
@@ -124,8 +124,7 @@ main div.cards-wrapper div.cards.wide div.three-card > div:last-child {
     padding: 40px 0;
   }
   main div.cards-wrapper {
-    width: 90% !important;
-    margin: auto;
+    width: 100% !important;
   }
   main.dev-biz div.cards-wrapper div.cards.wide div.three-card {
     width: 100% !important;

--- a/hlx_statics/blocks/cards/cards.css
+++ b/hlx_statics/blocks/cards/cards.css
@@ -82,6 +82,10 @@ main div.cards-wrapper div.cards > div img {
   margin-bottom: 24px;
 }
 
+main div.cards-wrapper div.cards.wide img {
+  height: 200px;
+}
+
 main div.cards-wrapper div.cards > div h3 {
   margin-bottom: 16px !important;
 }

--- a/hlx_statics/blocks/cards/cards.css
+++ b/hlx_statics/blocks/cards/cards.css
@@ -136,6 +136,9 @@ main div.cards-wrapper div.cards.wide div.three-card > div:last-child {
   main.dev-biz div.cards-wrapper div.cards > div > div {
     padding: 0;
   }
+  main div.cards-wrapper div.cards.wide img {
+    height: 150px !important;
+  }
 }
 
 @media screen and (max-width: 425px) {

--- a/hlx_statics/blocks/cards/cards.css
+++ b/hlx_statics/blocks/cards/cards.css
@@ -133,6 +133,9 @@ main div.cards-wrapper div.cards.wide div.three-card > div:last-child {
   main.dev-biz div.cards-wrapper div.cards {
     flex-direction: column;
   }
+  main.dev-biz div.cards-wrapper div.cards > div > div {
+    padding: 0;
+  }
 }
 
 @media screen and (max-width: 425px) {

--- a/hlx_statics/blocks/cards/cards.js
+++ b/hlx_statics/blocks/cards/cards.js
@@ -26,8 +26,7 @@ export default async function decorate(block) {
     decorateButtons(block);
   }
 
-  const isWide = block.classList.contains("wide") || block.getAttribute('data-wide') === 'true';
-  if (isWide) {
+  if (block.getAttribute('data-wide') === 'true') {
     block.classList.add('wide');
   }
 

--- a/hlx_statics/blocks/cards/cards.js
+++ b/hlx_statics/blocks/cards/cards.js
@@ -26,6 +26,11 @@ export default async function decorate(block) {
     decorateButtons(block);
   }
 
+  const isWide = block.classList.contains("wide") || block.getAttribute('data-wide') === 'true';
+  if (isWide) {
+    block.classList.add('wide');
+  }
+
   // for devdocs, the author can put in an attribute width to change the width of the cards.
   const width = block.getAttribute('data-width');
   if (width) {


### PR DESCRIPTION
## Release — `stage` → `main`

> **Commits ahead:** 31
> **Merge base:** `540b698`
> **Generated:** 2026-06-25

### Changes included

| # | PR | Title | Jira | Author | Approved by |
|---|-----|-------|------|--------|-------------|
| 1 | [#654](https://github.com/AdobeDocs/adp-devsite/pull/654) | update on the horizontalline error | [DEVSITE-2237](https://jira.corp.adobe.com/browse/DEVSITE-2237) | @louisachu | @melissag-ensemble |
| 2 | [#670](https://github.com/AdobeDocs/adp-devsite/pull/670) | Title align center | [DEVSITE-2477](https://jira.corp.adobe.com/browse/DEVSITE-2477) | @BaskarMitrah | @melissag-ensemble |
| 3 | [#667](https://github.com/AdobeDocs/adp-devsite/pull/667) | fix : miniresource card design issue | [DEVSITE-2476](https://jira.corp.adobe.com/browse/DEVSITE-2476) | @BaskarMitrah | @melissag-ensemble |
| 4 | [#672](https://github.com/AdobeDocs/adp-devsite/pull/672) | fix : infocard hover issue | [DEVSITE-2479](https://jira.corp.adobe.com/browse/DEVSITE-2479) | @BaskarMitrah | @melissag-ensemble |
| 5 | [#666](https://github.com/AdobeDocs/adp-devsite/pull/666) | Devbiz Codeblock Update | [DEVSITE-2474](https://jira.corp.adobe.com/browse/DEVSITE-2474) | @BaskarMitrah | @jiangy10 |
| 6 | [#673](https://github.com/AdobeDocs/adp-devsite/pull/673) | fix decoration of Code in Accordion | [DEVSITE-2193](https://jira.corp.adobe.com/browse/DEVSITE-2193) | @jiangy10 | @dianeba3 |
| 7 | [#674](https://github.com/AdobeDocs/adp-devsite/pull/674) | Devsite 1747 | [DEVSITE-1747](https://jira.corp.adobe.com/browse/DEVSITE-1747) | @jiangy10 | @melissag-ensemble |
| 8 | [#671](https://github.com/AdobeDocs/adp-devsite/pull/671) | Video block Alt | — | @BaskarMitrah | @timkim |
| 9 | [#668](https://github.com/AdobeDocs/adp-devsite/pull/668) | chore(ai-assistant): updated disclaimer text | — | @davids-ensemble | @melissag-ensemble, @timkim |
| 10 | [#669](https://github.com/AdobeDocs/adp-devsite/pull/669) | feat(ai-assistant): improve initial prompts | — | @davids-ensemble | @melissag-ensemble, @timkim |
| 11 | [#678](https://github.com/AdobeDocs/adp-devsite/pull/678) | fix: enable ai assitant for prod | — | @timkim | @melissag-ensemble |
| 12 | [#675](https://github.com/AdobeDocs/adp-devsite/pull/675) | fix: surface dev server startup errors | [DEVSITE-2430](https://jira.corp.adobe.com/browse/DEVSITE-2430) | @melissag-ensemble | @timkim |
| 13 | [#676](https://github.com/AdobeDocs/adp-devsite/pull/676) | fix: transform icon shortcodes in local dev | [DEVSITE-2440](https://jira.corp.adobe.com/browse/DEVSITE-2440) | @melissag-ensemble | @timkim |
| 14 | [#677](https://github.com/AdobeDocs/adp-devsite/pull/677) | feat : added wide in the cards component | [DEVSITE-2483](https://jira.corp.adobe.com/browse/DEVSITE-2483) | @BaskarMitrah | @melissag-ensemble |
| 15 | [#680](https://github.com/AdobeDocs/adp-devsite/pull/680) | fix : cards mobile responsive issue | [DEVSITE-2485](https://jira.corp.adobe.com/browse/DEVSITE-2485) | @BaskarMitrah | @melissag-ensemble |

---

### Descriptions

#### [1] #654 — update on the horizontalline error

**Jira:** [DEVSITE-2237](https://jira.corp.adobe.com/browse/DEVSITE-2237)
**Author:** @louisachu
**Approved by:** @melissag-ensemble
**Merged:** 2026-06-19

Fixes a rendering error affecting the HorizontalLine element on Express add-ons documentation pages.

#### [2] #670 — Title align center

**Jira:** [DEVSITE-2477](https://jira.corp.adobe.com/browse/DEVSITE-2477)
**Author:** @BaskarMitrah
**Approved by:** @melissag-ensemble
**Merged:** 2026-06-23

Corrects text alignment in the Title block so it centers properly on mobile and smaller screens.

#### [3] #667 — fix : miniresource card design issue

**Jira:** [DEVSITE-2476](https://jira.corp.adobe.com/browse/DEVSITE-2476)
**Author:** @BaskarMitrah
**Approved by:** @melissag-ensemble
**Merged:** 2026-06-23

Adjusts the Mini Resource Card layout to center cards when fewer than three are present (the component supports a maximum of three).

#### [4] #672 — fix : infocard hover issue

**Jira:** [DEVSITE-2479](https://jira.corp.adobe.com/browse/DEVSITE-2479)
**Author:** @BaskarMitrah
**Approved by:** @melissag-ensemble
**Merged:** 2026-06-23

Removes the hover underline that appeared on Info Card blocks when no link is set.

#### [5] #666 — Devbiz Codeblock Update

**Jira:** [DEVSITE-2474](https://jira.corp.adobe.com/browse/DEVSITE-2474)
**Author:** @BaskarMitrah
**Approved by:** @jiangy10
**Merged:** 2026-06-23

Scopes the code block tab spacing update to DevBiz only, reverting changes that had unintentionally affected DevDocs.

#### [6] #673 — fix decoration of Code in Accordion

**Jira:** [DEVSITE-2193](https://jira.corp.adobe.com/browse/DEVSITE-2193)
**Author:** @jiangy10
**Approved by:** @dianeba3
**Merged:** 2026-06-23

Fixes the text decoration of code rendered inside Accordion blocks.

#### [7] #674 — Devsite 1747

**Jira:** [DEVSITE-1747](https://jira.corp.adobe.com/browse/DEVSITE-1747)
**Author:** @jiangy10
**Approved by:** @melissag-ensemble
**Merged:** 2026-06-23

Suppresses the unwanted side-nav sliding animation that played when the viewport crossed the mobile breakpoint.

#### [8] #671 — Video block Alt

**Jira:** —
**Author:** @BaskarMitrah
**Approved by:** @timkim
**Merged:** 2026-06-24

Adds default alt text for videos without author-provided descriptions and fixes relative video path resolution across the Super Hero, Columns, Text, Carousel, and Embed blocks. ⚠️ No Jira ticket

#### [9] #668 — chore(ai-assistant): updated disclaimer text

**Jira:** —
**Author:** @davids-ensemble
**Approved by:** @melissag-ensemble, @timkim
**Merged:** 2026-06-24

Updates the AI assistant disclaimer text per the latest design. ⚠️ No Jira ticket

#### [10] #669 — feat(ai-assistant): improve initial prompts

**Jira:** —
**Author:** @davids-ensemble
**Approved by:** @melissag-ensemble, @timkim
**Merged:** 2026-06-24

Improves the AI assistant's initial suggested prompts. ⚠️ No Jira ticket

#### [11] #678 — fix: enable ai assitant for prod

**Jira:** —
**Author:** @timkim
**Approved by:** @melissag-ensemble
**Merged:** 2026-06-24

Enables the AI assistant in the production environment. ⚠️ No Jira ticket

#### [12] #675 — fix: surface dev server startup errors

**Jira:** [DEVSITE-2430](https://jira.corp.adobe.com/browse/DEVSITE-2430)
**Author:** @melissag-ensemble
**Approved by:** @timkim
**Merged:** 2026-06-24

Surfaces dev server startup errors such as port conflicts instead of failing silently.

#### [13] #676 — fix: transform icon shortcodes in local dev

**Jira:** [DEVSITE-2440](https://jira.corp.adobe.com/browse/DEVSITE-2440)
**Author:** @melissag-ensemble
**Approved by:** @timkim
**Merged:** 2026-06-24

Transforms icon shortcodes in local dev so they render the same way they do on deployed environments.

#### [14] #677 — feat : added wide in the cards component

**Jira:** [DEVSITE-2483](https://jira.corp.adobe.com/browse/DEVSITE-2483)
**Author:** @BaskarMitrah
**Approved by:** @melissag-ensemble
**Merged:** 2026-06-25

Adds a "wide" image option to the Cards component.

#### [15] #680 — fix : cards mobile responsive issue

**Jira:** [DEVSITE-2485](https://jira.corp.adobe.com/browse/DEVSITE-2485)
**Author:** @BaskarMitrah
**Approved by:** @melissag-ensemble
**Merged:** 2026-06-25

Fixes a mobile responsive layout issue in the Cards component.

---

### Notes

- ⚠️ No Jira ticket on: #671, #668, #669, #678.
- All PRs have at least one recorded approver.
- Note: DEVSITE-2474 also appears in the prior 6/18/26 release entry — #666 is the DevBiz-only follow-up to that earlier change.

---

**dev-docs-reference PR:** https://github.com/AdobeDocs/dev-docs-reference/pull/73