### PR TITLE
infocard updates : navigation , compact , reverse

### DIFF
--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -318,6 +318,15 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compa
   padding: 0;
 }
 
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact {
+  max-width: 1280px;
+  margin: auto;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact > ul >li {
+  max-width: 100%;
+}
+
 @media (max-width: 767px) {
   main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact>ul {
     grid-template-columns: 1fr;

--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -179,6 +179,7 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
   opacity: 1;
   transform: translateX(0);
   transition: transform 0.4s ease, opacity 0.4s ease;
+  margin: auto;
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-viewport>ul>li.hide {

--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -146,8 +146,6 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
   padding: 0;
 }
 
-/* Arrows now live in their own grid columns beside the viewport, instead of
-   being absolutely positioned on top of the card image. */
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-carousel-nav {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
@@ -169,6 +167,7 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
   display: grid;
   grid-template-columns: repeat(var(--info-card-visible), 1fr);
   gap: 40px;
+  padding: 0;
   width: 100%;
   margin: 0;
   list-style: none;
@@ -292,6 +291,11 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compa
   height: auto;
   padding: 0;
   line-height: 1.4;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  line-clamp: 3;
+  -webkit-line-clamp: 3;
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact .cards-card-body .card-heading {
@@ -314,7 +318,7 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compa
   margin: auto;
 }
 
-main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact > ul >li {
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact>ul>li {
   max-width: 100%;
 }
 

--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -151,6 +151,7 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 40px;
+  max-width: 1300px;
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul>li {
@@ -189,11 +190,11 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-prev {
-  left: -8%;
+  left: 12%;
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-next {
-  right: -8%;
+  right: 12%;
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav:disabled {

--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -36,7 +36,7 @@ main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)
   background-color: white;
 }
 
-main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) .cards-card-body > :is(h1, h2, h3, h4, h5, h6) {
+main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) .cards-card-body> :is(h1, h2, h3, h4, h5, h6) {
   overflow: hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -107,7 +107,7 @@ main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)
   color: rgb(0, 0, 0);
 }
 
-main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) .cards-card-body > p {
+main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) .cards-card-body>p {
   overflow: hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -138,4 +138,179 @@ main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)
 main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) a:hover,
 main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) a:focus {
   text-decoration: none;
+}
+
+/* navigation */
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation {
+  position: relative;
+  margin: auto;
+  padding: 0 56px;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 40px;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul>li {
+  width: 100%;
+  opacity: 1;
+  transform: translateX(0);
+  transition: transform 0.4s ease, opacity 0.4s ease;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul>li.hide {
+  opacity: 0;
+  transform: translateX(30px);
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid #d0d0d0;
+  border-radius: 50%;
+  background: #fff;
+  color: #555;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav:hover {
+  color: #000;
+  border-color: #999;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-prev {
+  left: -8%;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-next {
+  right: -8%;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard)>ul>li>a {
+  display: flex;
+  flex-direction: column;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).reverse>ul>li>a {
+  flex-direction: column-reverse;
+}
+
+@media (max-width: 1024px) {
+  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation {
+    padding: 0 48px;
+  }
+
+  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul {
+    grid-template-columns: 1fr;
+    gap: 24px;
+    justify-items: center;
+  }
+
+  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul>li {
+    width: 100%;
+    max-width: 400px;
+  }
+
+  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul>li img {
+    width: 100%;
+  }
+
+  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-prev {
+    left: 0;
+  }
+
+  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-next {
+    right: 0;
+  }
+}
+
+@media (min-width: 767px) and (max-width: 1024px) {
+  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-prev {
+    left: 10%;
+  }
+
+  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-next {
+    right: 10%;
+  }
+}
+
+/* compact */
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact>ul {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px 18px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact>ul>li {
+  width: 100%;
+  border: 1px solid #ebebeb;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact>ul>li:hover {
+  border-color: #b1b1b1;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact>ul>li>a,
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact>ul>li>div {
+  display: flex;
+  gap: 10px;
+  padding: 16px;
+  box-sizing: border-box;
+  background: #fff;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact>ul>li img {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+  border-radius: 10px;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact .cards-card-body {
+  height: auto;
+  padding: 0;
+  line-height: 1.4;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact .cards-card-body .card-heading {
+  display: inline;
+  margin: 0;
+  padding: 0;
+  color: #000;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact .cards-card-body>p {
+  display: inline;
+  margin: 5px;
+  padding: 0;
+}
+
+@media (max-width: 767px) {
+  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact>ul {
+    grid-template-columns: 1fr;
+  }
 }

--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -154,6 +154,12 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
   max-width: 1300px;
 }
 
+/* main.dev-docs :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 40px;
+} */
+
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul>li {
   width: 100%;
   opacity: 1;
@@ -258,6 +264,10 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compa
   padding: 0;
   margin: 0;
   list-style: none;
+}
+
+main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)>ul>li{
+  max-width: 100%;
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact>ul>li {

--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -142,39 +142,52 @@ main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)
 
 /* navigation */
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation {
-  position: relative;
   margin: auto;
-  padding: 0 56px;
+  padding: 0;
 }
 
-main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul {
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-carousel-nav {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  max-width: 1300px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0 12px;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-viewport {
+  overflow: hidden;
+  width: 100%;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-viewport>ul {
   --info-card-visible: 3;
   display: grid;
   grid-template-columns: repeat(var(--info-card-visible), 1fr);
   gap: 40px;
-  width: fit-content;
-  max-width: 1300px;
-  margin-left: auto;
-  margin-right: auto;
+  width: 100%;
+  margin: 0;
 }
 
-main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul>li {
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-viewport>ul>li {
   width: 100%;
   opacity: 1;
   transform: translateX(0);
   transition: transform 0.4s ease, opacity 0.4s ease;
+  margin: auto;
 }
 
-main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul>li.hide {
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-viewport>ul>li.hide {
   opacity: 0;
   transform: translateX(30px);
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 10;
+  position: static;
+  flex-shrink: 0;
+  z-index: 1;
   width: 32px;
   height: 32px;
   padding: 0;
@@ -188,21 +201,9 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
   cursor: pointer;
 }
 
-main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav[style*="top"] {
-  transform: none;
-}
-
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav:hover {
   color: #000;
   border-color: #999;
-}
-
-main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-prev {
-  left: 12%;
-}
-
-main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-next {
-  right: 12%;
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav:disabled {
@@ -210,51 +211,38 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
   cursor: not-allowed;
 }
 
-main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard)>ul>li>a {
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard) ul>li>a {
   display: flex;
   flex-direction: column;
 }
 
-main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).reverse>ul>li>a {
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).reverse ul>li>a {
   flex-direction: column-reverse;
 }
 
 @media (max-width: 1024px) {
   main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation {
-    padding: 0 48px;
+    padding: 0;
   }
 
-  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul {
+  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-carousel-nav {
+    gap: 8px;
+    padding: 0 4px;
+  }
+
+  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-viewport>ul {
     grid-template-columns: 1fr;
     gap: 24px;
     justify-items: center;
   }
 
-  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul>li {
+  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-viewport>ul>li {
     width: 100%;
     max-width: 400px;
   }
 
-  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul>li img {
+  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-viewport>ul>li img {
     width: 100%;
-  }
-
-  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-prev {
-    left: 0;
-  }
-
-  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-next {
-    right: 0;
-  }
-}
-
-@media (min-width: 767px) and (max-width: 1024px) {
-  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-prev {
-    left: 10%;
-  }
-
-  main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav-next {
-    right: 10%;
   }
 }
 

--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -1,4 +1,4 @@
-main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)>ul {
+main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) ul {
   list-style: none;
   margin-top: 0px;
   margin-bottom: 0px;
@@ -19,14 +19,14 @@ main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)
   text-align: center;
 }
 
-main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)>ul>li {
+main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) ul>li {
   max-width: 402px;
   border: 1px solid transparent;
   border-radius: 4px;
   border-color: rgb(235, 235, 235);
 }
 
-main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)>ul>li:hover {
+main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) ul>li:hover {
   border-color: rgb(177, 177, 177);
 }
 
@@ -78,7 +78,7 @@ main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)
   margin-top: 0;
 }
 
-main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)>ul>li img {
+main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) ul>li img {
   width: 400px;
   aspect-ratio: 4 / 3;
   object-fit: cover;
@@ -119,12 +119,12 @@ main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)
   color: rgb(71, 71, 71) !important;
 }
 
-main :is(div.info-card-wrapper div.info-card.wide, div.infocard-wrapper div.infocard.wide)>ul>li img {
+main :is(div.info-card-wrapper div.info-card.wide, div.infocard-wrapper div.infocard.wide) ul>li img {
   aspect-ratio: 16 / 9;
 }
 
 @media screen and (min-width : 350px) and (max-width : 400px) {
-  main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)>ul>li img {
+  main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) ul>li img {
     width: 100%;
     object-fit: cover;
   }

--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -151,14 +151,11 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 40px;
+  width: fit-content;
   max-width: 1300px;
+  margin-left: auto;
+  margin-right: auto;
 }
-
-/* main.dev-docs :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 40px;
-} */
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul>li {
   width: 100%;
@@ -188,6 +185,10 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
   align-items: center;
   justify-content: center;
   cursor: pointer;
+}
+
+main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav[style*="top"] {
+  transform: none;
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-nav:hover {
@@ -264,10 +265,6 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compa
   padding: 0;
   margin: 0;
   list-style: none;
-}
-
-main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)>ul>li{
-  max-width: 100%;
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compact>ul>li {

--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -171,6 +171,7 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
   gap: 40px;
   width: 100%;
   margin: 0;
+  list-style: none;
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-viewport>ul>li {

--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -1,4 +1,4 @@
-main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard) ul {
+main :is(div.info-card-wrapper div.info-card, div.infocard-wrapper div.infocard)>ul {
   list-style: none;
   margin-top: 0px;
   margin-bottom: 0px;
@@ -146,6 +146,8 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
   padding: 0;
 }
 
+/* Arrows now live in their own grid columns beside the viewport, instead of
+   being absolutely positioned on top of the card image. */
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-carousel-nav {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
@@ -176,7 +178,6 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
   opacity: 1;
   transform: translateX(0);
   transition: transform 0.4s ease, opacity 0.4s ease;
-  margin: auto;
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation .info-card-viewport>ul>li.hide {

--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -151,7 +151,7 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: 12px;
-  max-width: 1300px;
+  max-width: 1400px;
   margin-left: auto;
   margin-right: auto;
   padding: 0 12px;

--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -148,8 +148,9 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navig
 }
 
 main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).navigation>ul {
+  --info-card-visible: 3;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(var(--info-card-visible), 1fr);
   gap: 40px;
   width: fit-content;
   max-width: 1300px;

--- a/hlx_statics/components/info-card.js
+++ b/hlx_statics/components/info-card.js
@@ -15,6 +15,10 @@ function initializeNavigation(block, ul) {
   if (cards.length <= 3) return;
 
   block.querySelectorAll('.info-card-nav').forEach((btn) => btn.remove());
+  block.querySelectorAll('.info-card-viewport').forEach((el) => {
+    el.replaceWith(...el.childNodes);
+  });
+  block.querySelectorAll('.info-card-carousel-nav').forEach((el) => el.remove());
 
   const createNav = (direction, path) => {
     const btn = createTag('button', {
@@ -33,8 +37,14 @@ function initializeNavigation(block, ul) {
   const prevBtn = createNav('prev', 'M15 18L9 12L15 6');
   const nextBtn = createNav('next', 'M9 18L15 12L9 6');
 
-  block.prepend(prevBtn);
-  block.append(nextBtn);
+  const viewport = createTag('div', { class: 'info-card-viewport' });
+  const navWrapper = createTag('div', { class: 'info-card-carousel-nav' });
+
+  ul.parentNode.insertBefore(navWrapper, ul);
+  viewport.appendChild(ul);
+  navWrapper.appendChild(prevBtn);
+  navWrapper.appendChild(viewport);
+  navWrapper.appendChild(nextBtn);
 
   const getVisibleCount = () => {
     if (window.innerWidth <= 1024) {
@@ -44,13 +54,15 @@ function initializeNavigation(block, ul) {
   };
 
   let visible = getVisibleCount();
-  let page = 0;
+  let index = 0;
   let rafId = null;
 
+  const getMaxIndex = () => Math.max(0, cards.length - visible);
+
   const update = () => {
-    const maxPage = Math.ceil(cards.length / visible) - 1;
-    const start = Math.min(page * visible, cards.length - visible);
-    const shown = cards.slice(start, start + visible);
+    const maxIndex = getMaxIndex();
+    index = Math.min(index, maxIndex);
+    const shown = cards.slice(index, index + visible);
     if (rafId !== null) {
       cancelAnimationFrame(rafId);
       rafId = null;
@@ -67,43 +79,26 @@ function initializeNavigation(block, ul) {
       });
       requestAnimationFrame(() => {
         shown.forEach((card) => card.classList.remove('hide'));
-        positionArrows();
       });
       rafId = null;
     });
 
-    prevBtn.disabled = page === 0;
-    nextBtn.disabled = page >= maxPage;
+    prevBtn.disabled = index === 0;
+    nextBtn.disabled = index >= maxIndex;
   };
 
   const syncGridToVisible = () => {
     ul.style.setProperty('--info-card-visible', visible);
   };
 
-  const ARROW_GAP = 12;
-
-  const positionArrows = () => {
-    const blockRect = block.getBoundingClientRect();
-    const ulRect = ul.getBoundingClientRect();
-
-    const leftOffset = Math.max(0, ulRect.left - blockRect.left - prevBtn.offsetWidth - ARROW_GAP);
-    const rightOffset = Math.max(0, blockRect.right - ulRect.right - nextBtn.offsetWidth - ARROW_GAP);
-    const topOffset = (ulRect.top - blockRect.top) + (ulRect.height / 2);
-
-    prevBtn.style.left = `${leftOffset}px`;
-    nextBtn.style.right = `${rightOffset}px`;
-    prevBtn.style.top = `${topOffset}px`;
-    nextBtn.style.top = `${topOffset}px`;
-  };
-
-  const changePage = (step) => {
-    const maxPage = Math.ceil(cards.length / visible) - 1;
-    page = Math.max(0, Math.min(page + step, maxPage));
+  const changeIndex = (step) => {
+    const maxIndex = getMaxIndex();
+    index = Math.max(0, Math.min(index + step, maxIndex));
     update();
   };
 
-  prevBtn.onclick = () => changePage(-1);
-  nextBtn.onclick = () => changePage(1);
+  prevBtn.onclick = () => changeIndex(-1);
+  nextBtn.onclick = () => changeIndex(1);
 
   let resizeRaf = null;
   const handleResize = () => {
@@ -113,11 +108,9 @@ function initializeNavigation(block, ul) {
       const newVisible = getVisibleCount();
       if (newVisible !== visible) {
         visible = newVisible;
-        page = 0;
+        index = Math.min(index, getMaxIndex());
         syncGridToVisible();
         update();
-      } else {
-        positionArrows();
       }
     });
   };

--- a/hlx_statics/components/info-card.js
+++ b/hlx_statics/components/info-card.js
@@ -80,7 +80,7 @@ function initializeNavigation(block, ul) {
     ul.style.setProperty('--info-card-visible', visible);
   };
 
-  const ARROW_GAP = 12; 
+  const ARROW_GAP = 12;
 
   const positionArrows = () => {
     const blockRect = block.getBoundingClientRect();

--- a/hlx_statics/components/info-card.js
+++ b/hlx_statics/components/info-card.js
@@ -1,12 +1,85 @@
 import { createTag, removeEmptyPTags, decorateButtons } from '../scripts/lib-adobeio.js';
 import {
   createOptimizedPicture,
+  getMetadata,
 } from '../scripts/lib-helix.js';
 import {
   applyVideoContainer,
   getVideoTitle,
   parseVideoSource,
 } from '../scripts/video.js';
+
+function initializeNavigation(block, ul) {
+  const cards = [...ul.children];
+  if (cards.length <= 3) return;
+
+  block.querySelectorAll('.info-card-nav').forEach((btn) => btn.remove());
+
+  const createNav = (direction, path) => {
+    const btn = createTag('button', {
+      class: `info-card-nav info-card-nav-${direction}`,
+      'aria-label': direction === 'prev' ? 'Previous' : 'Next',
+    });
+
+    btn.innerHTML = `<svg viewBox="0 0 24 24" fill="none" width="16" height="16">
+      <path d="${path}" stroke="currentColor" stroke-width="2"
+        stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>`;
+
+    return btn;
+  };
+
+  const prevBtn = createNav('prev', 'M15 18L9 12L15 6');
+  const nextBtn = createNav('next', 'M9 18L15 12L9 6');
+
+  block.prepend(prevBtn);
+  block.append(nextBtn);
+
+  let visible = window.innerWidth <= 1024 ? 1 : 3;
+  let page = 0;
+
+  const update = () => {
+    const maxPage = Math.ceil(cards.length / visible) - 1;
+    const start = Math.min(page * visible, cards.length - visible);
+    const shown = cards.slice(start, start + visible);
+
+    cards.forEach((card) => {
+      card.classList.add('hide');
+      card.style.display = 'none';
+    });
+
+    setTimeout(() => {
+      shown.forEach((card) => {
+        card.style.display = '';
+        requestAnimationFrame(() => card.classList.remove('hide'));
+      });
+    }, 0);
+
+    prevBtn.disabled = page === 0;
+    nextBtn.disabled = page >= maxPage;
+  };
+
+  const changePage = (step) => {
+    const maxPage = Math.ceil(cards.length / visible) - 1;
+    page = Math.max(0, Math.min(page + step, maxPage));
+    update();
+  };
+
+  prevBtn.onclick = () => changePage(-1);
+  nextBtn.onclick = () => changePage(1);
+
+  window.onresize = () => {
+    const newVisible = window.innerWidth <= 1024 ? 1 : 3;
+
+    if (newVisible !== visible) {
+      visible = newVisible;
+      page = 0;
+      update();
+    }
+  };
+
+  update();
+}
 
 /** @param {Document} doc */
 function getOpenGraphMeta(doc) {
@@ -45,9 +118,21 @@ export default async function decorateInfoCard(block, options = {}) {
   const isArticles = block.getAttribute('data-slots')?.split(',')?.includes('articles');
   const isVideoCard = block.classList.contains('video') || block.getAttribute('data-slots')?.split(',')?.includes('video');
   const isControls = block.classList.contains('controls') || block.getAttribute('data-controls') === 'true';
+  const isNavigation = block.classList.contains('navigation') || block.getAttribute('data-navigation') === 'true';
+  const isReverse = block.classList.contains('reverse') || block.getAttribute('data-reverse') === 'true';
   const isWide = block.getAttribute('data-wide') === 'true';
+  const isCompact = block.classList.contains('compact') || block.getAttribute('data-compact') === 'true';
   if (isWide) {
     block.classList.add('wide');
+  }
+  if (isNavigation && getMetadata('template') === 'documentation') {
+    block.classList.add('navigation');
+  }
+  if (isReverse && getMetadata('template') === 'documentation') {
+    block.classList.add('reverse');
+  }
+  if (isCompact && getMetadata('template') === 'documentation') {
+    block.classList.add('compact');
   }
   removeEmptyPTags(block);
 
@@ -155,6 +240,9 @@ export default async function decorateInfoCard(block, options = {}) {
 
   block.textContent = '';
   block.appendChild(ul);
+  if (isNavigation) {
+    initializeNavigation(block, ul);
+  }
 
   block.querySelectorAll('.icon').forEach((s) => {
     const p_parent = s.parentElement;

--- a/hlx_statics/components/info-card.js
+++ b/hlx_statics/components/info-card.js
@@ -2,6 +2,7 @@ import { createTag, removeEmptyPTags, decorateButtons } from '../scripts/lib-ado
 import {
   createOptimizedPicture,
   getMetadata,
+  IS_DEV_DOCS,
 } from '../scripts/lib-helix.js';
 import {
   applyVideoContainer,
@@ -35,7 +36,7 @@ function initializeNavigation(block, ul) {
   block.prepend(prevBtn);
   block.append(nextBtn);
 
-  let visible = window.innerWidth <= 1024 ? 1 : 3;
+  let visible = window.innerWidth <= 1024 ? 1 : IS_DEV_DOCS ? 2 : 3;
   let page = 0;
 
   const update = () => {
@@ -125,13 +126,13 @@ export default async function decorateInfoCard(block, options = {}) {
   if (isWide) {
     block.classList.add('wide');
   }
-  if (isNavigation && getMetadata('template') === 'documentation') {
+  if (isNavigation && IS_DEV_DOCS) {
     block.classList.add('navigation');
   }
-  if (isReverse && getMetadata('template') === 'documentation') {
+  if (isReverse && IS_DEV_DOCS) {
     block.classList.add('reverse');
   }
-  if (isCompact && getMetadata('template') === 'documentation') {
+  if (isCompact && IS_DEV_DOCS) {
     block.classList.add('compact');
   }
   removeEmptyPTags(block);

--- a/hlx_statics/components/info-card.js
+++ b/hlx_statics/components/info-card.js
@@ -36,28 +36,64 @@ function initializeNavigation(block, ul) {
   block.prepend(prevBtn);
   block.append(nextBtn);
 
-  let visible = window.innerWidth <= 1024 ? 1 : IS_DEV_DOCS ? 2 : 3;
+  const getVisibleCount = () => {
+    if (window.innerWidth <= 1024) {
+      return 1;
+    }
+    return IS_DEV_DOCS ? 2 : 3;
+  };
+
+  let visible = getVisibleCount();
   let page = 0;
+  let rafId = null;
 
   const update = () => {
     const maxPage = Math.ceil(cards.length / visible) - 1;
     const start = Math.min(page * visible, cards.length - visible);
     const shown = cards.slice(start, start + visible);
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
 
     cards.forEach((card) => {
       card.classList.add('hide');
       card.style.display = 'none';
     });
 
-    setTimeout(() => {
+    rafId = requestAnimationFrame(() => {
       shown.forEach((card) => {
         card.style.display = '';
-        requestAnimationFrame(() => card.classList.remove('hide'));
       });
-    }, 0);
+      requestAnimationFrame(() => {
+        shown.forEach((card) => card.classList.remove('hide'));
+        positionArrows();
+      });
+      rafId = null;
+    });
 
     prevBtn.disabled = page === 0;
     nextBtn.disabled = page >= maxPage;
+  };
+
+  const syncGridToVisible = () => {
+    ul.style.setProperty('--info-card-visible', visible);
+  };
+
+  const ARROW_GAP = 12; 
+
+  const positionArrows = () => {
+    const blockRect = block.getBoundingClientRect();
+    const ulRect = ul.getBoundingClientRect();
+
+    const leftOffset = Math.max(0, ulRect.left - blockRect.left - prevBtn.offsetWidth - ARROW_GAP);
+    const rightOffset = Math.max(0, blockRect.right - ulRect.right - nextBtn.offsetWidth - ARROW_GAP);
+    const topOffset = (ulRect.top - blockRect.top) + (ulRect.height / 2);
+
+    prevBtn.style.left = `${leftOffset}px`;
+    nextBtn.style.right = `${rightOffset}px`;
+    prevBtn.style.top = `${topOffset}px`;
+    nextBtn.style.top = `${topOffset}px`;
   };
 
   const changePage = (step) => {
@@ -69,16 +105,30 @@ function initializeNavigation(block, ul) {
   prevBtn.onclick = () => changePage(-1);
   nextBtn.onclick = () => changePage(1);
 
-  window.onresize = () => {
-    const newVisible = window.innerWidth <= 1024 ? 1 : 3;
-
-    if (newVisible !== visible) {
-      visible = newVisible;
-      page = 0;
-      update();
-    }
+  let resizeRaf = null;
+  const handleResize = () => {
+    if (resizeRaf !== null) cancelAnimationFrame(resizeRaf);
+    resizeRaf = requestAnimationFrame(() => {
+      resizeRaf = null;
+      const newVisible = getVisibleCount();
+      if (newVisible !== visible) {
+        visible = newVisible;
+        page = 0;
+        syncGridToVisible();
+        update();
+      } else {
+        positionArrows();
+      }
+    });
   };
 
+  if (block._infoCardResizeHandler) {
+    window.removeEventListener('resize', block._infoCardResizeHandler);
+  }
+  block._infoCardResizeHandler = handleResize;
+  window.addEventListener('resize', handleResize);
+
+  syncGridToVisible();
   update();
 }
 

--- a/hlx_statics/components/info-card.js
+++ b/hlx_statics/components/info-card.js
@@ -16,6 +16,7 @@ function initializeNavigation(block, ul) {
 
   block.querySelectorAll('.info-card-nav').forEach((btn) => btn.remove());
   block.querySelectorAll('.info-card-viewport').forEach((el) => {
+    // unwrap any viewport from a previous initialization run
     el.replaceWith(...el.childNodes);
   });
   block.querySelectorAll('.info-card-carousel-nav').forEach((el) => el.remove());
@@ -37,6 +38,8 @@ function initializeNavigation(block, ul) {
   const prevBtn = createNav('prev', 'M15 18L9 12L15 6');
   const nextBtn = createNav('next', 'M9 18L15 12L9 6');
 
+  // Wrap the viewport + ul so the arrows live in their own grid columns
+  // instead of being absolutely positioned on top of the card content.
   const viewport = createTag('div', { class: 'info-card-viewport' });
   const navWrapper = createTag('div', { class: 'info-card-carousel-nav' });
 
@@ -54,6 +57,8 @@ function initializeNavigation(block, ul) {
   };
 
   let visible = getVisibleCount();
+  // `index` is the position of the first visible card (one-card-step),
+  // not a page multiplier — every arrow click moves the window by 1 card.
   let index = 0;
   let rafId = null;
 


### PR DESCRIPTION
## Description

Added three new variants to the Info Card component:

1. **Infocard Navigation**
        The navigation should work like a carousel. We need to add left and right navigation arrows to the Info Cards, similar to a carousel. For example, if there are six cards, the UI should initially display the first three cards. When the user clicks the right arrow, the cards should slide to display the next set of cards. 

2. **Infocard Reverse**
         Reverse the order of the content and image. The content should appear first, followed by the image in the Info Card.

3. **Infocard Compact**
         if the content length varies across the cards, the layout may look a little inconsistent(https://stage--adp-devsite--adobedocs.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/card&index=0) We'd like to update the Info card component by adding a new variant that keeps all the cards aligned and maintains a consistent layout

## Jira 

https://jira.corp.adobe.com/browse/DEVSITE-2514
https://jira.corp.adobe.com/browse/DEVSITE-2515
https://jira.corp.adobe.com/browse/DEVSITE-2516

## Test URL

### Infocard Navigation
Added the new navigation variant to the Info Card component to enable carousel-style navigation.

#### Devdocs
Previous : https://main--adp-devsite--adobedocs.aem.page/github-actions-test/test/infocard-navigation
Update : https://baskar-infocard--adp-devsite--adobedocs.aem.page/github-actions-test/test/infocard-navigation

#### Devbiz
Previous : https://main--adp-devsite-stage--adobedocs.aem.page/test/baskar/infocard-navigation
Update : https://baskar-infocard--adp-devsite-stage--adobedocs.aem.page/test/baskar/infocard-navigation

### Infocard Reverse
Added the new reverse variant to the Info Card component to display the content first, followed by the image.

#### Devdocs
Previous : https://main--adp-devsite--adobedocs.aem.page/github-actions-test/test/infocard-reverse
Update : https://baskar-infocard--adp-devsite--adobedocs.aem.page/github-actions-test/test/infocard-reverse

#### Devbiz
Previous : https://main--adp-devsite-stage--adobedocs.aem.page/test/baskar/infocard-reverse
Update : https://baskar-infocard--adp-devsite-stage--adobedocs.aem.page/test/baskar/infocard-reverse

### Infocard Compact
Added the new compact variant to the Info Card component to maintain consistent alignment across cards with varying content lengths and to make the cards more compact.

#### Devdocs
Previous : https://main--adp-devsite--adobedocs.aem.page/github-actions-test/test/infocard-compact
Update : https://baskar-infocard--adp-devsite--adobedocs.aem.page/github-actions-test/test/infocard-compact

#### Devbiz
Previous : https://main--adp-devsite-stage--adobedocs.aem.page/test/baskar/infocard-compact
Update : https://baskar-infocard--adp-devsite-stage--adobedocs.aem.page/test/baskar/infocard-compact
