### PR TITLE
feat(ai-assistant): add landmark region to chat transcript

### DIFF
--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -18,6 +18,7 @@ import {
 import {
   CHAT_BUTTON_ID,
   CHAT_SKIP_BUTTON_LABEL,
+  CHAT_WINDOW_CONTENT_LABEL,
   CHAT_WINDOW_ID,
   CHAT_WINDOW_LABEL_ID,
   ELEMENTS,
@@ -103,7 +104,11 @@ export default async function decorate(block) {
   ELEMENTS.CHAT_WINDOW = chatWindow;
 
   chatWindow.appendChild(createChatWindowHeader());
-  const content = createTag("div", { class: "chat-window-content" });
+  const content = createTag("div", {
+    class: "chat-window-content",
+    role: "region",
+    "aria-label": CHAT_WINDOW_CONTENT_LABEL,
+  });
   ELEMENTS.CHAT_WINDOW_CONTENT = content;
   content.appendChild(createSuggestedQuestionsSection());
   chatWindow.appendChild(content);

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_constants.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_constants.js
@@ -7,6 +7,7 @@ export const CHAT_SKIP_BUTTON_LABEL = "Skip to AI Assistant";
 export const CHAT_BUTTON_ID = "ai-assistant-chat-button";
 export const CHAT_WINDOW_ID = "ai-assistant-chat-window";
 export const CHAT_WINDOW_LABEL_ID = "ai-assistant-label";
+export const CHAT_WINDOW_CONTENT_LABEL = "Chat messages";
 /**
  * @type {Record<string, HTMLElement | null>}
  */


### PR DESCRIPTION
Marks the chat window content as an ARIA region with an accessible
label so screen reader users can navigate directly to the transcript.

[ADPGENAI-221](https://jira.corp.adobe.com/browse/ADPGENAI-221)
