### PR TITLE
fix: make hardcoded prod nav links environment-aware

### DIFF
--- a/hlx_statics/blocks/header/header.js
+++ b/hlx_statics/blocks/header/header.js
@@ -6,7 +6,8 @@ import {
   getClosestFranklinSubfolder,
   decorateProfile,
   fetchProfileAvatar,
-  LoadingState
+  LoadingState,
+  setExpectedOrigin
 } from '../../scripts/lib-adobeio.js';
 import { readBlockConfig, getMetadata, fetchTopNavHtml, fetchTopButtonsNavHtml, IS_DEV_DOCS } from '../../scripts/lib-helix.js';
 import { loadFragment } from '../fragment/fragment.js';
@@ -615,7 +616,7 @@ async function initSearch() {
 
 function globalConsoleButton() {
   const div = createTag('div', { class: 'nav-console-button' });
-  div.innerHTML = `<a href="https://developer.adobe.com/console/" class="spectrum-Button spectrum-Button--outline spectrum-Button--secondary  spectrum-Button--sizeM">
+  div.innerHTML = `<a href="${setExpectedOrigin(window.location.origin, '/console/')}" class="spectrum-Button spectrum-Button--outline spectrum-Button--secondary  spectrum-Button--sizeM">
     <span class="spectrum-Button-label">
       Console
     </span>
@@ -805,7 +806,7 @@ function globalMobileDistributeButton() {
 
 function globalMobileConsoleButton() {
   const div = createTag('li', { class: 'nav-mobile-console-button' });
-  div.innerHTML = `<a href="https://developer.adobe.com/console/" class="spectrum-Button spectrum-Button--secondary  spectrum-Button--sizeM">
+  div.innerHTML = `<a href="${setExpectedOrigin(window.location.origin, '/console/')}" class="spectrum-Button spectrum-Button--secondary  spectrum-Button--sizeM">
     <span class="spectrum-Button-label">
       Console
     </span>
@@ -1072,7 +1073,7 @@ export default async function decorate(block) {
   // Add Adobe icon and title
   const iconContainer = createTag('p', { class: 'icon-adobe-container' });
   const title = "Adobe Developer";
-  const siteLink = createTag('a', { class: 'na-console-adobeio-link', href: "https://developer.adobe.com/" });
+  const siteLink = createTag('a', { class: 'na-console-adobeio-link', href: setExpectedOrigin(window.location.origin) });
   const iconLink = createTag('a', { class: 'na-console-adobeio-link', href: siteLink.href });
   iconLink.innerHTML = '<img class="icon icon-adobe" src="/hlx_statics/icons/adobe.svg" alt="adobe icon">';
   iconContainer.appendChild(iconLink);
@@ -1090,13 +1091,13 @@ export default async function decorate(block) {
     // Add Products link for documentation template
     if (isTopLevelNav(window.location.pathname)) {
       const homeLinkLi = createTag('li', {class: 'navigation-home'});
-      const homeLinkA = createTag('a', {href: 'https://developer.adobe.com', 'daa-ll': 'Home', 'fullPath': true});
+      const homeLinkA = createTag('a', {href: setExpectedOrigin(window.location.origin), 'daa-ll': 'Home', 'fullPath': true});
       homeLinkA.innerHTML = 'Products';
       homeLinkLi.append(homeLinkA);
       navigationLinks.append(homeLinkLi);
     } else {
       const productLi = createTag('li', {class: 'navigation-products'});
-      const productA = createTag('a', {href: 'https://developer.adobe.com/apis', 'daa-ll': 'Products',  'fullPath': true});
+      const productA = createTag('a', {href: setExpectedOrigin(window.location.origin, '/apis'), 'daa-ll': 'Products',  'fullPath': true});
       productA.innerHTML = 'Products';
       productLi.append(productA);
       navigationLinks.append(productLi);
@@ -1148,13 +1149,13 @@ export default async function decorate(block) {
 
     if (isTopLevelNav(window.location.pathname)) {
       const homeLinkLi = createTag('li', {class: 'navigation-home'});
-      const homeLinkA = createTag('a', {href: 'https://developer.adobe.com', 'daa-ll': 'Home'});
+      const homeLinkA = createTag('a', {href: setExpectedOrigin(window.location.origin), 'daa-ll': 'Home'});
       homeLinkA.innerHTML = 'Products';
       homeLinkLi.append(homeLinkA);
       navigationLinks.append(homeLinkLi);
     } else {
       const productLi = createTag('li', {class: 'navigation-products'});
-      const productA = createTag('a', {href: 'https://developer.adobe.com/apis', 'daa-ll': 'Products'});
+      const productA = createTag('a', {href: setExpectedOrigin(window.location.origin, '/apis'), 'daa-ll': 'Products'});
       productA.innerHTML = 'Products';
       productLi.append(productA);
       navigationLinks.append(productLi);

--- a/hlx_statics/blocks/side-nav/side-nav.js
+++ b/hlx_statics/blocks/side-nav/side-nav.js
@@ -2,6 +2,7 @@ import {
   createTag,
   getClosestFranklinSubfolder,
   isTopLevelNav,
+  setExpectedOrigin,
 } from "../../scripts/lib-adobeio.js";
 import {
   fetchSideNavHtml,
@@ -147,7 +148,7 @@ export default async function decorate(block) {
 
   // Add Products link first
   const productLi = createTag('li');
-  productLi.innerHTML = '<a href="https://developer.adobe.com/apis">Products</a>';
+  productLi.innerHTML = `<a href="${setExpectedOrigin(window.location.origin, '/apis')}">Products</a>`;
   menuUl.append(productLi);
 
   if(IS_DEV_DOCS) {
@@ -198,7 +199,7 @@ export default async function decorate(block) {
     });
   }
   if (!buttons.length) {
-    buttons.push({ href: 'https://developer.adobe.com/console/', title: 'Console' });
+    buttons.push({ href: setExpectedOrigin(window.location.origin, '/console/'), title: 'Console' });
   }
 
   buttons.forEach(({ href, title }, index) => {

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -818,16 +818,26 @@ export const setExpectedOrigin = (host, suffix = '') => {
   if (isLocalHostEnvironment(host)) {
     return `http://localhost:3000${suffix}`;
   }
-  if (isStageEnvironment(host)) {
+  if (isStageEnvironment(host, true)) {
     return `https://developer-stage.adobe.com${suffix}`;
-  }
-  if (isHlxPath(host)) {
-    return `${window.location.origin}${suffix}`;
   }
   if (isDevEnvironment(host)) {
     return `https://developer-dev.adobe.com${suffix}`;
   }
   return `https://developer.adobe.com${suffix}`;
+};
+
+/**
+ * Returns expected account.adobe.com origin based on the host
+ * @param {*} host The host
+ * @param {*} suffix A suffix to append
+ * @returns The expected account origin
+ */
+export const setExpectedAccountOrigin = (host, suffix = '') => {
+  if (isStageEnvironment(host, true)) {
+    return `https://stage.account.adobe.com${suffix}`;
+  }
+  return `https://account.adobe.com${suffix}`;
 };
 
 /**
@@ -931,7 +941,7 @@ function globalNavProfileTemplate(profile) {
             <div class="nav-profile-popover-divider">
               <hr />
             </div>
-            <a href="https://account.adobe.com/" data-prefetch=false class="spectrum-Button spectrum-Button--primary spectrum-Button--quiet spectrum-Button--sizeM nav-profile-popover-edit" daa-ll="profile-edit-button">
+            <a href="${setExpectedAccountOrigin(window.location.origin)}" data-prefetch=false class="spectrum-Button spectrum-Button--primary spectrum-Button--quiet spectrum-Button--sizeM nav-profile-popover-edit" daa-ll="profile-edit-button">
               Edit Profile
             </a>
             <a href="#" id="signOut" data-prefetch=false class="spectrum-Button spectrum-Button--secondary spectrum-Button--sizeM nav-profile-popover-sign-out" daa-ll="profile-sign-out-button">


### PR DESCRIPTION
### Ticket
[DEVSITE-2497](https://jira.corp.adobe.com/browse/DEVSITE-2497)

### Summary
Nav links were hardcoded to `developer.adobe.com` / `account.adobe.com`, sending stage/dev users to prod. They now resolve to the current environment's origin (desktop + mobile).

### Links to verify

| Link | Appears on | Expected |
|---|---|---|
| Header "Console" button | Desktop + Mobile | `{origin}/console/` |
| Header logo | Desktop + Mobile | `{origin}` |
| Top nav "Home" — top-level page | Desktop + Mobile | `{origin}` |
| Top nav "Products" — other pages | Desktop + Mobile | `{origin}/apis` |
| Dev Docs top nav "Home"/"Products" | Desktop (Mobile via side-nav) | `{origin}` or `{origin}/apis` |
| Side-nav "Products" — Dev Docs page | Desktop + Mobile | `{origin}/apis` |
| Side-nav "Console" — Dev Docs page | Desktop + Mobile | `{origin}/console/` |
| Profile popover "Edit Profile" — signed in | Desktop + Mobile | `{account}` |

`{origin}` / `{account}`:
- **Stage** — `developer-stage.adobe.com` / `stage.account.adobe.com`
- **Prod** — `developer.adobe.com` / `account.adobe.com`

### Test
Check each link's `href` **host** via Inspect / hover.

**Now (branch preview — covers the new logic):**
- [x] [DEVSITE-2497--adp-devsite-stage--adobedocs.aem.page](https://devsite-2497--adp-devsite-stage--adobedocs.aem.page/) → stage origins
- [x] [DEVSITE-2497--adp-devsite--adobedocs.aem.live](DEVSITE-2497--adp-devsite--adobedocs.aem.live) → prod origins

**After deploy (Fastly domains):**
- [x] Stage [developer-stage.adobe.com](https://developer-stage.adobe.com) — post-merge to `stage`
- [x] Prod [developer.adobe.com](https://developer.adobe.com) — post production release


