### PR TITLE
fix: clamp mini-resource-card body text at all breakpoints

### DIFF
--- a/hlx_statics/blocks/mini-resource-card/mini-resource-card.css
+++ b/hlx_statics/blocks/mini-resource-card/mini-resource-card.css
@@ -65,6 +65,13 @@ main div.mini-resource-card-wrapper div.mini-resource-card .mini-resource-card-b
   padding: 0 0 0 4% !important;
 }
 
+main div.mini-resource-card-wrapper div.mini-resource-card .mini-resource-card-body p {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 main div.mini-resource-card-wrapper .section-title {
   margin: 48px 0 40px 0;
 }
@@ -108,10 +115,6 @@ main div.mini-resource-card-wrapper > div.wide {
 
   main div.mini-resource-card .mini-resource-card-body p {
     font-size: 14px !important;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
   }
   main div.title-container>.title-wrapper>div {
     margin: 0 20px !important;


### PR DESCRIPTION
Ticket: https://jira.corp.adobe.com/browse/DEVSITE-1861

Extends the mobile-only line-clamp rule to every screen size so long body text is truncated with an ellipsis instead of overflowing the fixed-height card.

before: 
https://stage--adp-devsite-stage--adobedocs.aem.page/commerce/code-samples

now:
https://devsite-1861--adp-devsite-stage--adobedocs.aem.page/commerce/code-samples