### PR TITLE
fix : codeblock border issue

### DIFF
--- a/hlx_statics/blocks/tab/tab.css
+++ b/hlx_statics/blocks/tab/tab.css
@@ -33,7 +33,8 @@ main div.tab-wrapper > div:not(.background-color-navy) .tab-button:hover {
 }
 
 main div.tab-wrapper div.tab-content:has(.sub-content-wrapper) .code-toolbar pre {
-  border-radius: 0;
+  border-bottom-left-radius: 2vh;
+  border-bottom-right-radius: 2vh;
 }
 
 main div.tab-wrapper div.code-toolbar pre.line-numbers {

--- a/hlx_statics/blocks/tab/tab.css
+++ b/hlx_statics/blocks/tab/tab.css
@@ -33,8 +33,7 @@ main div.tab-wrapper > div:not(.background-color-navy) .tab-button:hover {
 }
 
 main div.tab-wrapper div.tab-content:has(.sub-content-wrapper) .code-toolbar pre {
-  border-bottom-left-radius: 2vh;
-  border-bottom-right-radius: 2vh;
+    border-radius: 0 0 2vh 2vh;
 }
 
 main div.tab-wrapper div.code-toolbar pre.line-numbers {

--- a/hlx_statics/blocks/tab/tab.css
+++ b/hlx_statics/blocks/tab/tab.css
@@ -32,6 +32,10 @@ main div.tab-wrapper > div:not(.background-color-navy) .tab-button:hover {
     color: white !important;
 }
 
+main div.tab-wrapper div.tab-content:has(.sub-content-wrapper) .code-toolbar pre {
+  border-radius: 0;
+}
+
 main div.tab-wrapper div.code-toolbar pre.line-numbers {
     padding-top: 3.5em;
 }


### PR DESCRIPTION
## Description

**Code Block Border Issue:**
When the header is present, we don't need to apply a border radius to the code block. It looks a little inconsistent compared to the version without the header. I've fixed this issue in this PR.

## Jira

https://jira.corp.adobe.com/browse/DEVSITE-2509

## Test URL

Previous : https://main--adp-devsite-stage--adobedocs.aem.page/test/baskar/tab
Updated : https://codeblock-border-fix--adp-devsite-stage--adobedocs.aem.page/test/baskar/tab

## Regression

Previous 
<img width="1902" height="354" alt="image" src="https://github.com/user-attachments/assets/a3765a06-9e18-4561-bf79-98726af7acc4" />

Update 
<img width="1897" height="356" alt="image" src="https://github.com/user-attachments/assets/e507797c-70ce-4362-bbe9-98d44141fc6d" />

## Fix 

Previous 
<img width="1902" height="593" alt="image" src="https://github.com/user-attachments/assets/c55d6c2d-55fd-4a72-880a-bb139bdd3403" />

Update 
<img width="1895" height="561" alt="image" src="https://github.com/user-attachments/assets/8889208d-d870-4f67-8093-80cb67853320" />
