### PR TITLE
feat(InfoCard): new "narrow" variant

### DIFF
--- a/hlx_statics/blocks/info-card/info-card.css
+++ b/hlx_statics/blocks/info-card/info-card.css
@@ -327,3 +327,11 @@ main :is(.info-card-wrapper, .infocard-wrapper) :is(.info-card, .infocard).compa
     grid-template-columns: 1fr;
   }
 }
+
+main :is(div.info-card-wrapper div.info-card.narrow, div.infocard-wrapper div.infocard.narrow)>ul>li {
+  max-width: 222px;
+}
+
+main :is(div.info-card-wrapper div.info-card.narrow, div.infocard-wrapper div.infocard.narrow)>ul>li img {
+  width: 222px;
+}


### PR DESCRIPTION
## Description

The Info Card needs to be narrower and more compact. In EDS, it currently takes up too much space on the page, so we need to reduce its width.
I've added a new variant `narrow` to the Info Card in DevBiz to achieve the required width.

## Jira 

https://jira.corp.adobe.com/browse/DEVSITE-2517

## Test URL

Before : https://main--adp-devsite-stage--adobedocs.aem.page/test/petheanraj/infocard-reduce-width
<img width="1919" height="615" alt="image" src="https://github.com/user-attachments/assets/90cb418c-a48b-49b5-9dd2-ef91e8175156" />

After : https://devsite-2517--adp-devsite-stage--adobedocs.aem.page/test/petheanraj/infocard-reduce-width
<img width="1919" height="476" alt="image" src="https://github.com/user-attachments/assets/1b438ac0-b24c-4647-86c2-48c3baf913bb" />
