### PR TITLE
fix: code block hide the picker languages were not shown

### DIFF
--- a/hlx_statics/blocks/codeblock/codeblock.js
+++ b/hlx_statics/blocks/codeblock/codeblock.js
@@ -64,12 +64,8 @@ export default function decorate(block) {
   // get from block before additional children are added
   const panels = [...block.children].slice(0, tabContents.length);
 
-  const hasLanguagesParam = Boolean(block.getAttribute('data-languages')?.trim());
-  const languages = hasLanguagesParam
-    ? block.getAttribute('data-languages').split(',').map((language) => language.trim()).filter(Boolean)
-    : [];
-  // Group tabs only when data-languages is explicitly provided and valid.
-  const areTabsGrouped = hasLanguagesParam && languages.length > 1 && languages.length === tabContents.length;
+  const languages = block.getAttribute('data-languages')?.split(',').map((language) => language.trim()).filter(Boolean) ?? [];
+  const areTabsGrouped = languages.length > 0;
   const selectId = 'select-language';
   
   const controlBar = document.createElement('div');
@@ -105,7 +101,7 @@ export default function decorate(block) {
 
   const select = document.createElement('select');
   select.id = selectId;
-  select.style.display = hasLanguagesParam ? '' : 'none';
+  select.style.display = areTabsGrouped ? '' : 'none';
   select.addEventListener('change', handleSelectChange);
   rightControls.append(select);
 

--- a/hlx_statics/blocks/codeblock/codeblock.js
+++ b/hlx_statics/blocks/codeblock/codeblock.js
@@ -101,7 +101,11 @@ export default function decorate(block) {
 
   const select = document.createElement('select');
   select.id = selectId;
-  select.addEventListener('change', handleSelectChange);
+  if(!hasLanguagesParam) {
+    select.style.display = 'none';
+  } else {
+    select.addEventListener('change', handleSelectChange);
+  }
   rightControls.append(select);
 
   // set up customizable select (as opposed to classic which can't be styled) as described in https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select

--- a/hlx_statics/blocks/codeblock/codeblock.js
+++ b/hlx_statics/blocks/codeblock/codeblock.js
@@ -64,8 +64,12 @@ export default function decorate(block) {
   // get from block before additional children are added
   const panels = [...block.children].slice(0, tabContents.length);
 
-  const languages = block.getAttribute('data-languages')?.split(',').map((language) => language.trim()).filter(Boolean) ?? [];
-  const areTabsGrouped = languages.length > 1 && languages.length === tabContents.length;
+  const hasLanguagesParam = Boolean(block.getAttribute('data-languages')?.trim());
+  const languages = hasLanguagesParam
+    ? block.getAttribute('data-languages').split(',').map((language) => language.trim()).filter(Boolean)
+    : [];
+  // Group tabs only when data-languages is explicitly provided and valid.
+  const areTabsGrouped = hasLanguagesParam && languages.length > 1 && languages.length === tabContents.length;
   const selectId = 'select-language';
   
   const controlBar = document.createElement('div');
@@ -101,11 +105,8 @@ export default function decorate(block) {
 
   const select = document.createElement('select');
   select.id = selectId;
-  if(!hasLanguagesParam) {
-    select.style.display = 'none';
-  } else {
-    select.addEventListener('change', handleSelectChange);
-  }
+  select.style.display = hasLanguagesParam ? '' : 'none';
+  select.addEventListener('change', handleSelectChange);
   rightControls.append(select);
 
   // set up customizable select (as opposed to classic which can't be styled) as described in https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select

--- a/hlx_statics/blocks/codeblock/codeblock.js
+++ b/hlx_statics/blocks/codeblock/codeblock.js
@@ -3,12 +3,22 @@ import decoratePreformattedCode from '../../components/code.js';
 
 export default function decorate(block) {
   const handleSelectChange = () => {
-    // show tabpanel associated with selected option
+    const selectedOption = select.options[select.selectedIndex];
+    const selectedHeading = selectedOption?.getAttribute('heading');
     const panels = [...block.querySelectorAll('[role=tabpanel]')];
+    const tabs = [...block.querySelectorAll('[role=tab]')];
+    const tabIndexToSelect = areTabsGrouped
+      ? tabs.findIndex((tab) => tab.getAttribute('heading') === selectedHeading)
+      : select.selectedIndex;
+
+    tabs.forEach((tab, i) => {
+      tab.setAttribute('aria-selected', i === tabIndexToSelect);
+    });
+
     panels.forEach((panel, i) => {
       panel.classList.toggle('hidden', i !== select.selectedIndex);
     });
-  }
+  };
 
   const filterSelectOptions = (clickedTabId) => {
     const clickedTab = block.querySelector(`[role=tab][id='${clickedTabId}']`);
@@ -54,8 +64,8 @@ export default function decorate(block) {
   // get from block before additional children are added
   const panels = [...block.children].slice(0, tabContents.length);
 
-  const languages = block.getAttribute('data-languages')?.split(',').map(language => language.trim()) ?? [];
-  const areTabsGrouped = languages.length > 0;
+  const languages = block.getAttribute('data-languages')?.split(',').map((language) => language.trim()).filter(Boolean) ?? [];
+  const areTabsGrouped = languages.length > 1 && languages.length === tabContents.length;
   const selectId = 'select-language';
   
   const controlBar = document.createElement('div');
@@ -76,6 +86,7 @@ export default function decorate(block) {
     tab.setAttribute('role', 'tab');
     tab.setAttribute('type', 'button');
     tab.innerHTML = tabContent.innerHTML;
+    tab.setAttribute('heading', toClassName(tab.textContent));
     tab.addEventListener('click', handleTabClick);
 
     const isGroupAdded = [...tabs.children].find(existingTab => tab.textContent === existingTab.textContent);
@@ -90,7 +101,6 @@ export default function decorate(block) {
 
   const select = document.createElement('select');
   select.id = selectId;
-  select.classList.toggle('hidden', !areTabsGrouped);
   select.addEventListener('change', handleSelectChange);
   rightControls.append(select);
 
@@ -105,9 +115,9 @@ export default function decorate(block) {
     option.value = i;
     option.setAttribute('heading', toClassName(tabContent.textContent));
     option.setAttribute('aria-controls', `tabpanel-${i}`);
-    option.text = languages[i] ?? i;
+    option.text = languages[i] || tabContent.textContent.trim() || `Tab ${i + 1}`;
     select.append(option); 
-  })
+  });
 
   panels.forEach((panel, i) => {
     panel.className = 'tabs-panel';


### PR DESCRIPTION
## Description

Codeblock showing language picker even though language is not given

## Jira

https://jira.corp.adobe.com/browse/DEVSITE-2491

## Devdocs Test URL

Previous : https://main--adp-devsite--adobedocs.aem.page/github-actions-test/blocks/codeblock/code-block-without-picklist
Update : https://devsite-2491--adp-devsite--adobedocs.aem.page/github-actions-test/blocks/codeblock/code-block-without-picklist

## Regression Screenshot

Previous : 
<img width="1031" height="650" alt="image" src="https://github.com/user-attachments/assets/e2fea20c-af3d-4d34-bcaf-c0aa38b186c7" />

Update : 
<img width="1071" height="704" alt="image" src="https://github.com/user-attachments/assets/84c86af6-cb39-4d7b-8734-22a623ec2fb5" />
