### PR TITLE
fix : tab block font color issue

### DIFF
--- a/hlx_statics/blocks/tab/tab.css
+++ b/hlx_statics/blocks/tab/tab.css
@@ -32,6 +32,10 @@ main div.tab-wrapper > div:not(.background-color-navy) .tab-button:hover {
     color: white !important;
 }
 
+main div.tab-wrapper > div.background-color-navy .tab-content {
+    color: white;
+}
+
 main div.tab-wrapper div.tab-content:has(.sub-content-wrapper) .code-toolbar pre {
     border-radius: 0 0 2vh 2vh;
 }


### PR DESCRIPTION
## Description

I found an issue with the Tabs block code block.

When the background color is set to Navy, the tab block text remains black by default, making it difficult to read. In the other blocks, the text automatically changes to white when the background is Navy, but the Tabs block wasn't following the same behavior.

I updated the Tabs block in this PR to make it consistent with the other components, and it's now working as expected.

## Jira

https://jira.corp.adobe.com/browse/DEVSITE-2510

## Test URL

Previous : https://main--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/tab&index=1
Updated : https://tab-color-issue--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/tab&index=1

## Regression

Previous : https://main--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/tab&index=0

<img width="1911" height="996" alt="image" src="https://github.com/user-attachments/assets/82f69b6c-5e08-4a26-9edc-3fc30aadf997" />

Updated : https://tab-color-issue--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/tab&index=0

<img width="1919" height="851" alt="image" src="https://github.com/user-attachments/assets/c2e88661-d30b-4f8f-8398-0dc6ae646e50" />

## Fix 

Previous 
<img width="1919" height="774" alt="image" src="https://github.com/user-attachments/assets/719b4bde-87e7-430d-9118-3476122eaf53" />

Updated
<img width="1919" height="756" alt="image" src="https://github.com/user-attachments/assets/0cb70a67-c9bc-4e5d-9bb5-c70756ed4565" />
