### PR TITLE
feat(Cards): add a "start" variant

### DIFF
--- a/hlx_statics/blocks/cards/cards.css
+++ b/hlx_statics/blocks/cards/cards.css
@@ -101,6 +101,28 @@ main div.cards-wrapper div.cards a.card-button {
   margin-bottom: 12px;
 }
 
+main div.cards-wrapper div.cards .cards-button-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 12px;
+  margin-bottom: 12px;
+}
+
+main div.cards-wrapper div.cards.start .cards-button-container  {
+  justify-content: start;
+}
+
+main div.cards-wrapper div.cards.end .cards-button-container  {
+  justify-content: end;
+}
+
+main div.cards-wrapper div.cards .cards-button-container a.card-button {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
 main div.cards-wrapper div.cards.wide {
   max-width: 80%;
 }

--- a/hlx_statics/blocks/cards/cards.css
+++ b/hlx_statics/blocks/cards/cards.css
@@ -150,3 +150,11 @@ main.dev-docs div.cards-wrapper {
   display: inline-flex;
   flex-direction: column;
 }
+
+main div.cards-wrapper div.cards.start > div {
+  text-align: start;
+}
+
+main div.cards-wrapper div.cards.start .cards-button-container  {
+  justify-content: start;
+}

--- a/hlx_statics/blocks/cards/cards.js
+++ b/hlx_statics/blocks/cards/cards.js
@@ -1,4 +1,4 @@
-import { decorateButtons } from '../../scripts/lib-adobeio.js';
+import { createTag, decorateButtons } from '../../scripts/lib-adobeio.js';
 import { createOptimizedPicture, decorateLightOrDark } from '../../scripts/lib-helix.js';
 
 /**
@@ -62,10 +62,21 @@ export default async function decorate(block) {
         a.classList.add('spectrum-Link', 'spectrum-Button--secondary');
       });
     } else {
-      card.querySelectorAll('p > a').forEach((a) => {
+      const buttonPs = [...card.querySelectorAll('p > a')].map((a) => {
         a.classList.remove('spectrum-Button--secondary', 'spectrum-Button--outline');
         a.classList.add('spectrum-Button--accent', 'spectrum-Button--fill', 'spectrum-Button', 'card-button');
+        return a.parentElement;
       });
+
+      if (buttonPs.length > 1) {
+        const buttonWrap = createTag('div', { class: 'cards-button-container' });
+        buttonPs.forEach((p, key) => {
+          if (key === 0) {
+            p.previousElementSibling?.insertAdjacentElement('afterend', buttonWrap);
+          }
+          buttonWrap.appendChild(p);
+        });
+      }
     }
 
     if (array.length === 3) {

--- a/hlx_statics/blocks/cards/cards.js
+++ b/hlx_statics/blocks/cards/cards.js
@@ -30,6 +30,10 @@ export default async function decorate(block) {
     block.classList.add('wide');
   }
 
+   if (block.getAttribute('data-start') === 'true') {
+    block.classList.add('start');
+  }
+
   // for devdocs, the author can put in an attribute width to change the width of the cards.
   const width = block.getAttribute('data-width');
   if (width) {


### PR DESCRIPTION
## Description

Need to align the content to the left side in the Cards component using the `start` variant.
Need to support multiple components and align them properly within the Cards component. 

## Jira 

https://jira.corp.adobe.com/browse/DEVSITE-2518
https://jira.corp.adobe.com/browse/DEVSITE-2520

## Test URL (With start variant)

Before : https://main--adp-devsite-stage--adobedocs.aem.page/test/petheanraj/cards-narrow-start
<img width="1916" height="438" alt="image" src="https://github.com/user-attachments/assets/6a778e7b-5422-4a58-bd98-f003ddf74cc9" />

After : https://devsite-2518--adp-devsite-stage--adobedocs.aem.page/test/petheanraj/cards-narrow-start
<img width="1919" height="440" alt="image" src="https://github.com/user-attachments/assets/86a94070-5916-42f0-a0b4-a4bb947e6e80" />

## Test URL(supports multiple button with proper alignment)

Before: https://main--adp-devsite-stage--adobedocs.aem.page/test/petheanraj/cards-with-mulitple-button
<img width="1919" height="522" alt="image" src="https://github.com/user-attachments/assets/945be89c-76fa-4f79-b7c7-4a559917e0fc" />

After : https://devsite-2518--adp-devsite-stage--adobedocs.aem.page/test/petheanraj/cards-with-mulitple-button
<img width="1915" height="408" alt="image" src="https://github.com/user-attachments/assets/b838c2c6-226c-4193-906a-8b9cd105972c" />
