### PR TITLE
feat(Summary): add right-aligned variant 

### DIFF
--- a/hlx_statics/blocks/summary/summary.css
+++ b/hlx_statics/blocks/summary/summary.css
@@ -142,6 +142,6 @@ main div.summary-wrapper div.summary.right > div {
 
 @media screen and (min-width: 320px) and (max-width: 1024px) {
   main div.summary-wrapper div.summary.right > div {
-    left: 0% ;
+    left: 0% !important;
   }
 }

--- a/hlx_statics/blocks/summary/summary.css
+++ b/hlx_statics/blocks/summary/summary.css
@@ -135,13 +135,3 @@ main div.summary-wrapper div.summary.background-color-white p a:hover, main div.
 main div.summary-wrapper div.summary.background-color-white {
   background-color: rgb(255, 255, 255);
 }
-
-main div.summary-wrapper div.summary.right > div {
- left: 30% !important;
-}
-
-@media screen and (min-width: 320px) and (max-width: 1024px) {
-  main div.summary-wrapper div.summary.right > div {
-    left: 0% !important;
-  }
-}

--- a/hlx_statics/blocks/summary/summary.css
+++ b/hlx_statics/blocks/summary/summary.css
@@ -137,5 +137,5 @@ main div.summary-wrapper div.summary.background-color-white {
 }
 
 main div.summary-wrapper div.summary.right > div {
- left: 30% ;
+ left: 30% !important;
 }

--- a/hlx_statics/blocks/summary/summary.css
+++ b/hlx_statics/blocks/summary/summary.css
@@ -139,3 +139,9 @@ main div.summary-wrapper div.summary.background-color-white {
 main div.summary-wrapper div.summary.right > div {
  left: 30% !important;
 }
+
+@media screen and (min-width: 320px) and (max-width: 1024px) {
+  main div.summary-wrapper div.summary.right > div {
+    left: 0% ;
+  }
+}

--- a/hlx_statics/blocks/summary/summary.css
+++ b/hlx_statics/blocks/summary/summary.css
@@ -136,4 +136,6 @@ main div.summary-wrapper div.summary.background-color-white {
   background-color: rgb(255, 255, 255);
 }
 
-
+main div.summary-wrapper div.summary.right > div {
+ left: 30% ;
+}

--- a/hlx_statics/blocks/summary/summary.js
+++ b/hlx_statics/blocks/summary/summary.js
@@ -13,7 +13,7 @@ function decorateSummaryPosition(block) {
   if (!block.classList.contains('right')) return;
   const content = block.querySelector(':scope > div');
   if (!content) return;
-  content.style.left = window.innerWidth <= 1024 ? '0%' : '30%';
+  content.style.right = window.innerWidth <= 1024 ? '0%' : '10%';
 }
 
 export default async function decorate(block) {

--- a/hlx_statics/blocks/summary/summary.js
+++ b/hlx_statics/blocks/summary/summary.js
@@ -14,6 +14,7 @@ function decorateSummaryPosition(block) {
   const content = block.querySelector(':scope > div');
   if (!content) return;
   content.style.right = window.innerWidth <= 1024 ? '0%' : '10%';
+  
 }
 
 export default async function decorate(block) {
@@ -63,7 +64,7 @@ export default async function decorate(block) {
 
   if (block.querySelector('picture')) {
     //if there is an image as the background set up the overlay style
-    const overlayStyle = 'position: absolute; display: flex; left: 0%; z-index: 1000;';
+    const overlayStyle = 'position: absolute; display: flex; z-index: 1000;';
     rearrangeHeroPicture(block, overlayStyle);
   }
 

--- a/hlx_statics/blocks/summary/summary.js
+++ b/hlx_statics/blocks/summary/summary.js
@@ -8,6 +8,14 @@ import {
  * decorates the summary
  * @param {Element} block The summary block element
  */
+
+function decorateSummaryPosition(block) {
+  if (!block.classList.contains('right')) return;
+  const content = block.querySelector(':scope > div');
+  if (!content) return;
+  content.style.left = window.innerWidth <= 1024 ? '0%' : '30%';
+}
+
 export default async function decorate(block) {
   block.setAttribute('daa-lh', 'summary');
   decorateButtons(block);
@@ -58,6 +66,7 @@ export default async function decorate(block) {
     const overlayStyle = 'position: absolute; display: flex; left: 0%; z-index: 1000;';
     rearrangeHeroPicture(block, overlayStyle);
   }
+
+  // Set position for right-aligned summary.
+  decorateSummaryPosition(block);
 }
-
-


### PR DESCRIPTION
## Description

Need to align the Summary Block content to the right. By default, it's aligned to the left, so I've added a new variant to support right alignment.

## Jira 

https://jira.corp.adobe.com/browse/DEVSITE-2522

## Test URL

Before:

https://main--adp-devsite-stage--adobedocs.aem.page/test/petheanraj/summary-right

<img width="1919" height="439" alt="image" src="https://github.com/user-attachments/assets/98bffc2b-1075-4068-a60c-95c0191350b8" />

After:

https://devsite-2522--adp-devsite-stage--adobedocs.aem.page/test/petheanraj/summary-right

<img width="1919" height="445" alt="image" src="https://github.com/user-attachments/assets/3171fb65-35ef-4e00-a7d1-d3934ce45906" />