### PR TITLE
fix(ai-assistant): fixed rendered links not opening in a new tab

### DIFF
--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -59,7 +59,7 @@ export default async function decorate(block) {
           // @ts-expect-error - DOMPurify is not on the Window object
           window.DOMPurify.addHook('afterSanitizeAttributes', (node) => {
             console.log('afterSanitizeAttributes')
-            if ('data-ll' in node) {
+            if (node.hasAttribute('data-ll')) {
               node.setAttribute('daa-ll', node.getAttribute('data-ll'));
             }
           });

--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -45,7 +45,8 @@ export default async function decorate(block) {
            * @param {string} options.text
            */
           link({ href, title, text }) {
-            return `<a href="${href}" title="${title || text}" daa-ll="DevsiteAI Assistant:Message:Link:${title || text}|${href}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+            const analyticsLabel = `DevsiteAI Assistant:Message:Link:${title || text}|${href}`;
+            return `<a href="${href}" title="${title || text}" data-ll="${analyticsLabel}" target="_blank" rel="noopener noreferrer">${text}</a>`;
           },
         },
       });
@@ -53,6 +54,15 @@ export default async function decorate(block) {
         document.body,
         "https://unpkg.com/dompurify@^3/dist/purify.min.js",
         () => {
+          // @ts-expect-error - DOMPurify is not on the Window object
+          window.DOMPurify.setConfig({ ADD_ATTR: ["daa-ll", "daa-lh", "target"] });
+          // @ts-expect-error - DOMPurify is not on the Window object
+          window.DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+            console.log('afterSanitizeAttributes')
+            if ('data-ll' in node) {
+              node.setAttribute('daa-ll', node.getAttribute('data-ll'));
+            }
+          });
           restoreChatHistory();
         },
       );

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -58,11 +58,10 @@ export class ChatBubble {
       bubble.style.marginTop = "12px";
     }
 
-    // @ts-expect-error - marked is not on the Window type
-    contentElement.innerHTML = window.marked.parse(this.content);
+    this.#_renderContent(contentElement);
     bubble.appendChild(contentElement);
 
-    // Create actions for AI messages but don't append to DOM yet
+    // Create actions for AI messages
     if (this.source === "ai") {
       this._actionsContainer = createTag("div", {
         class: "chat-bubble-actions",
@@ -248,6 +247,18 @@ export class ChatBubble {
   }
 
   /**
+   * Renders this.content into a content element via marked + DOMPurify.
+   * @param {Element} contentElement
+   */
+  #_renderContent(contentElement) {
+    // @ts-expect-error - DOMPurify is not on the Window object
+    contentElement.innerHTML = window.DOMPurify.sanitize(
+      // @ts-expect-error - marked is not on the Window object
+      window.marked.parse(this.content),
+    );
+  }
+
+  /**
    * Updates the content of the chat bubble
    * @param {string} content
    */
@@ -255,11 +266,7 @@ export class ChatBubble {
     this.content = content;
     const contentElement = this.element.querySelector(".chat-bubble-content");
     if (contentElement) {
-      // @ts-expect-error - DOMPurify is not on the Window object
-      contentElement.innerHTML = window.DOMPurify.sanitize(
-        // @ts-expect-error - marked is not on the Window object
-        window.marked.parse(this.content),
-      );
+      this.#_renderContent(contentElement);
     }
   }
 


### PR DESCRIPTION
Adds `target` and analytics attributes to the allow list.

Jira: [ADPGENAI-204](https://jira.corp.adobe.com/browse/ADPGENAI-204)

There's still an issue for daa-ll attributes not being set sometimes but I'll open a different PR for that once I figure out the issue.