### PR TITLE
fix(ai-assistant): clamp markdown heading sizes in chat messages

### DIFF
--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -40,6 +40,7 @@ export default async function decorate(block) {
     document.body.prepend(skipLink);
   }
 
+  const headingSizes = ["XL", "M", "S", "XS", "XXS", "XXS"];
   addExtraScriptWithLoad(
     document.body,
     "https://unpkg.com/marked@18.0.5/lib/marked.umd.js",
@@ -47,6 +48,17 @@ export default async function decorate(block) {
       // @ts-expect-error - marked is not on the Window object
       window.marked.use({
         renderer: {
+          /**
+           * @param {Object} options
+           * @param {Array<unknown>} options.tokens
+           * @param {number} options.depth
+           */
+          heading({ tokens, depth }) {
+            /** @type {string} **/
+            const text = this.parser.parseInline(tokens);
+            const newDepth = Math.min(depth + 2, 6);
+            return `<h${newDepth} class="spectrum-Heading spectrum-Heading--size${headingSizes[newDepth - 1]}">${text}</h${newDepth}>\n`;
+          },
           /**
            * @param {Object} options
            * @param {string} options.href


### PR DESCRIPTION
## Summary
- AI-generated markdown could produce H1/H2 headings, which render far too large inside the chat window.
- Uses a custom renderer to limit heading sizes and add missing spectrum classes.

Jira: [ADPGENAI-214](https://jira.corp.adobe.com/browse/ADPGENAI-214)

| BEFORE | AFTER |
|--------|--------|
| <img width="486" height="844" alt="image" src="https://github.com/user-attachments/assets/fe9317ac-1220-4146-8417-760e5f8dcbdc" /> | <img width="525" height="875" alt="SCR-20260708-bfgl" src="https://github.com/user-attachments/assets/bf9c76f3-3d1c-496d-92c2-68e1e510620f" /> |

 