### PR TITLE
refactor(ai-assistant): use Bedrock sessionId instead of history concatenenation

### DIFF
--- a/hlx_statics/blocks/ai-assistant/ai-assistant_api-client.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_api-client.js
@@ -6,6 +6,7 @@ import { isProdEnvironment } from "../../scripts/lib-adobeio.js";
  * @typedef {Object} RequestBody
  * @property {string} query
  * @property {string} [collectionId]
+ * @property {string} [sessionId]
  */
 
 /**
@@ -379,20 +380,21 @@ export class AiApiClient {
   }
 
   /**
-   * Makes a query request with conversation history
+   * Makes a streaming query request.
+   *
    * @param {Object} options - Query options
    * @param {string} options.query - The user's query
-   * @param {string} [options.context] - Optional conversation context/history
    * @param {string} [options.systemPrompt] - Optional system prompt instructions
    * @param {string|null} [options.collectionId] - Optional collection ID for the query
+   * @param {string|null} [options.sessionId] - Bedrock session id from a prior response; omitted on the first request
    * @param {Partial<StreamRequestCallbacks>} options.callbacks
    * @returns {Promise<void>}
    */
   async query({
     query,
-    context = "",
     systemPrompt = "",
     collectionId = null,
+    sessionId = null,
     callbacks = {},
   }) {
     const defaultSystemPrompt = `
@@ -405,7 +407,6 @@ export class AiApiClient {
         <system>
           ${systemPrompt || defaultSystemPrompt}
         </system>
-        ${context ? `<history>\n${context}\n</history>` : ""}
         <question>
           ${query}
         </question>
@@ -413,6 +414,9 @@ export class AiApiClient {
     };
     if (collectionId) {
       body.collectionId = collectionId;
+    }
+    if (sessionId) {
+      body.sessionId = sessionId;
     }
 
     return this.streamRequest({

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-controller.js
@@ -383,10 +383,6 @@ export const handleUserQuery = async (
     return;
   };
 
-  // TODO: We'll have to decide how much context to send to the AI.
-  // -2 because we want to exclude the current user message and the thinking message
-  const queryContext = chatHistory.getContextForAI({ excludeLast: 2 });
-
   let responseContent = "";
   /** @type {import('./ai-assistant_chat-history.js').ChatReference[]} */
   let accumulatedReferences = [];
@@ -395,10 +391,14 @@ export const handleUserQuery = async (
 
   await aiApiClient.query({
     query: messageContent,
-    context: queryContext,
     collectionId,
+    sessionId: chatHistory.getSessionId(),
     callbacks: {
       onMetadata: (data) => {
+        // Persist the session id so the next request continues the same Bedrock session.
+        if (data.sessionId) {
+          chatHistory.setSessionId(data.sessionId);
+        }
         if (data.requestId) {
           chatHistory.updateLast({ id: data.requestId });
           targetBubble.setMessageId(data.requestId);

--- a/hlx_statics/blocks/ai-assistant/ai-assistant_chat-history.js
+++ b/hlx_statics/blocks/ai-assistant/ai-assistant_chat-history.js
@@ -30,6 +30,7 @@
  * @typedef {Object} Conversation
  * @property {ChatMessage[]} messages
  * @property {SuggestedQuestion[]|null} suggestedQuestions
+ * @property {string|null} sessionId - Bedrock session id for the conversation
  */
 
 export class ChatHistory {
@@ -56,6 +57,7 @@ export class ChatHistory {
       this._cache = {
         messages: this._sanitizeMessages(parsed?.messages ?? []),
         suggestedQuestions: parsed?.suggestedQuestions ?? null,
+        sessionId: parsed?.sessionId ?? null,
       };
       return this._cache;
     } catch (error) {
@@ -70,7 +72,7 @@ export class ChatHistory {
    * @private
    */
   _emptyConversation() {
-    return { messages: [], suggestedQuestions: null };
+    return { messages: [], suggestedQuestions: null, sessionId: null };
   }
 
   /**
@@ -152,6 +154,26 @@ export class ChatHistory {
   }
 
   /**
+   * Gets the Bedrock session id for the current conversation.
+   * @returns {string|null}
+   */
+  getSessionId() {
+    return this._getConversation().sessionId ?? null;
+  }
+
+  /**
+   * Stores the Bedrock session id for the current conversation. Overwrites any
+   * existing value, so a fresh id minted after an expiry-triggered reset is
+   * reused transparently on subsequent requests. No-ops when unchanged.
+   * @param {string|null} sessionId
+   */
+  setSessionId(sessionId) {
+    const conversation = this._getConversation();
+    if (conversation.sessionId === sessionId) return;
+    this._save({ ...conversation, sessionId });
+  }
+
+  /**
    * Gets messages formatted for AI context
    * @param {Object} [options]
    * @param {number} [options.excludeLast=2] - Number of recent messages to exclude (0 = include all)
@@ -203,6 +225,7 @@ export class ChatHistory {
       const serializable = {
         messages: this._sanitizeMessages(conversation.messages),
         suggestedQuestions: conversation.suggestedQuestions ?? null,
+        sessionId: conversation.sessionId ?? null,
       };
       sessionStorage.setItem(
         ChatHistory.STORAGE_KEY,


### PR DESCRIPTION
Adopt Bedrock's native session management ([ADPGENAI-181](https://jira.corp.adobe.com/browse/ADPGENAI-181)) for retrieve-generate: persist the sessionId returned in the first response's metadata event and send it on every subsequent request, so history is maintained server-side rather than packed into the query string.

- chat-history: persist sessionId in the sessionStorage-backed Conversation with get/setSessionId accessors; clear() drops it with the conversation
- api-client: query() drops the <history> block and accepts sessionId
- chat-controller: send the stored sessionId and overwrite it from each metadata event, so a fresh id after an expiry reset is reused transparently

The suggested-questions path (collectResponse) keeps its own context concatenation until the next PR.

JIRA: [ADPGENAI-228](https://jira.corp.adobe.com/browse/ADPGENAI-228)
URL: https://feat-ai-assistant-bedrock-id--adp-devsite--adobedocs.aem.page/