### PR TITLE
fix: fixed custom daa-ll getting overwritten

### DIFF
--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -69,7 +69,6 @@ export default async function decorate(block) {
           });
           // @ts-expect-error - DOMPurify is not on the Window object
           window.DOMPurify.addHook("afterSanitizeAttributes", (node) => {
-            console.log("afterSanitizeAttributes");
             if (node.hasAttribute("data-ll")) {
               node.setAttribute("daa-ll", node.getAttribute("data-ll"));
             }

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -1165,7 +1165,7 @@ export async function loadCustomAnalytic(domObj, path) {
  */
 export async function applyAnalytic(domObj = document) {
   domObj.querySelectorAll('a').forEach((a) => {
-    if (a.innerText.length > 0) {
+    if (a.innerText.length > 0 && !a.hasAttribute('daa-ll')) {
       a.setAttribute('daa-ll', a.innerText);
     }
   });


### PR DESCRIPTION
Noticed that on rare occasions a saved AI Assistant session gets restored before `applyAnalytic` runs. In practice this means that any custom `daa-ll` attributes gets overwritten when `applyAnalytic` runs.

I added a condition to bypass anchor tags that have `daa-ll` set already.

@timkim let me know if you think this might negatively affect something.

JIRA: [ADPGENAI-210](https://jira.corp.adobe.com/browse/ADPGENAI-210)