### PR TITLE
feat(ai-assistant): add screen-reader speaker attribution to chat messages

### DIFF
--- a/hlx_statics/blocks/ai-assistant/ai-assistant.css
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.css
@@ -571,6 +571,7 @@
     --bubble-background-color: #f8f8f8;
     --bubble-text-color: #292929;
 
+    position: relative;
     display: grid;
     grid-template-columns: auto;
     grid-template-rows: auto auto auto;
@@ -606,6 +607,15 @@
         --size: 24px;
         grid-area: avatar;
         align-self: start;
+    }
+
+    .chat-bubble-speaker {
+        position: absolute;
+        top: -1px;
+        left: -1px;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
     }
 
     .chat-bubble-content {

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -5,8 +5,15 @@ import { ensurePrismLoaded } from "../../scripts/prism-loader.js";
 import { aiApiClient } from "./ai-assistant_api-client.js";
 import { chatHistory } from "./ai-assistant_chat-history.js";
 import { createAiAvatar } from "./ai-assistant_chat-ui.js";
+import {
+  CHAT_BUBBLE_AI_LABEL,
+  CHAT_BUBBLE_USER_LABEL,
+} from "./ai-assistant_constants.js";
 
 export class ChatBubble {
+  /** Incrementing id so each bubble's speaker label has a unique DOM id for aria-labelledby. */
+  static #labelCounter = 0;
+
   /**
    * Creates a chat bubble for a single message.
    * @param {Object} options - Constructor options
@@ -33,6 +40,7 @@ export class ChatBubble {
     this.feedback = feedback;
     this.references = null;
     this._actionsContainer = null;
+    this._speakerLabelId = `chat-bubble-speaker-${ChatBubble.#labelCounter++}`;
     /** @type {HTMLElement} */
     this.element = this.#_init();
   }
@@ -41,7 +49,20 @@ export class ChatBubble {
    * Creates the DOM element
    */
   #_init() {
-    const bubble = createTag("div", { class: "chat-bubble" });
+    const bubble = createTag("div", {
+      class: "chat-bubble",
+      role: "article",
+      "aria-labelledby": this._speakerLabelId,
+    });
+    const speakerLabel = createTag("span", {
+      class: "chat-bubble-speaker",
+      id: this._speakerLabelId,
+      "aria-hidden": "true",
+    });
+    speakerLabel.textContent =
+      this.source === "user" ? CHAT_BUBBLE_USER_LABEL : CHAT_BUBBLE_AI_LABEL;
+    bubble.appendChild(speakerLabel);
+
     const contentElement = createTag("div", {
       class: "chat-bubble-content",
     });

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_constants.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_constants.js
@@ -8,6 +8,9 @@ export const CHAT_BUTTON_ID = "ai-assistant-chat-button";
 export const CHAT_WINDOW_ID = "ai-assistant-chat-window";
 export const CHAT_WINDOW_LABEL_ID = "ai-assistant-label";
 export const CHAT_WINDOW_CONTENT_LABEL = "Chat messages";
+export const CHAT_BUBBLE_USER_LABEL = "Your message";
+export const CHAT_BUBBLE_AI_LABEL = "Assistant";
+
 /**
  * @type {Record<string, HTMLElement | null>}
  */


### PR DESCRIPTION
Marks each chat bubble as role="article" with an aria-labelledby pointing
at a visually-hidden, aria-hidden label ("Your message" / "Assistant"),
so screen reader users can tell who sent each message without it being
read again as body content or duplicating the markdown reply's own
accessible names.

[ADPGENAI-222](https://jira.corp.adobe.com/browse/ADPGENAI-222)
