### PR TITLE
feat(ProductCard): add a "narrow" version

### DIFF
--- a/hlx_statics/blocks/product-card/product-card.css
+++ b/hlx_statics/blocks/product-card/product-card.css
@@ -46,6 +46,10 @@ main div.product-card-wrapper .button-container {
     height: auto;
 }
 
+main div.product-card-wrapper div.product-card.narrow {
+    max-width: 1000px;
+}
+
 @media screen and (max-width : 1400px) {
     main div.product-card-wrapper div.product-card {
         margin: 0px 20px;


### PR DESCRIPTION
## Description

The Product Card needs to be narrower and more compact. In EDS, it currently takes up too much space on the page, so we need to reduce its width.

I've added a new variant `narrow` to the Product Card in DevBiz to achieve the required width.

## Jira 

https://jira.corp.adobe.com/browse/DEVSITE-2521

## Test URL

Before : https://main--adp-devsite-stage--adobedocs.aem.page/test/petheanraj/product-card-reduce-width
<img width="1919" height="505" alt="image" src="https://github.com/user-attachments/assets/11d265ad-ef01-476a-b8f8-6ec0b8d2cf5a" />

After : https://devsite-2521--adp-devsite-stage--adobedocs.aem.page/test/petheanraj/product-card-reduce-width
<img width="1918" height="554" alt="image" src="https://github.com/user-attachments/assets/94be038e-3162-46d6-9602-412e8eaa6025" />
