### PR TITLE
feat(ai-assistant): add role="alert" for error message

### DIFF
--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -278,11 +278,17 @@ export class ChatBubble {
   /**
    * Updates the content of the chat bubble
    * @param {string} content
+   * @param {Object} [options]
+   * @param {boolean} [options.alert=false] - When true, marks the content element
+   * `role="alert"` so screen readers announce it immediately (APG Alert pattern / WCAG 4.1.3).
    */
-  updateContent(content) {
+  updateContent(content, { alert = false } = {}) {
     this.content = content;
     const contentElement = this.element.querySelector(".chat-bubble-content");
     if (contentElement) {
+      if (alert) {
+        contentElement.setAttribute("role", "alert");
+      }
       this.#_renderContent(contentElement);
     }
   }

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
@@ -362,7 +362,7 @@ export const handleUserQuery = async (
   const showErrorMessage = (message = GENERIC_ERROR_MESSAGE) => {
     targetBubble.hideThinking();
     targetBubble.hideStreamingCursor();
-    targetBubble.updateContent(message);
+    targetBubble.updateContent(message, { alert: true });
     return;
   };
 


### PR DESCRIPTION
This should make the screen reader announce the error message the moment it shows up.

The AI assistant doesn't currently work on this aem.page URLs so it will always show an error message: https://feat-ai-assistant-error-alert--adp-devsite--adobedocs.aem.page/

JIRA: [ADPGENAI-224](https://jira.corp.adobe.com/browse/ADPGENAI-224)