### PR TITLE
update redirect option

### DIFF
--- a/dev.mjs
+++ b/dev.mjs
@@ -123,7 +123,7 @@ app.use(async (req, res) => {
   console.log(`Fetching upstream url: ${upstreamUrl}`);
 
   // For font files, request uncompressed data to avoid decoding issues
-  const fetchOptions = {};
+  const fetchOptions = {redirect: 'manual'};
   if (req.path.includes('.otf') || req.path.includes('.woff2') || req.path.includes('.ttf')) {
     fetchOptions.headers = {
       'Accept-Encoding': 'identity'


### PR DESCRIPTION
Due to the change in devsite-runtime-connector - https://github.com/aemsites/devsite-runtime-connector/pull/97 - the connector will now returns real 301 redirects when a request hits the wrong trailing-slash form of a page, the fetch call in dev.mjs needs to change ot to stop auto-following (change to use redirect using manual) and hand back the raw 301+ location header to whatever status and headers it receives.  