### PR TITLE
Add client-side fallback for trailing-slash mismatches

### DIFF
--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -1222,7 +1222,7 @@ function toggleTrailingSlash(path) {
  */
 async function redirectOnTrailingSlashMismatch() {
   const candidate = toggleTrailingSlash(window.location.pathname);
-  const resp = await fetch(candidate);
+  const resp = await fetch(candidate, { method: 'HEAD' });
   if (resp.ok) {
     window.location.pathname = candidate;
     return true;

--- a/hlx_statics/scripts/lib-adobeio.js
+++ b/hlx_statics/scripts/lib-adobeio.js
@@ -1202,6 +1202,35 @@ export async function getdevsitePathFile() {
 };
 
 /**
+ * Toggles the trailing slash on a path: strips it if present, adds it if absent.
+ * @param {string} path
+ * @returns {string}
+ */
+function toggleTrailingSlash(path) {
+  return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : `${path}/`;
+}
+
+/**
+ * Checks whether the sibling trailing-slash form of the current path resolves
+ * to a real page, and redirects to it if so. EDS treats a folder-index page
+ * (needs a trailing slash) and a direct-file page (no trailing slash) as two
+ * distinct resources, unlike Gatsby which tolerated either form for the same
+ * page. External links/bookmarks predating the migration often use the
+ * "wrong" form for a given page, which otherwise 404s even though the page
+ * exists under the other form.
+ * @returns {Promise<boolean>} true if a redirect was performed
+ */
+async function redirectOnTrailingSlashMismatch() {
+  const candidate = toggleTrailingSlash(window.location.pathname);
+  const resp = await fetch(candidate);
+  if (resp.ok) {
+    window.location.pathname = candidate;
+    return true;
+  }
+  return false;
+}
+
+/**
  * @returns Fetches and redirects page based on redirects.json
  */
 export async function redirect() {
@@ -1248,16 +1277,22 @@ export async function redirect() {
       if (resp.ok) {
         const redirectList = await resp.json();
         // apply redirect
+        let matched = false;
         redirectList.data.forEach((redirect) => {
           if(window.location.pathname === redirect?.Source) {
-            window.location.pathname = redirect?.Destination
+            window.location.pathname = redirect?.Destination;
+            matched = true;
           }
         });
-      } else {
-        return null;
+        if (matched) {
+          return;
+        }
       }
     }
   }
+
+  // no curated redirect applied - fall back to a trailing-slash mismatch check
+  await redirectOnTrailingSlashMismatch();
 }
 
 /**


### PR DESCRIPTION
EDS treats a folder-index page and a direct-file page as distinct resources based on the trailing slash, unlike Gatsby which tolerated either form. External links/bookmarks predating the migration often use the wrong form and 404 even though the page exists under the other form.

The connector (devsite-runtime-connector) already returns a real 301 for this case, but Helix's content-bus integration discards non-200 responses from custom content sources and substitutes its own generic 404, so the redirect never reaches real users. This client-side fallback checks, from the 404 page, whether the sibling slash-form resolves and redirects there if so - it runs after the curated redirects.json lookup so intentional page-move redirects still take priority.

Before:
https://stage--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/table

Now:
https://devsite-2506-test--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/table will redirect to 
https://devsite-2506-test--adp-devsite-stage--adobedocs.aem.page/dev-docs-reference/blocks/table/

bug:
https://jira.corp.adobe.com/browse/DEVSITE-2506