### PR TITLE
fix: let inlinealert fill full content-area on no-layout pages

### DIFF
--- a/hlx_statics/blocks/inlinealert/inlinealert.css
+++ b/hlx_statics/blocks/inlinealert/inlinealert.css
@@ -134,8 +134,6 @@ main div.inlinealert-wrapper .spectrum-InLineAlert--warning .spectrum-InLineAler
     color: rgb(203, 93, 0);
 }
 main div.inlinealert-wrapper .inlinealert{
-    max-width: 1280px;
-    margin: 0 auto;
     font-size: 16px;
     width: 100%;
     display: inline-flex;


### PR DESCRIPTION
ticket: https://jira.corp.adobe.com/browse/DEVSITE-2487

Removes the block's self-imposed max-width: 1280px / margin: 0 auto, which fought the wider .grid-main-area on no-layout pages. Matches the getcredential block's pattern of leaving width control to the ancestor container.

Before: 
https://stage--adp-devsite-stage--adobedocs.aem.page/adobe-pass/api/dcr-api/interactive/

After:
https://devsite-2487--adp-devsite-stage--adobedocs.aem.page/adobe-pass/api/dcr-api/interactive/