### PR TITLE
feat(ai-assistant): add feed announcement for assistant responses

### DIFF
--- a/hlx_statics/blocks/ai-assistant/ai-assistant.css
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.css
@@ -1,6 +1,26 @@
 /* Ai Assistant Floating Chat Bot */
 
 /*
+ * MARK: Screen-reader announcer
+ * Visually-hidden live regions (role="log" + role="status") used to announce
+ * completed assistant replies and the "responding…" state to screen readers.
+ * Kept 1px (not display:none) so the regions remain in the accessibility tree
+ * and can announce; decoupled from the visible transcript.
+ */
+.chat-announcer {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+}
+
+/*
  * MARK: Skip Link
  * Visually hidden "Skip to AI Assistant" link. Kept 1px (not display:none) so it
  * stays in the accessibility tree and tab order; revealed on keyboard focus.

--- a/hlx_statics/blocks/ai-assistant/ai-assistant.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant.js
@@ -24,6 +24,7 @@ import {
   ELEMENTS,
 } from "./ai-assistant_constants.js";
 import { createSuggestedQuestionsSection } from "./ai-assistant_suggested-questions.js";
+import { createAnnouncerRegions } from "./ai-assistant_announcer.js";
 
 /**
  * Decorates the ai-assistant block
@@ -116,6 +117,11 @@ export default async function decorate(block) {
 
   panel.appendChild(createChatButton());
   panel.appendChild(chatWindow);
+
+  // a11y: visually-hidden live regions for screen-reader announcements, kept
+  // outside the toggled chat-window so they stay in the DOM (a live region
+  // inside a `display:none` ancestor won't announce).
+  panel.appendChild(createAnnouncerRegions());
 
   block.appendChild(panel);
 

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_announcer.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_announcer.js
@@ -13,7 +13,7 @@ import {
  * long enough for the screen reader to read it, short enough that the log
  * doesn't grow unbounded.
  */
-const ANNOUNCEMENT_TIMEOUT_MS = 7000;
+const ANNOUNCEMENT_TIMEOUT_MS = 30_000;
 
 /**
  * Creates the visually-hidden live regions used to announce assistant activity

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_announcer.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_announcer.js
@@ -1,0 +1,91 @@
+// @ts-check
+import { createTag } from "../../scripts/lib-adobeio.js";
+import {
+  CHAT_ANNOUNCER_ID,
+  CHAT_STATUS_ID,
+  CHAT_STATUS_RESPONDING,
+  ELEMENTS,
+} from "./ai-assistant_constants.js";
+
+/**
+ * How long an appended announcement node lingers in the DOM before it is
+ * removed. Mirrors @react-aria/live-announcer's LIVEREGION_TIMEOUT_DELAY (7s):
+ * long enough for the screen reader to read it, short enough that the log
+ * doesn't grow unbounded.
+ */
+const ANNOUNCEMENT_TIMEOUT_MS = 7000;
+
+/**
+ * Creates the visually-hidden live regions used to announce assistant activity
+ * to screen readers, kept deliberately separate from the visible transcript.
+ *
+ * The visible `.chat-bubble-content` gets a full `innerHTML` replace on every
+ * streamed chunk (see `updateContent`), so it must never itself be a live
+ * region, that would announce every partial word. Instead this mirrors
+ * Adobe's own `@react-aria/live-announcer` pattern:
+ *   - a `role="log"` region (implicit `aria-live="polite"`,
+ *     `aria-atomic="false"`) that announces by appending a fresh node per
+ *     completed message, and
+ *   - a separate `role="status"` region for the transient "Assistant is
+ *     responding…" indicator.
+ *
+ * @returns {HTMLElement} container holding both regions, ready to append to the DOM
+ */
+export function createAnnouncerRegions() {
+  const container = createTag("div", { class: "chat-announcer" });
+
+  const announcer = createTag("div", {
+    id: CHAT_ANNOUNCER_ID,
+    role: "log",
+    "aria-live": "polite",
+    "aria-atomic": "false",
+    "aria-relevant": "additions",
+  });
+
+  const status = createTag("div", {
+    id: CHAT_STATUS_ID,
+    role: "status",
+  });
+
+  container.appendChild(announcer);
+  container.appendChild(status);
+
+  ELEMENTS.CHAT_ANNOUNCER = announcer;
+  ELEMENTS.CHAT_STATUS = status;
+
+  return container;
+}
+
+/**
+ * Announces a completed message to screen readers by appending a brand-new node
+ * (rather than mutating an existing node's `textContent`), so repeated or
+ * similar replies still trigger re-announcement. The node is removed after a
+ * timeout to keep the log from growing unbounded.
+ *
+ * @param {string} message - plain-text message to announce
+ */
+export function announce(message) {
+  const announcer = ELEMENTS.CHAT_ANNOUNCER;
+  if (!announcer || !message) return;
+
+  const node = createTag("div", {});
+  node.textContent = message;
+  announcer.appendChild(node);
+
+  window.setTimeout(() => node.remove(), ANNOUNCEMENT_TIMEOUT_MS);
+}
+
+/**
+ * Toggles the "Assistant is responding…" status indicator. This is a single,
+ * transient status value (not sequential history), so it lives in the
+ * `role="status"` region (implicit `aria-live="polite"`), decoupled from the
+ * announcer log.
+ *
+ * @param {boolean} isResponding
+ */
+export function setResponding(isResponding) {
+  const status = ELEMENTS.CHAT_STATUS;
+  if (!status) return;
+
+  status.textContent = isResponding ? CHAT_STATUS_RESPONDING : "";
+}

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -293,6 +293,16 @@ export class ChatBubble {
     }
   }
 
+  /**
+   * Returns the rendered message as plain text.
+   *
+   * @returns {string}
+   */
+  getPlainText() {
+    const contentElement = this.element.querySelector(".chat-bubble-content");
+    return contentElement?.textContent?.trim() ?? "";
+  }
+
   scrollIntoView() {
     this.element.scrollIntoView({
       behavior: "smooth",
@@ -427,10 +437,7 @@ export class ChatBubble {
         rel: "noopener noreferrer",
       });
       a.textContent = title || url;
-      a.setAttribute(
-        "daa-ll",
-        `DevsiteAI Assistant:Message:Sources:Link`,
-      );
+      a.setAttribute("daa-ll", `DevsiteAI Assistant:Message:Sources:Link`);
       li.appendChild(a);
       list.appendChild(li);
     });

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-bubble.js
@@ -278,11 +278,17 @@ export class ChatBubble {
   /**
    * Updates the content of the chat bubble
    * @param {string} content
+   * @param {Object} [options]
+   * @param {boolean} [options.alert=false] - When true, marks the content element
+   * `role="alert"` so screen readers announce it immediately (APG Alert pattern / WCAG 4.1.3).
    */
-  updateContent(content) {
+  updateContent(content, { alert = false } = {}) {
     this.content = content;
     const contentElement = this.element.querySelector(".chat-bubble-content");
     if (contentElement) {
+      if (alert) {
+        contentElement.setAttribute("role", "alert");
+      }
       this.#_renderContent(contentElement);
     }
   }

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
@@ -17,6 +17,7 @@ import {
   showSuggestedQuestions,
   updateSuggestedQuestions,
 } from "./ai-assistant_suggested-questions.js";
+import { announce, setResponding } from "./ai-assistant_announcer.js";
 
 let userScrolledUp = false;
 let lastScrollTop = 0;
@@ -358,8 +359,11 @@ export const handleUserQuery = async (
 
   const targetBubble = sendMessage({ content: "Thinking", source: "ai" });
   targetBubble.showThinking();
+  // a11y: announce the "responding" state while thinking/streaming is active,
+  setResponding(true);
 
   const showErrorMessage = (message = GENERIC_ERROR_MESSAGE) => {
+    setResponding(false);
     targetBubble.hideThinking();
     targetBubble.hideStreamingCursor();
     targetBubble.updateContent(message, { alert: true });
@@ -428,10 +432,14 @@ export const handleUserQuery = async (
       },
       onComplete: async () => {
         hideStopButton();
+        setResponding(false);
         if (!responseContent) {
           targetBubble.hideThinking();
           responseContent = "_Response stopped by user._";
           targetBubble.updateContent(responseContent);
+          // a11y: announce the completed reply once, as plain text, 
+          // from the final content only 
+          announce(targetBubble.getPlainText());
           updateSuggestedQuestions(INITIAL_SUGGESTED_QUESTIONS);
           window.setTimeout(
             () =>
@@ -441,6 +449,8 @@ export const handleUserQuery = async (
           return;
         }
         targetBubble.completeBubble();
+        // a11y: announce the completed reply once, as plain text.
+        announce(targetBubble.getPlainText());
         chatHistory.updateLast({
           content: responseContent,
           references: accumulatedReferences,

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
@@ -362,7 +362,7 @@ export const handleUserQuery = async (
   const showErrorMessage = (message = GENERIC_ERROR_MESSAGE) => {
     targetBubble.hideThinking();
     targetBubble.hideStreamingCursor();
-    targetBubble.updateContent(message);
+    targetBubble.updateContent(message, { alert: true });
     return;
   };
 

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
@@ -3,6 +3,8 @@ import { aiApiClient } from "./ai-assistant_api-client.js";
 import { ChatBubble } from "./ai-assistant_chat-bubble.js";
 import { chatHistory } from "./ai-assistant_chat-history.js";
 import {
+  CHAT_BUBBLE_AI_LABEL,
+  CHAT_BUBBLE_USER_LABEL,
   CHAT_BUTTON_LABEL_MINIMIZE,
   CHAT_BUTTON_LABEL_OPEN,
   ELEMENTS,
@@ -353,9 +355,20 @@ export const handleUserQuery = async (
 
   hideSuggestedQuestions();
 
+  // Clicking a suggested-question button then hides that button, which would
+  // otherwise drop focus to the document body (the main browser window). Move
+  // focus back into the chat window's input so keyboard/screen-reader users stay
+  // oriented and can immediately type a follow-up. This mirrors where focus
+  // already sits after a typed submission.
+  textarea.focus();
+
   const suggestedQuestionsDelayMs = 600;
 
   sendMessage({ content: messageContent, source: "user" });
+  // a11y: confirm the message that was just sent. This matters most for
+  // suggested-question clicks, where the sent text differs from the button's
+  // short label and the user never typed it themselves.
+  announce(`${CHAT_BUBBLE_USER_LABEL}: ${messageContent}`);
 
   const targetBubble = sendMessage({ content: "Thinking", source: "ai" });
   targetBubble.showThinking();
@@ -437,9 +450,9 @@ export const handleUserQuery = async (
           targetBubble.hideThinking();
           responseContent = "_Response stopped by user._";
           targetBubble.updateContent(responseContent);
-          // a11y: announce the completed reply once, as plain text, 
-          // from the final content only 
-          announce(targetBubble.getPlainText());
+          // a11y: announce the completed reply once, as plain text,
+          // from the final content only
+          announce(`${CHAT_BUBBLE_AI_LABEL}: ${targetBubble.getPlainText()}`);
           updateSuggestedQuestions(INITIAL_SUGGESTED_QUESTIONS);
           window.setTimeout(
             () =>
@@ -450,7 +463,7 @@ export const handleUserQuery = async (
         }
         targetBubble.completeBubble();
         // a11y: announce the completed reply once, as plain text.
-        announce(targetBubble.getPlainText());
+        announce(`${CHAT_BUBBLE_AI_LABEL}: ${targetBubble.getPlainText()}`);
         chatHistory.updateLast({
           content: responseContent,
           references: accumulatedReferences,

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_constants.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_constants.js
@@ -10,6 +10,9 @@ export const CHAT_WINDOW_LABEL_ID = "ai-assistant-label";
 export const CHAT_WINDOW_CONTENT_LABEL = "Chat messages";
 export const CHAT_BUBBLE_USER_LABEL = "Your message";
 export const CHAT_BUBBLE_AI_LABEL = "Assistant";
+export const CHAT_ANNOUNCER_ID = "ai-assistant-announcer";
+export const CHAT_STATUS_ID = "ai-assistant-status";
+export const CHAT_STATUS_RESPONDING = "Assistant is responding…";
 
 /**
  * @type {Record<string, HTMLElement | null>}
@@ -24,6 +27,8 @@ export const ELEMENTS = {
   CHAT_WINDOW: null,
   CHAT_WINDOW_CONTENT: null,
   CHAT_SUGGESTED_QUESTIONS: null,
+  CHAT_ANNOUNCER: null,
+  CHAT_STATUS: null,
 };
 /**
  * @type {Array<{id?: string | null; label: string; question: string;}>}


### PR DESCRIPTION
### [ADPGENAI-224](https://jira.corp.adobe.com/browse/ADPGENAI-224)

This should make the screen reader announce the error message the moment it shows up.

The AI assistant doesn't currently work on this aem.page URLs so it will always show an error message: https://feat-ai-assistant-error-alert--adp-devsite--adobedocs.aem.page/

### [ADPGENAI-223](https://jira.corp.adobe.com/browse/ADPGENAI-223)

This adds an announcer to the AI Assistant which can be used to announce text to screenreaders programmatically.
When a new message from the assistant completes streaming we use the announcer to insert the text content in the feed element.
I've also fixed some focus issues when picking a suggested prompt

Video: https://github.com/user-attachments/assets/2c7c78cf-eac6-4220-a892-10333c08c9e5