### PR TITLE
feat(ai-assistant): add skip link to improve accessibility

### DIFF
--- a/hlx_statics/blocks/ai-assistant/ai-assistant.css
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.css
@@ -1,6 +1,41 @@
 /* Ai Assistant Floating Chat Bot */
 
 /*
+ * MARK: Skip Link
+ * Visually hidden "Skip to AI Assistant" link. Kept 1px (not display:none) so it
+ * stays in the accessibility tree and tab order; revealed on keyboard focus.
+ */
+.skip-to-ai-assistant {
+    position: absolute;
+    top: -1px;
+    left: -1px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+.skip-to-ai-assistant:focus,
+.skip-to-ai-assistant:focus-visible {
+    position: fixed;
+    top: 16px;
+    left: 16px;
+    z-index: 1000001; /* above the sticky global-nav header (z-index: 1000000) */
+    width: auto;
+    height: auto;
+    padding: 8px 16px;
+    overflow: visible;
+    background-color: #fff;
+    color: #292929;
+    font-size: 14px;
+    font-weight: 700;
+    text-decoration: none;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgb(0 0 0 / 25%);
+    outline: 2px solid #1473e6;
+    outline-offset: 2px;
+}
+
+/*
  * MARK: Root & Layout
  */
 .ai-assistant-wrapper {

--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -40,9 +40,6 @@ export default async function decorate(block) {
     document.body.prepend(skipLink);
   }
 
-  // Prefetch collections to warm cache — resolves before user opens chat
-  aiApiClient.getCollections();
-
   addExtraScriptWithLoad(
     document.body,
     "https://unpkg.com/marked@18.0.5/lib/marked.umd.js",

--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -16,6 +16,7 @@ import {
   createInputSection,
 } from "./ai-assistant_chat-ui.js";
 import {
+  CHAT_BUTTON_ID,
   CHAT_WINDOW_ID,
   CHAT_WINDOW_LABEL_ID,
   ELEMENTS,
@@ -27,6 +28,20 @@ import { createSuggestedQuestionsSection } from "./ai-assistant_suggested-questi
  * @param {Element} block - the ai-assistant block element
  */
 export default async function decorate(block) {
+  // a11y: a visually-hidden "Skip to AI Assistant" link
+  if (!document.getElementById("skip-to-ai-assistant")) {
+    const skipLink = createTag("a", {
+      id: "skip-to-ai-assistant",
+      class: "skip-to-ai-assistant",
+      href: `#${CHAT_BUTTON_ID}`,
+    });
+    skipLink.textContent = "Skip to AI Assistant";
+    document.body.prepend(skipLink);
+  }
+
+  // Prefetch collections to warm cache — resolves before user opens chat
+  aiApiClient.getCollections();
+
   addExtraScriptWithLoad(
     document.body,
     "https://unpkg.com/marked@18.0.5/lib/marked.umd.js",
@@ -51,12 +66,14 @@ export default async function decorate(block) {
         "https://unpkg.com/dompurify@3.4.11/dist/purify.min.js",
         () => {
           // @ts-expect-error - DOMPurify is not on the Window object
-          window.DOMPurify.setConfig({ ADD_ATTR: ["daa-ll", "daa-lh", "target"] });
+          window.DOMPurify.setConfig({
+            ADD_ATTR: ["daa-ll", "daa-lh", "target"],
+          });
           // @ts-expect-error - DOMPurify is not on the Window object
-          window.DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-            console.log('afterSanitizeAttributes')
-            if (node.hasAttribute('data-ll')) {
-              node.setAttribute('daa-ll', node.getAttribute('data-ll'));
+          window.DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+            console.log("afterSanitizeAttributes");
+            if (node.hasAttribute("data-ll")) {
+              node.setAttribute("daa-ll", node.getAttribute("data-ll"));
             }
           });
           restoreChatHistory();
@@ -93,7 +110,9 @@ export default async function decorate(block) {
   ELEMENTS.CHAT_WINDOW_CLEAR_BUTTON?.addEventListener("click", () => {
     const dialog = createClearDialog();
     chatWindow.appendChild(dialog);
-    /** @type {HTMLElement | null} */ (dialog.querySelector(".chat-window-dialog-cancel"))?.focus();
+    /** @type {HTMLElement | null} */ (
+      dialog.querySelector(".chat-window-dialog-cancel")
+    )?.focus();
   });
   ELEMENTS.CHAT_WINDOW_CLOSE_BUTTON?.addEventListener(
     "click",

--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -17,6 +17,7 @@ import {
 } from "./ai-assistant_chat-ui.js";
 import {
   CHAT_BUTTON_ID,
+  CHAT_SKIP_BUTTON_LABEL,
   CHAT_WINDOW_ID,
   CHAT_WINDOW_LABEL_ID,
   ELEMENTS,
@@ -35,7 +36,7 @@ export default async function decorate(block) {
       class: "skip-to-ai-assistant",
       href: `#${CHAT_BUTTON_ID}`,
     });
-    skipLink.textContent = "Skip to AI Assistant";
+    skipLink.textContent = CHAT_SKIP_BUTTON_LABEL;
     document.body.prepend(skipLink);
   }
 

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-ui.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-ui.js
@@ -7,6 +7,7 @@ import {
 } from "./ai-assistant_chat-controller.js";
 
 import {
+  CHAT_BUTTON_ID,
   CHAT_BUTTON_LABEL_CLEAR,
   CHAT_BUTTON_LABEL_CLOSE,
   CHAT_BUTTON_LABEL_OPEN,
@@ -150,6 +151,7 @@ export const createInputSection = () => {
 export const createChatButton = () => {
   const chatButton = createTag("button", {
     class: "chat-button",
+    id: CHAT_BUTTON_ID,
     type: "button",
     "aria-controls": CHAT_WINDOW_ID,
     "aria-expanded": "false",

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_constants.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_constants.js
@@ -3,6 +3,7 @@ export const CHAT_BUTTON_LABEL_OPEN = "Open AI Assistant";
 export const CHAT_BUTTON_LABEL_CLOSE = "Close AI Assistant";
 export const CHAT_BUTTON_LABEL_MINIMIZE = "Minimize AI Assistant";
 export const CHAT_BUTTON_LABEL_CLEAR = "Clear AI Assistant";
+export const CHAT_SKIP_BUTTON_LABEL = "Skip to AI Assistant";
 export const CHAT_BUTTON_ID = "ai-assistant-chat-button";
 export const CHAT_WINDOW_ID = "ai-assistant-chat-window";
 export const CHAT_WINDOW_LABEL_ID = "ai-assistant-label";

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_constants.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_constants.js
@@ -3,6 +3,7 @@ export const CHAT_BUTTON_LABEL_OPEN = "Open AI Assistant";
 export const CHAT_BUTTON_LABEL_CLOSE = "Close AI Assistant";
 export const CHAT_BUTTON_LABEL_MINIMIZE = "Minimize AI Assistant";
 export const CHAT_BUTTON_LABEL_CLEAR = "Clear AI Assistant";
+export const CHAT_BUTTON_ID = "ai-assistant-chat-button";
 export const CHAT_WINDOW_ID = "ai-assistant-chat-window";
 export const CHAT_WINDOW_LABEL_ID = "ai-assistant-label";
 /**


### PR DESCRIPTION
This adds a "Skip to AI Assistant" at the beginning of the body. 
The link is hidden from users but still accessible using the keyboard. 
This makes navigation easier for keyboard and screen reader users, advertising the existence of the assistant early in the tab order without changing where we insert the element.
Without this the users have to tab through the entire page before they reach the chat bubble.

Note:  The link becomes visible when focused to advertise its existence to sighted users.
> To be usable by all keyboard users, particularly sighted keyboard users, the link must:
>
> - be hidden by default
> - be accessible to keyboard navigation
> - become prominently visible when it is focused
> - properly set focus to the main content area when activated

https://webaim.org/techniques/skipnav/#:~:text=To%20be%20usable,activated